### PR TITLE
Lazy loading of Change History

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -9,7 +9,8 @@ aspect aspect @(UI.Facets: [{
   ID    : 'ChangeHistoryFacet',
   Label : '{i18n>ChangeHistoryList}',
   Target: 'changes/@UI.PresentationVariant',
-  ![@UI.PartOfPreview] : false // Lazy load Change History
+  //TODO: Use for lazy-loading once Fiori fixes bugs and v1.120 is released
+  //![@UI.PartOfPreview]: false
 }]) {
   // Essentially: Association to many Changes on changes.changeLog.entityKey = ID;
   changes : Association to many ChangeView on changes.entityKey = ID;


### PR DESCRIPTION
- [x] Decision to go for i. `@UI.PartOfPreview`annotation solution
- [x] Keep as TODO for now as this requires **fixes from Fiori**, see: https://support.wdf.sap.corp/sap/support/message/2370110305

--------

# Options for lazy loading in the UI for *Change History*

We want to lazy load the *Change History* table on a [Fiori Object Page](https://experience.sap.com/fiori-design-web/object-page/) as this table can have a large number of entries which we only want to see/search on demand.

## Requirements
In implementing this, we have the following restrictions:

1. We are restricting ourselves to an *Object Page*:

   Unlike the [*Go* Button from the List Report Page](https://experience.sap.com/fiori-design-web/list-report-floorplan-sap-fiori-element/#initial-focus), an Object Page treats lazy loading different [according to the number of items](https://experience.sap.com/fiori-design-web/object-page/#tables), where the *Change History* table would fall into the *last* category (as marked by :arrow_right: ):

    | Lazy Loading type | # Items |
    | ------------------|:-------:|
    | Lazy Loading Behavior (“More” button) |  < 100 |
    | Tab Navigation | > 100 but <= 400 |
    | :arrow_right:  &nbsp; Navigation to Another Page | > 400 |  

2. We are restricting ourselves to using only [Fiori annotations](https://sap.github.io/odata-vocabularies/vocabularies/UI.html)

     That means, no changes to the *manifest.json*, which contains most of the controls that we need, such as navigating to a separate Page (component), using another template (List Report), etc. that would support the extra features we need. 

In general, any solution we take should **not violate the Fiori guidelines** and stick to the possible (existing/customized) features of the floorplan (see Object Page) as designed.


## Possible solutions

To implement a solution within the realm of requirements (from above), we can only do two more things to influence the table loading: By showing/hiding the entire table or by implementing a button that only loads the data for that table on demand.

 &nbsp;&nbsp; i. [Using `@UI.PartOfPreview`](#preview)
 &nbsp;&nbsp;  ii. [Using `@UI.Hidden` on facet](#hidden_facet)
 &nbsp;&nbsp;  ii. [Using `@UI.Hidden` on columns](#hidden_columns)
 &nbsp;&nbsp;  iii. [Using an Action to set `$skip`, `$top`](#action)

-----------

### i. <a name="preview">Using `@UI.PartOfPreview`</a>

- Disabling `@UI.PartOfPreview` hides the facet initially:

  <img width="1318" alt="Screenshot 2023-09-26 at 06 26 02" src="https://github.com/cap-js/change-tracking/assets/8320933/1ce0e249-874d-4fbd-960e-b390210b46ae">

- Provides the buttons **Show More**/**Show Less** Buttons to show/hide it on demand:

  <img width="1318" alt="Screenshot 2023-09-26 at 06 26 21" src="https://github.com/cap-js/change-tracking/assets/8320933/07134522-4499-43e2-b6f2-61f045aa2920">

> [!IMPORTANT]  
> **COULD USE as long as filter/search erroneous behavior is fixed on page refresh**
> Could this be due to the following [restriction on facet target](https://sapui5.hana.ondemand.com/sdk/docs/topics/9fcea86d8ffd48459dd053eb5255a046.html)?

-----------

  ### ii.  <a name="hidden_facet">Using `@UI.Hidden` on facet</a>

 - Hiding the entire facet will stop data from loading automatically. We would then need an action button at the top of the Object page to toggle (show/hide) the facet on demand.

   <img width="1205" alt="Screenshot 2023-10-05 at 07 40 26" src="https://github.com/cap-js/change-tracking/assets/8320933/078d304a-4272-4d77-a52b-a410a1eec806">

> [!IMPORTANT]  
> **COULD USE as long we can set `@UI.Hidden` dynamically so that the Table as the button is pressed.**

-----------

  ### iii.  <a name="hidden_columns">Using `@UI.Hidden` on columns</a>

  - Hiding all columns does not have this issue (we still have a button), but the user might wonder why there are no default columns set to display:
 
    <img width="1331" alt="Screenshot 2023-09-26 at 08 47 40" src="https://github.com/cap-js/change-tracking/assets/8320933/a60ef43a-4928-413f-b170-7163f9b9739d">

> [!WARNING]
> **SHOULD NOT USE due to misleading message in the UI (we cannot change this text)**

-----------

  ### vi. <a name="action">Using an Action to set `$skip`,`$top`</a>

  - We display the table by default but initially set `$top = 0`. On pressing an action button "Show Changelogs", we could send a request to OData to retrieve the data, but with extra parameters that reset `$top`/`$skip` to their defaults. The user might still be confused by the default message 'No items available'.
   
     <img width="1331" alt="Screenshot 2023-09-26 at 08 54 20" src="https://github.com/cap-js/change-tracking/assets/8320933/ab656f59-ec2a-4763-a1d7-c167bd022371">

> [!WARNING]
> **SHOULD NOT USE, as it interferes with standard OData calls.**

-------------