### PR TITLE
[POC] UI: Support hierarchies

### DIFF
--- a/_i18n/i18n.properties
+++ b/_i18n/i18n.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=Changes ID
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Old Value
 #XTIT: Field Name
 Changes.valueChangedTo=New Value
 #XTIT: Field Name
-Changes.entity=Object Type
+Changes.entityName=Object Type
 #XTIT: Field Name
 Changes.serviceEntity=Service Object Type
 #XTIT: Field Name
 Changes.valueDataType=Value Data Type
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entity
+Changes.entityName=Entity
 #XTIT: Field Name
-ChangeLog.entityKey=Entity Key
+Changes.entityKey=Entity Key
 #XTIT: Field Name
-ChangeLog.serviceEntity=Service Entity
+Changes.serviceEntity=Service Entity
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Create
+Changes.modification.create=Create
 #XFLD: Field label
-ChangeLog.modification.update=Update
+Changes.modification.update=Update
 #XFLD: Field label
-ChangeLog.modification.delete=Delete
+Changes.modification.delete=Delete
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Change List

--- a/_i18n/i18n_de.properties
+++ b/_i18n/i18n_de.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=ID der \u00C4nderungen
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Alter Wert
 #XTIT: Field Name
 Changes.valueChangedTo=Neuer Wert
 #XTIT: Field Name
-Changes.entity=Objekttyp
+Changes.entityName=Objekttyp
 #XTIT: Field Name
 Changes.serviceEntity=Serviceobjekttyp
 #XTIT: Field Name
 Changes.valueDataType=Wertdatentyp
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entit\u00E4t
+Changes.entityName=Entit\u00E4t
 #XTIT: Field Name
-ChangeLog.entityKey=Entit\u00E4tsschl\u00FCssel
+Changes.entityKey=Entit\u00E4tsschl\u00FCssel
 #XTIT: Field Name
-ChangeLog.serviceEntity=Serviceentit\u00E4t
+Changes.serviceEntity=Serviceentit\u00E4t
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Anlegen
+Changes.modification.create=Anlegen
 #XFLD: Field label
-ChangeLog.modification.update=Aktualisieren
+Changes.modification.update=Aktualisieren
 #XFLD: Field label
-ChangeLog.modification.delete=L\u00F6schen
+Changes.modification.delete=L\u00F6schen
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Änderungsliste

--- a/_i18n/i18n_en.properties
+++ b/_i18n/i18n_en.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=Changes ID
@@ -21,27 +21,28 @@ Changes.valueChangedFrom=Old Value
 #XTIT: Field Name
 Changes.valueChangedTo=New Value
 #XTIT: Field Name
-Changes.entity=Object Type
+Changes.entityName=Object Type
 #XTIT: Field Name
 Changes.serviceEntity=Service Object Type
 #XTIT: Field Name
 Changes.valueDataType=Value Data Type
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entity
+Changes.entityName=Entity
 #XTIT: Field Name
-ChangeLog.entityKey=Entity Key
+Changes.entityKey=Entity Key
 #XTIT: Field Name
-ChangeLog.serviceEntity=Service Entity
+Changes.serviceEntity=Service Entity
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Create
+Changes.modification.create=Create
 #XFLD: Field label
-ChangeLog.modification.update=Update
+Changes.modification.update=Update
 #XFLD: Field label
-ChangeLog.modification.delete=Delete
+Changes.modification.delete=Delete
+
+## Changes Title##
+########################################
+#XFLD,50: Label for a section
+ChangeLogList=Change List

--- a/_i18n/i18n_es.properties
+++ b/_i18n/i18n_es.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=ID de modificaciones
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Valor antiguo
 #XTIT: Field Name
 Changes.valueChangedTo=Valor nuevo
 #XTIT: Field Name
-Changes.entity=Tipo de objeto
+Changes.entityName=Tipo de objeto
 #XTIT: Field Name
 Changes.serviceEntity=Tipo de objeto de servicio
 #XTIT: Field Name
 Changes.valueDataType=Tipo de dato de valor
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entidad
+Changes.entityName=Entidad
 #XTIT: Field Name
