### PR TITLE
Make `ChangeView` readonly

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -19,6 +19,7 @@ aspect aspect @(UI.Facets: [{
 
 
 // This is a helper view to flatten the assoc path to the entityKey
+@readonly
 view ChangeView as
   select from Changes {
     *,


### PR DESCRIPTION
- Make `ChangeView` @readonly such that on *Edit* events, the table no longer looks like this:
<img width="1331" alt="Screenshot 2023-10-13 at 09 48 27" src="https://github.com/cap-js/change-tracking/assets/8320933/e264fa79-bad4-4901-97b2-9aeabe7ea9ce">
