### PR TITLE
Fix: labels looked up from serviceEntity

### DIFF
--- a/lib/localization.js
+++ b/lib/localization.js
@@ -1,8 +1,6 @@
 const cds = require("@sap/cds/lib");
 const LOG = cds.log("change-log");
 const { getNameFromPathVal, getDBEntity } = require("./entity-helper");
-const OBJECT_TYPE_I18N_LABEL_KEY = "@Common.Label"
-const OBJECT_TYPE_I18N_TITLE_KEY = "@title"
 
 const MODIF_I18N_MAP = {
     create: "{i18n>ChangeLog.modification.create}",
@@ -43,7 +41,7 @@ const _localizeDefaultObjectID = function (change, locale) {
         const parentEntityName = getNameFromPathVal(parentNodePathVal);
         const dbEntity = getDBEntity(parentEntityName);
         try {
-            const labelI18nKey = dbEntity[OBJECT_TYPE_I18N_LABEL_KEY];
+            const labelI18nKey = dbEntity['@Common.Label'];
             const labelI18nValue = labelI18nKey ? _getLocalization(locale, labelI18nKey) : null;
             change.parentObjectID = labelI18nValue ? labelI18nValue : dbEntity.name;
         } catch (e) {
@@ -56,7 +54,7 @@ const _localizeDefaultObjectID = function (change, locale) {
 const _localizeEntityType = function (change, locale) {
     if (change.entity) {
         try {
-            const labelI18nKey = _getLabelI18nKeyOnEntity(change.entity);
+            const labelI18nKey = _getLabelI18nKeyOnEntity(change.serviceEntity);
             const labelI18nValue = labelI18nKey ? _getLocalization(locale, labelI18nKey) : null;
 
             change.entity = labelI18nValue ? labelI18nValue : change.entity;
@@ -83,12 +81,11 @@ const _localizeAttribute = function (change, locale) {
         try {
             const serviceEntity = cds.model.definitions[change.serviceEntity];
             let labelI18nKey = _getLabelI18nKeyOnEntity(change.serviceEntity, change.attribute);
-            const element = serviceEntity.elements[change.attribute];
-            if (element.isAssociation && !labelI18nKey) {
-                labelI18nKey = _getLabelI18nKeyOnEntity(element.target);
+            if (!labelI18nKey) {
+                const element = serviceEntity.elements[change.attribute];
+                if (element.isAssociation) labelI18nKey = _getLabelI18nKeyOnEntity(element.target);
             }
             const labelI18nValue = labelI18nKey ? _getLocalization(locale, labelI18nKey) : null;
-
             change.attribute = labelI18nValue ? labelI18nValue : change.attribute;
         } catch (e) {
             LOG.error("Failed to localize change attribute", e);
@@ -98,14 +95,10 @@ const _localizeAttribute = function (change, locale) {
 };
 
 const _getLabelI18nKeyOnEntity = function (entityName, /** optinal */ attribute) {
-    const entity = cds.model.definitions[entityName];
-    if (!entity) return "";
-    if (attribute) {
-        const element = entity.elements[attribute] ? entity.elements[attribute] : {};
-        return element[OBJECT_TYPE_I18N_LABEL_KEY];
-    }
-    const entityLabel = entity[OBJECT_TYPE_I18N_LABEL_KEY] ? entity[OBJECT_TYPE_I18N_LABEL_KEY] : entity[OBJECT_TYPE_I18N_TITLE_KEY];
-    return entityLabel;
+    let def = cds.model.definitions[entityName];
+    if (attribute) def = def?.elements[attribute]
+    if (!def) return "";
+    return def['@Common.Label'] || def['@title'];
 };
 
 const localizeLogFields = function (data, locale) {

--- a/lib/localization.js
+++ b/lib/localization.js
@@ -41,7 +41,7 @@ const _localizeDefaultObjectID = function (change, locale) {
         const parentEntityName = getNameFromPathVal(parentNodePathVal);
         const dbEntity = getDBEntity(parentEntityName);
         try {
-            const labelI18nKey = dbEntity['@Common.Label'];
+            const labelI18nKey = dbEntity['@Common.Label'] || dbEntity['@title'];
             const labelI18nValue = labelI18nKey ? _getLocalization(locale, labelI18nKey) : null;
             change.parentObjectID = labelI18nValue ? labelI18nValue : dbEntity.name;
         } catch (e) {

--- a/tests/integration/fiori-draft-enabled.test.js
+++ b/tests/integration/fiori-draft-enabled.test.js
@@ -886,7 +886,7 @@ describe("change log integration test", () => {
         );
         await utils.apiAction("admin", "BookStores", "64625905-c234-4d0d-9bc1-283ee8946770", "AdminService", action);
 
-        const selectedColumns = ["attribute", "modification", "entity", "objectID"];
+        const selectedColumns = ["attribute", "modification", "entity", "objectID", "parentObjectID"];
         const bookElementChanges = [];
         for (const selectedColumn of selectedColumns) {
             const bookChanges = await adminService.run(
@@ -910,7 +910,7 @@ describe("change log integration test", () => {
 
         // To do localization, entity only needs parameters entity itself, so the localization could be done
         const bookChangeEntity = bookElementChanges[2];
-        expect(bookChangeEntity.entity).to.equal("Book Store");
+        expect(bookChangeEntity.entity).to.equal("sap.capire.bookshop.BookStores");
 
         // To do localization, object id needs parameters entity (if no object id is annotated), so the localization could not be done
         // If no object id is annotated, the real value stored in db of object id should be "".


### PR DESCRIPTION
Labels were erroneously looked from db entity only, e.g. `sap.capire.incidents.Incidents` but should also and always be looked up from the service entity, e.g. `ProcessorsService.Incidents` (labels from underlying db entities are inherited). 

This PR fixes that. 