### PR TITLE
Get rid of ChangeView

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -22,7 +22,7 @@ cds.on('loaded', m => {
       const keys = [], { elements: elms } = entity
       for (let e in elms) if (elms[e].key) keys.push(e)
 
-      // Add association to ChangeView...
+      // Add association to ChangeLog...
       const on = [...changes.on]; keys.forEach((k, i) => { i && on.push('||'); on.push({ ref: [k] }) })
       const assoc = { ...changes, on }
       const query = entity.projection || entity.query?.SELECT
@@ -40,21 +40,40 @@ cds.on('loaded', m => {
 
 // Add generic change tracking handlers
 cds.on('served', () => {
-  const { track_changes, _afterReadChangeView } = require("./lib/change-log")
+  const { track_changes, _afterReadChangeLog } = require("./lib/change-log")
   for (const srv of cds.services) {
     if (srv instanceof cds.ApplicationService) {
       let any = false
       for (const entity of Object.values(srv.entities)) {
         if (isChangeTracked(entity)) {
+          // For (nested) changes, dump to table
+          srv.after('READ', `${srv.name}.ChangeLog`, changeViewHandler)
+
           cds.db.before("CREATE", entity, track_changes)
           cds.db.before("UPDATE", entity, track_changes)
           cds.db.before("DELETE", entity, track_changes)
           any = true
         }
       }
-      if (any && srv.entities.ChangeView) {
-        srv.after("READ", srv.entities.ChangeView, _afterReadChangeView)
+      if (any && srv.entities.ChangeLog) {
+        srv.after("READ", srv.entities.ChangeLog, _afterReadChangeLog)
       }
     }
   }
 })
+
+/** For each ChangeLog entries, write corresponding
+ * changes (json) to table as plain text
+ */
+async function changeViewHandler(results, req) {
+  if (results.length === 0) return;
+  let i = 0
+  for (const result of results) {
+    const { ID } = result;
+    const query = SELECT.from(`${this.name}.ChangeLog`).where({ID})
+    const queryResult = await cds.db.run(query)
+    if (!queryResult || queryResult.length === 0) return;
+    results[i].changelist = JSON.stringify(queryResult[0].changes, null, 4)
+    i++
+  }
+}

--- a/index.cds
+++ b/index.cds
@@ -12,14 +12,14 @@ aspect aspect @(
     Target: 'changes/@UI.PresentationVariant'
   }]
 ) {
-  changes : Association to many ChangeView on changes.entityKey = ID;
+  changes : Association to many ChangeLog on changes.entityKey = ID;
   key ID : UUID;
 }
 
 
-entity Changes : managed {
+type Changes : managed {
 
-  key ID            : UUID                    @UI.Hidden;
+  ID                : UUID                    @UI.Hidden;
   keys              : String                   @title: '{i18n>Changes.keys}';
   attribute         : String                   @title: '{i18n>Changes.attribute}';
   valueChangedFrom  : String                   @title: '{i18n>Changes.valueChangedFrom}';
@@ -27,13 +27,13 @@ entity Changes : managed {
 
   // Business meaningful object id
   entityID          : String                   @title: '{i18n>Changes.entityID}';
-  entity            : String                   @title: '{i18n>Changes.entity}';
+  entityKey         : String                   @title: '{i18n>Changes.entity}';
   serviceEntity     : String                   @title: '{i18n>Changes.serviceEntity}';
 
   // Business meaningful parent object id
   parentEntityID    : String                   @title: '{i18n>Changes.parentEntityID}';
   parentKey         : UUID                     @title: '{i18n>Changes.parentKey}';
-  serviceEntityPath : String                   @title: '{i18n>Changes.serviceEntityPath}';
+  serviceEntityPath : String                   @UI.Hidden @title: '{i18n>Changes.serviceEntityPath}';
 
   @title: '{i18n>Changes.modification}'
   modification      : String enum {
@@ -43,44 +43,25 @@ entity Changes : managed {
   };
 
   valueDataType     : String                   @title: '{i18n>Changes.valueDataType}';
-  changeLog         : Association to ChangeLog @title: '{i18n>ChangeLog.ID}';
 }
 
 // REVISIT: Get rid of that
+@cds.autoexpose
 entity ChangeLog : managed, cuid {
-  entity        : String @title: '{i18n>ChangeLog.entity}';
+  entityName    : String @title: '{i18n>ChangeLog.entity}';
   entityKey     : UUID   @title: '{i18n>ChangeLog.entityKey}';
   serviceEntity : String @title: '{i18n>ChangeLog.serviceEntity}';
-  changes       : Composition of many Changes on changes.changeLog = $self;
+  changes       : many Changes;
+  virtual changelist: String;
 }
 
-// REVISIT: Get rid of that
-view ChangeView as
-  select from Changes {
-    ID                  as ID                @UI.Hidden,
-    attribute           as attribute,
-    entityID            as objectID,
-    entity              as entity,
-    serviceEntity       as serviceEntity,
-    parentEntityID      as parentObjectID,
-    parentKey           as parentKey,
-    valueChangedFrom    as valueChangedFrom,
-    valueChangedTo      as valueChangedTo,
-    modification        as modification,
-    createdBy           as createdBy,
-    createdAt           as createdAt,
-    changeLog.entityKey as entityKey,
-    serviceEntityPath   as serviceEntityPath @UI.Hidden,
-  };
-
-
-annotate ChangeView with @(UI: {
+annotate ChangeLog with @(UI: {
   PresentationVariant: {
     Visualizations: ['@UI.LineItem'],
     RequestAtLeast: [
-      parentKey,
+      //parentKey,
       serviceEntity,
-      serviceEntityPath
+      //serviceEntityPath
     ],
     SortOrder     : [{
       Property  : createdAt,
@@ -88,15 +69,16 @@ annotate ChangeView with @(UI: {
     }],
   },
   LineItem           : [
-    { Value: objectID },
-    { Value: entity },
-    { Value: parentObjectID },
-    { Value: attribute },
-    { Value: valueChangedTo },
-    { Value: valueChangedFrom },
+    //{ Value: objectID },
+    { Value: entityName },
+    //{ Value: parentObjectID },
+    //{ Value: attribute },
+    //{ Value: valueChangedTo },
+    //{ Value: valueChangedFrom },
     { Value: createdBy },
     { Value: createdAt },
-    { Value: modification }
+    //{ Value: modification },
+    { Value: changelist, ![@UI.Importance]: #High }
   ],
   DeleteHidden       : true,
 });

--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -318,7 +318,7 @@ const _formatChangeLog = async function (changes, req) {
 //   change.valueChangedTo = valueChangedTos.join(VALUE_DELIMITER)
 // }
 
-const _afterReadChangeView = async function (data, req) {
+const _afterReadChangeLog = async function (data, req) {
   if (!data) {
     return
   }
@@ -348,7 +348,7 @@ function _trackedChanges4 (srv, target, diff) {
 
       changes.push({
         serviceEntityPath: row._path,
-        entity: getDBEntity(element.parent).name,
+        entityName: getDBEntity(element.parent).name,
         serviceEntity: element.parent.name,
         attribute: element["@odata.foreignKey4"] || key,
         valueChangedFrom: from || '',
@@ -414,11 +414,11 @@ async function track_changes (req) {
   }
   const dbEntity = getDBEntity(target)
   await INSERT.into("sap.changelog.ChangeLog").entries({
-    entity: dbEntity.name,
+    entityName: dbEntity.name,
     entityKey: entityKey,
     serviceEntity: target.name,
     changes: changes.filter(c => c.valueChangedFrom || c.valueChangedTo),
   })
 }
 
-module.exports = { track_changes, _afterReadChangeView }
+module.exports = { track_changes, _afterReadChangeLog }


### PR DESCRIPTION
### Modal Optimization
- As requested by @danjoa, we have rolled back the *main* branch to [cc6b140](https://github.com/cap-js/change-tracking/tree/cc6b140618cbfefbf8a005d59754bdc0f38995dc) so everyone has a clear understanding of the *model-only* changes we introduced so we can take it from there. These include: 

  1. Removing the view `ChangeView`
        Hence, our *aspect* then becomes an *Association to* `ChangeLog`
        We dump the (nested) `ChangeLog.changes` into a UI column (for now)

  2. Modifying `Changes` kind from *entity* to *type*
  
  3. Renaming element `entity` to `entityName` (due to dubious syntax highlighting in the editor otherwise)

### New PR label [model change]
@All: I've also added a new label "model change" for this and future PRs that modify the model.