-ChangeLog.entityKey=Clave de entidad
+Changes.entityKey=Clave de entidad
 #XTIT: Field Name
-ChangeLog.serviceEntity=Entidad de servicio
+Changes.serviceEntity=Entidad de servicio
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Crear
+Changes.modification.create=Crear
 #XFLD: Field label
-ChangeLog.modification.update=Actualizar
+Changes.modification.update=Actualizar
 #XFLD: Field label
-ChangeLog.modification.delete=Borrar
+Changes.modification.delete=Borrar
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Lista modificaciones

--- a/_i18n/i18n_fr.properties
+++ b/_i18n/i18n_fr.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=ID de modifications
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Ancienne valeur
 #XTIT: Field Name
 Changes.valueChangedTo=Nouvelle valeur
 #XTIT: Field Name
-Changes.entity=Type d'objet
+Changes.entityName=Type d'objet
 #XTIT: Field Name
 Changes.serviceEntity=Type d'objet de service
 #XTIT: Field Name
 Changes.valueDataType=Type de donn\u00E9es de valeur
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entit\u00E9
+Changes.entityName=Entit\u00E9
 #XTIT: Field Name
-ChangeLog.entityKey=Cl\u00E9 d'entit\u00E9
+Changes.entityKey=Cl\u00E9 d'entit\u00E9
 #XTIT: Field Name
-ChangeLog.serviceEntity=Entit\u00E9 de service
+Changes.serviceEntity=Entit\u00E9 de service
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Cr\u00E9er
+Changes.modification.create=Cr\u00E9er
 #XFLD: Field label
-ChangeLog.modification.update=Mettre \u00E0 jour
+Changes.modification.update=Mettre \u00E0 jour
 #XFLD: Field label
-ChangeLog.modification.delete=Supprimer
+Changes.modification.delete=Supprimer
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Liste des modifications

--- a/_i18n/i18n_ja.properties
+++ b/_i18n/i18n_ja.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=\u5909\u66F4 ID
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=\u53E4\u3044\u5024
 #XTIT: Field Name
 Changes.valueChangedTo=\u65B0\u3057\u3044\u5024
 #XTIT: Field Name
-Changes.entity=\u30AA\u30D6\u30B8\u30A7\u30AF\u30C8\u30BF\u30A4\u30D7
+Changes.entityName=\u30AA\u30D6\u30B8\u30A7\u30AF\u30C8\u30BF\u30A4\u30D7
 #XTIT: Field Name
 Changes.serviceEntity=\u30B5\u30FC\u30D3\u30B9\u30AA\u30D6\u30B8\u30A7\u30AF\u30C8\u30BF\u30A4\u30D7
 #XTIT: Field Name
 Changes.valueDataType=\u5024\u306E\u30C7\u30FC\u30BF\u578B
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3
+Changes.entityName=\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3
 #XTIT: Field Name
-ChangeLog.entityKey=\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3\u30AD\u30FC
+Changes.entityKey=\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3\u30AD\u30FC
 #XTIT: Field Name
-ChangeLog.serviceEntity=\u30B5\u30FC\u30D3\u30B9\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3
+Changes.serviceEntity=\u30B5\u30FC\u30D3\u30B9\u30A8\u30F3\u30C6\u30A3\u30C6\u30A3
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=\u4F5C\u6210
+Changes.modification.create=\u4F5C\u6210
 #XFLD: Field label
-ChangeLog.modification.update=\u66F4\u65B0
+Changes.modification.update=\u66F4\u65B0
 #XFLD: Field label
-ChangeLog.modification.delete=\u524A\u9664
+Changes.modification.delete=\u524A\u9664
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=変更一覧

--- a/_i18n/i18n_pl.properties
+++ b/_i18n/i18n_pl.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=Identyfikator zmian
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Stara warto\u015B\u0107
 #XTIT: Field Name
 Changes.valueChangedTo=Nowa warto\u015B\u0107
 #XTIT: Field Name
-Changes.entity=Typ obiektu
+Changes.entityName=Typ obiektu
 #XTIT: Field Name
 Changes.serviceEntity=Typ obiektu us\u0142ugi
 #XTIT: Field Name
 Changes.valueDataType=Typ danych warto\u015Bci
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Encja
+Changes.entityName=Encja
 #XTIT: Field Name
