### PR TITLE
Coemstics

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -100,7 +100,7 @@ annotate ChangeView with @(UI: {
     { Value: parentObjectID, @HTML5.CssDefaults: {width:'14%'} },
     { Value: attribute, @HTML5.CssDefaults: {width:'9%'} },
     { Value: valueChangedTo, @HTML5.CssDefaults: {width:'11%'} },
-    { Value: valueChangedFrom, @HTML5.CssDefaults: {width:'11%'} }
+    { Value: valueChangedFrom, @HTML5.CssDefaults: {width:'11%'} },
     { Value: entity, @HTML5.CssDefaults: {width:'11%'} },
   ],
   DeleteHidden       : true,


### PR DESCRIPTION
- Fix i18n label: `ChangeHistoryList`-> `ChangeHistory`
- Remove following note (as this is no longer the case):
```
  // IMPORTANT: If we omit field 'entity' below, objectID and parentObjetId are empty in the UI
  // REVISIT: Find out and eliminate the reason for that
```
- Fix column widths so as not to cut off the first one as seen here:
<img width="1298" alt="Screenshot 2023-10-12 at 14 41 28" src="https://github.com/cap-js/change-tracking/assets/8320933/b6db1765-328b-4780-9283-26c0a9dfffa0">
