### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 1.0.0 - TBD
+## Version 1.0.1 - TBD
+
+### Fixed
+
+- Labels are looked up from the service entity (not the db entity only).
+
+## Version 1.0.0 - 18.10.23
 
 ### Added
 


### PR DESCRIPTION
- Fill in missing release date (v1.0.0)
- Add CHANGELOG entry for [labels fix](https://github.com/cap-js/change-tracking/pull/33)