-ChangeLog.entityKey=Klucz encji
+Changes.entityKey=Klucz encji
 #XTIT: Field Name
-ChangeLog.serviceEntity=Encja us\u0142ugi
+Changes.serviceEntity=Encja us\u0142ugi
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Utw\u00F3rz
+Changes.modification.create=Utw\u00F3rz
 #XFLD: Field label
-ChangeLog.modification.update=Aktualizuj
+Changes.modification.update=Aktualizuj
 #XFLD: Field label
-ChangeLog.modification.delete=Usu\u0144
+Changes.modification.delete=Usu\u0144
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Lista zmian

--- a/_i18n/i18n_pt.properties
+++ b/_i18n/i18n_pt.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=ID das altera\u00E7\u00F5es
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=Valor antigo
 #XTIT: Field Name
 Changes.valueChangedTo=Valor novo
 #XTIT: Field Name
-Changes.entity=Tipo de objeto
+Changes.entityName=Tipo de objeto
 #XTIT: Field Name
 Changes.serviceEntity=Tipo de objeto de servi\u00E7o
 #XTIT: Field Name
 Changes.valueDataType=Tipo de dados de valor
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=Entidade
+Changes.entityName=Entidade
 #XTIT: Field Name
-ChangeLog.entityKey=Chave de entidade
+Changes.entityKey=Chave de entidade
 #XTIT: Field Name
-ChangeLog.serviceEntity=Entidade de servi\u00E7o
+Changes.serviceEntity=Entidade de servi\u00E7o
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=Criar
+Changes.modification.create=Criar
 #XFLD: Field label
-ChangeLog.modification.update=Atualizar
+Changes.modification.update=Atualizar
 #XFLD: Field label
-ChangeLog.modification.delete=Eliminar
+Changes.modification.delete=Eliminar
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Lista de modificações

--- a/_i18n/i18n_ru.properties
+++ b/_i18n/i18n_ru.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=\u0418\u0434. \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F
@@ -21,30 +21,28 @@ Changes.valueChangedFrom=\u0421\u0442\u0430\u0440\u043E\u0435 \u0437\u043D\u0430
 #XTIT: Field Name
 Changes.valueChangedTo=\u041D\u043E\u0432\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435
 #XTIT: Field Name
-Changes.entity=\u0422\u0438\u043F \u043E\u0431\u044A\u0435\u043A\u0442\u0430
+Changes.entityName=\u0422\u0438\u043F \u043E\u0431\u044A\u0435\u043A\u0442\u0430
 #XTIT: Field Name
 Changes.serviceEntity=\u0422\u0438\u043F \u043E\u0431\u044A\u0435\u043A\u0442\u0430 \u0441\u0435\u0440\u0432\u0438\u0441\u0430
 #XTIT: Field Name
 Changes.valueDataType=\u0422\u0438\u043F \u0434\u0430\u043D\u043D\u044B\u0445 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u044F
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=\u0421\u0443\u0449\u043D\u043E\u0441\u0442\u044C
+Changes.entityName=\u0421\u0443\u0449\u043D\u043E\u0441\u0442\u044C
 #XTIT: Field Name
-ChangeLog.entityKey=\u041A\u043B\u044E\u0447 \u0441\u0443\u0449\u043D\u043E\u0441\u0442\u0438
+Changes.entityKey=\u041A\u043B\u044E\u0447 \u0441\u0443\u0449\u043D\u043E\u0441\u0442\u0438
 #XTIT: Field Name
-ChangeLog.serviceEntity=\u0421\u0443\u0449\u043D\u043E\u0441\u0442\u044C \u0441\u0435\u0440\u0432\u0438\u0441\u0430
+Changes.serviceEntity=\u0421\u0443\u0449\u043D\u043E\u0441\u0442\u044C \u0441\u0435\u0440\u0432\u0438\u0441\u0430
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=\u0421\u043E\u0437\u0434\u0430\u0442\u044C
+Changes.modification.create=\u0421\u043E\u0437\u0434\u0430\u0442\u044C
 #XFLD: Field label
