### PR TITLE
Prepare Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Use view of the full change-tracking table instead of the customized one for the main image.
+- In README, use view of the full change-tracking table instead of the customized one for the main image.
 
 ## Version 1.0.1 - 26.10.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.0.2 - 31.10.23
+
+### Changed
+
+- Use view of the full change-tracking table instead of the customized one for the main image.
+
 ## Version 1.0.1 - 26.10.23
+
+### Changed
+
+- Flattened README structure.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
- Required to publish [*updated* README contents](https://github.com/cap-js/change-tracking/pull/37) to npm