### PR TITLE
Valid ObjectID for simultaneous creation of parent/child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.0.3 - TBD
+
+### Changed
+
+- Support cases where parent/child entries are created simultaneously.
+
 ## Version 1.0.2 - 31.10.23
 
 ### Changed

--- a/lib/entity-helper.js
+++ b/lib/entity-helper.js
@@ -85,7 +85,9 @@ async function getObjectId (entityName, fields, curObj) {
         if (IDval) try {
           // REVISIT: This always reads all elements -> should read required ones only!
           let ID = assoc.keys?.[0]?.ref[0] || 'ID'
-          _db_data = await SELECT.one.from(assoc._target).where({[ID]: IDval}) || {}
+          _db_data = await SELECT.one.from(assoc._target).where({[ID]: IDval}) ||
+            // When parent/child nodes are created simulateously, data is taken from draft table
+            await SELECT.one.from(`${assoc._target}.drafts`).where({[ID]: IDval}) || {}
         } catch (e) {
           LOG.error("Failed to generate object Id for an association entity.", e)
           throw new Error("Failed to generate object Id for an association entity.", e)

--- a/lib/entity-helper.js
+++ b/lib/entity-helper.js
@@ -85,8 +85,8 @@ async function getObjectId (entityName, fields, curObj) {
         if (IDval) try {
           // REVISIT: This always reads all elements -> should read required ones only!
           let ID = assoc.keys?.[0]?.ref[0] || 'ID'
+          // When parent/child nodes are created simultaneously, data is taken from draft table
           _db_data = await SELECT.one.from(assoc._target).where({[ID]: IDval}) ||
-            // When parent/child nodes are created simulateously, data is taken from draft table
             await SELECT.one.from(`${assoc._target}.drafts`).where({[ID]: IDval}) || {}
         } catch (e) {
           LOG.error("Failed to generate object Id for an association entity.", e)

--- a/tests/integration/fiori-draft-enabled.test.js
+++ b/tests/integration/fiori-draft-enabled.test.js
@@ -806,6 +806,43 @@ describe("change log integration test", () => {
         const deleteTitleChange = deleteTitleChanges[0];
         expect(deleteTitleChange.objectID).to.equal("new title, In Preparation, France");
 
+        // Check object ID "bookStore.city.country.countryName.code" when creating BookStores/Books
+        // (parent/child) at the same time.
+        cds.services.AdminService.entities.Books["@changelog"] = [
+            { "=": "bookStore.city.country.countryName.code" },
+        ];
+
+        const createBooksAndBookStoresAction = POST.bind({}, `/odata/v4/admin/BookStores`, {
+            ID: "48268451-8552-42a6-a3d7-67564be86634",
+            city_ID: "60b4c55d-ec87-4edc-84cb-2e4ecd60de48",
+            books: [
+                {
+                    ID: "12ed5dd8-d45b-11ed-afa1-1942bd119007",
+                    title: "New title",
+                },
+            ],
+        });
+
+        await utils.apiAction(
+            "admin",
+            "BookStores",
+            "48268451-8552-42a6-a3d7-67564be86634",
+            "AdminService",
+            createBooksAndBookStoresAction,
+            true,
+        );
+
+        const createBooksAndBookStoresChanges = await adminService.run(
+            SELECT.from(ChangeView).where({
+                entity: "sap.capire.bookshop.Books",
+                attribute: "title",
+                modification: "create",
+            }),
+        );
+        expect(createBooksAndBookStoresChanges.length).to.equal(1);
+        const createBooksAndBookStoresChange = createBooksAndBookStoresChanges[0];
+        expect(createBooksAndBookStoresChange.objectID).to.equal("USA");
+
         cds.services.AdminService.entities.Books["@changelog"] = [
             { "=": "title" },
             { "=": "author.name.firstName" },


### PR DESCRIPTION
- *Hot fix* to support the common case where **parent/child entries are created simultaneously**
- For example:
  -  Suppose we have the following change-tracking annotation on a model with parent `RootLevel` and Child `NestedChild`:
      ```cds
      namespace sap.capire.sample;
      using { managed, cuid } from '@sap/cds/common';
      
      entity RootLevel: cuid {
        additionalInfo : String;
        children : Composition of many NestedChild on children.parent = $self;
      };
      
      entity NestedChild: cuid {
        value : String;
        parent : Association to RootLevel;
      };
      ```
  - And we have the change-tracking annotation:
    ```cds
    using { sap.capire.sample } from './list-service';
    
    annotate ListService.RootLevel with @changelog: [ additionalInfo ] {
      additionalInfo @changelog @Common.Label: 'Additional Info';
    }
    
    annotate ListService.NestedChild with @changelog: [ parent.additionalInfo ] {
      value @changelog @Common.Label: 'Value';
    }
    ```

  - In the application, when creating 'parent 1'/'child 1' in draft mode, both Object IDs should be 'parent 1':

    <img width="1035" alt="Screenshot 2023-11-03 at 14 06 49" src="https://github.com/cap-js/change-tracking/assets/8320933/4ee3c2dd-9ad1-4c3b-986e-34a59a5b36da">

- Without this fix, if the parent data could not be resolved at the time the child is created and hence, the ObjectID for NestedChild would have simply defaulted to 'Nested Child (i.e. the title of the entity.) 