-ChangeLog.modification.update=\u041E\u0431\u043D\u043E\u0432\u0438\u0442\u044C
+Changes.modification.update=\u041E\u0431\u043D\u043E\u0432\u0438\u0442\u044C
 #XFLD: Field label
-ChangeLog.modification.delete=\u0423\u0434\u0430\u043B\u0438\u0442\u044C
+Changes.modification.delete=\u0423\u0434\u0430\u043B\u0438\u0442\u044C
 
+## Changes Title##
+########################################
 #XFLD,50: Label for a section
 ChangeLogList=Список изменений

--- a/_i18n/i18n_zh_CN.properties
+++ b/_i18n/i18n_zh_CN.properties
@@ -1,4 +1,4 @@
-## Change Table Fields Description##
+## Changes Table Fields Description##
 ####################################
 #XTIT: Field Name
 Changes.ID=\u66F4\u6539\u6807\u8BC6
@@ -21,27 +21,28 @@ Changes.valueChangedFrom=\u65E7\u503C
 #XTIT: Field Name
 Changes.valueChangedTo=\u65B0\u503C
 #XTIT: Field Name
-Changes.entity=\u5BF9\u8C61\u7C7B\u578B
+Changes.entityName=\u5BF9\u8C61\u7C7B\u578B
 #XTIT: Field Name
 Changes.serviceEntity=\u670D\u52A1\u5BF9\u8C61\u7C7B\u578B
 #XTIT: Field Name
 Changes.valueDataType=\u6570\u503C\u6570\u636E\u7C7B\u578B
-
-## Change Log Table Fields Description##
-########################################
 #XTIT: Field Name
-ChangeLog.entity=\u5B9E\u4F53
+Changes.entityName=\u5B9E\u4F53
 #XTIT: Field Name
-ChangeLog.entityKey=\u5B9E\u4F53\u53C2\u6570
+Changes.entityKey=\u5B9E\u4F53\u53C2\u6570
 #XTIT: Field Name
-ChangeLog.serviceEntity=\u670D\u52A1\u5B9E\u4F53
+Changes.serviceEntity=\u670D\u52A1\u5B9E\u4F53
 
-
-## Change Log Modifications##
+## Changes Modifications##
 ########################################
 #XFLD: Field label
-ChangeLog.modification.create=\u521B\u5EFA
+Changes.modification.create=\u521B\u5EFA
 #XFLD: Field label
-ChangeLog.modification.update=\u66F4\u65B0
+Changes.modification.update=\u66F4\u65B0
 #XFLD: Field label
-ChangeLog.modification.delete=\u5220\u9664
+Changes.modification.delete=\u5220\u9664
+
+## Changes Title##
+########################################
+#XFLD,50: Label for a section
+ChangeLogList=

--- a/index.cds
+++ b/index.cds
@@ -16,10 +16,11 @@ aspect aspect @(
   key ID : UUID;
 }
 
+@readonly
 @cds.autoexpose
 entity Changes : cuid, managed {
   entityKey        : String @title: '{i18n>Changes.entityID}';
-  entity           : String @title: '{i18n>Changes.entity}';
+  entityName       : String @title: '{i18n>Changes.entity}';
   serviceEntity    : String @title: '{i18n>Changes.serviceEntity}';
   keys             : String @title: '{i18n>Changes.keys}';
   attribute        : String @title: '{i18n>Changes.attribute}';
@@ -41,21 +42,33 @@ entity Changes : cuid, managed {
 annotate Changes with @(UI: {
   PresentationVariant: {
     Visualizations: ['@UI.LineItem'],
-    RequestAtLeast: [
-      entityKey,
-      entity
-    ],
+    RequestAtLeast: [entityKey],
     SortOrder     : [{
       Property  : createdAt,
       Descending: true
-    }],
-    GroupBy       : [ createdAt ]
+    },
+    {
+      Property  : hierarchyLevel,
+      Descending: false
+    }]
   },
   LineItem: [
-        {
+    {
       $Type : 'UI.DataField',
-      Value: attribute,
-      Label: '{i18n>Changes.attribute}'
+      Value: hierarchyLevel
+    },
+    {
+      $Type : 'UI.DataField',
+      Value: createdAt
+    },
+    {
+      $Type : 'UI.DataField',
+      Value: createdBy
+    },
+    {
+      $Type : 'UI.DataField',
+      Value: entityName,
+      Label: '{i18n>Changes.entity}'
     },
     {
        $Type : 'UI.DataField',
@@ -69,23 +82,13 @@ annotate Changes with @(UI: {
     },
     {
       $Type : 'UI.DataField',
-      Value: entity,
-      Label: '{i18n>Changes.entity}'
+      Value: attribute,
+      Label: '{i18n>Changes.attribute}'
     },
     {
       $Type : 'UI.DataField',
       Value: modification,
       Label: '{i18n>Changes.modification}'
-    },
-    {
-      $Type : 'UI.DataField',
-      Value: createdBy,
-      Label: '{i18n>Changes.createdBy}'
-    },
-    {
-      $Type : 'UI.DataField',
-      Value: createdAt,
-      Label: '{i18n>Changes.createdAt}'
     }
   ]
 });

--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -348,7 +348,7 @@ function _trackedChanges4 (srv, target, diff) {
 
       changes.push({
         serviceEntityPath: row._path,
-        entity: getDBEntity(element.parent).name,
+        entityName: getDBEntity(element.parent).name,
         serviceEntity: element.parent.name,
         attribute: element["@odata.foreignKey4"] || key,
         valueChangedFrom: from || '',
@@ -415,7 +415,7 @@ async function track_changes (req) {
   const dbEntity = getDBEntity(target)
   await INSERT.into("sap.changelog.Changes").entries({
     entityKey,
-    entity: dbEntity.name,
+    entityName: dbEntity.name,
     serviceEntity: target.name,
     parent_ID: entityKey
   })
@@ -423,7 +423,7 @@ async function track_changes (req) {
     const { keys, attribute, valueChangedFrom, valueChangedTo, modification } = change
     await INSERT.into("sap.changelog.Changes").entries({
       entityKey: entityKey,
-      entity: dbEntity.name,
+      entityName: dbEntity.name,
       serviceEntity: target.name,
       keys,
       attribute,


### PR DESCRIPTION
### Tree Tables
  - Use *Tree* type instead to map hierarchies naturally
    -  `initialExpansionLevel` takes care of granular loading of change data (as desired)
    - Currently only supported for Odata v2, but [on SAPUI5 Roadmap for Q3 2023 ](https://roadmaps.sap.com/board?SC=000D3AAADBCE1EDBA3AD72B204ADAD11&range=FIRST-LAST#Q3%202023;INNO=000D3AAADBCE1EECBEA6B9B4C8F74730)
    - More on *Hierarchies with OData V4*, see:
       - [Link to Wiki](https://wiki.one.int.sap/wiki/pages/viewpage.action?pageId=3625367162)
       - [Link to Jira](https://jira.tools.sap/browse/CPOUI5ODATAV4-1592)
    - Also, see [Client-side alignment Hierarchy Maintenance](https://wiki.one.int.sap/wiki/display/UI/Client-side+alignment+Hierarchy+Maintenance)

### S/4 HANA Fiori Expert Network Meeting (24.3.23)
  - [Recoding](https://sap.sharepoint.com/teams/S4HANAFioriExpertNetwork/_layouts/15/stream.aspx?id=%2Fteams%2FS4HANAFioriExpertNetwork%2FShared%20Documents%2FFiori%20Expert%20Network%20Meeting%2FMaterial%202023%2F2023%2D02%2D24%2FS%5F4%20HANA%20Fiori%20Expert%20Network%20Meeting%2D20230224%5F103313%2DMeeting%20Recording%2Emp4&referrer=Teams%2ETEAMS%2DELECTRON&referrerScenario=p2p%5Fns%2Dbim&ga=1)
  - [Slides](https://sap.sharepoint.com/:p:/r/teams/S4HANAFioriExpertNetwork/_layouts/15/Doc.aspx?sourcedoc=%7B1774A3AE-3D61-4DEC-8632-EDB72E5A64CB%7D&file=Hierarchy%20V4%20POC.pptx&action=edit&mobileredirect=true)