### PR TITLE
fix: When a custom action is triggered on a child entity, the corresponding changelog is captured.

### DIFF
--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -359,7 +359,7 @@ async function track_changes (req) {
   if (!changes) return
 
   await _formatChangeLog(changes, req)
-  if (isComposition && !isDraftEnabled) {
+  if (isComposition) {
     [ target, entityKey ] = await _prepareChangeLogForComposition(target, entityKey, changes, this)
   }
   const dbEntity = getDBEntity(target)

--- a/tests/bookshop/db/codelists.cds
+++ b/tests/bookshop/db/codelists.cds
@@ -1,0 +1,11 @@
+using {sap.common.CodeList as CodeList} from '@sap/cds/common';
+
+namespace sap.capire.bookshop;
+
+entity PaymentAgreementStatusCodes : CodeList {
+  key code : String(10);
+}
+
+entity ActivationStatusCode : CodeList {
+  key code : String(20);
+}

--- a/tests/bookshop/db/common/codeLists.cds
+++ b/tests/bookshop/db/common/codeLists.cds
@@ -10,3 +10,7 @@ entity LifecycleStatusCodes : CodeList {
 entity BookTypeCodes : CodeList {
     key code : String(3);
 }
+
+entity ActivationStatusCode : CodeList {
+    key code : String(20);
+}

--- a/tests/bookshop/db/data/sap.capire.bookshop-ActivationStatusCode.csv
+++ b/tests/bookshop/db/data/sap.capire.bookshop-ActivationStatusCode.csv
@@ -1,0 +1,3 @@
+code;name
+INACTIVE;Inactive
+ACTIVE;Active

--- a/tests/bookshop/db/data/sap.capire.bookshop-PaymentAgreementStatusCodes.csv
+++ b/tests/bookshop/db/data/sap.capire.bookshop-PaymentAgreementStatusCodes.csv
@@ -1,0 +1,5 @@
+code;name
+EXPIRED;Expired
+VALID;Valid
+VALIDLATER;Valid Later
+INACTIVE;Inactive

--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -9,6 +9,8 @@ using {
   sap.capire.common.types.LifecycleStatusCode as LifecycleStatusCode,
   sap.capire.common.types.BookTypeCodes as BookTypeCodes,
 } from './common/types.cds';
+using {sap.capire.bookshop.ActivationStatusCode} from './codelists';
+using {sap.capire.bookshop.PaymentAgreementStatusCodes as PaymentAgreementStatusCodes} from './codelists';
 
 namespace sap.capire.bookshop;
 
@@ -77,6 +79,10 @@ entity Volumns : managed, cuid {
   @title : '{i18n>volumns.sequence}'
   sequence : Integer;
   book     : Association to one Books;
+  @title : '{i18n>Status}'
+  @changelog : [ActivationStatus.name]
+  ActivationStatus : Association to one ActivationStatusCode;
+  PaymentAgreementStatus : Association to one PaymentAgreementStatusCodes on PaymentAgreementStatus.code = ActivationStatus.code;
 }
 
 @title                  : '{i18n>bookStoreRegistry.objectTitle}'
@@ -140,6 +146,9 @@ entity OrderItem : cuid {
 entity OrderItemNote : cuid {
   orderItem : Association to one OrderItem;
   content   : String;
+  @title : '{i18n>Status}'
+  ActivationStatus : Association to one ActivationStatusCode;
+  PaymentAgreementStatus : Association to one PaymentAgreementStatusCodes on PaymentAgreementStatus.code = ActivationStatus.code;
 }
 
 entity City : cuid {

--- a/tests/bookshop/srv/admin-service.cds
+++ b/tests/bookshop/srv/admin-service.cds
@@ -1,4 +1,5 @@
 using {sap.capire.bookshop as my} from '../db/schema';
+using {sap.capire.bookshop.PaymentAgreementStatusCodes as PaymentAgreementStatusCodes} from '../db/codelists';
 
 service AdminService {
   @odata.draft.enabled
@@ -8,8 +9,19 @@ service AdminService {
   entity Report                       as projection on my.Report;
   entity Order                        as projection on my.Order;
   entity OrderItem                    as projection on my.OrderItem;
-  entity OrderItemNote                as projection on my.OrderItemNote;
-  entity Volumns                      as projection on my.Volumns;
+  
+  entity OrderItemNote                as projection on my.OrderItemNote actions {
+    @cds.odata.bindingparameter.name: 'self'
+    @Common.SideEffects             : {TargetEntities: [self]}
+    action activate();
+  };
+
+  entity Volumns                      as projection on my.Volumns actions {
+    @cds.odata.bindingparameter.name: 'self'
+    @Common.SideEffects             : {TargetEntities: [self]}
+    action activate();
+  };
+
   entity Customers                    as projection on my.Customers;
 }
 
@@ -82,6 +94,7 @@ annotate AdminService.OrderItem with {
 
 annotate AdminService.OrderItemNote with {
   content @changelog;
+  ActivationStatus @changelog : [ActivationStatus.name];
 }
 
 annotate AdminService.Customers with {

--- a/tests/bookshop/srv/admin-service.js
+++ b/tests/bookshop/srv/admin-service.js
@@ -5,4 +5,23 @@ module.exports = cds.service.impl(async (srv) => {
         const newBookStores = req.data;
         newBookStores.lifecycleStatus_code = "IP";
     });
+
+    const onActivateVolumns = async (req) => {
+        const entity = req.entity;
+        const entityID = req._params[req._params.length - 1].ID;
+        await UPDATE.entity(entity)
+          .where({ ID: entityID })
+          .set({ ActivationStatus_code: "VALID" });
+    };
+
+    const onActivateOrderItemNote = async (req) => {
+        const entity = req.entity;
+        const entityID = req._params[req._params.length - 1];
+        await UPDATE.entity(entity)
+          .where({ ID: entityID })
+          .set({ ActivationStatus_code: "VALID" });
+    };
+
+    srv.on("activate", "Volumns", onActivateVolumns);
+    srv.on("activate", "OrderItemNote", onActivateOrderItemNote);
 });

--- a/tests/integration/fiori-draft-disabled.test.js
+++ b/tests/integration/fiori-draft-disabled.test.js
@@ -368,4 +368,22 @@ describe("change log draft disabled test", () => {
         expect(headerChange.parentObjectID).to.equal("Post");
         delete cds.services.AdminService.entities.Order["@changelog"];
     });
+
+    it("11.2 The change log should be captured when a child entity in draft-disabled mode triggers a custom action (ERP4SMEPREPWORKAPPPLAT-6211)", async () => {
+        await POST(
+            `/odata/v4/admin/Order(ID=0a41a187-a2ff-4df6-bd12-fae8996e6e31)/orderItems(ID=9a61178f-bfb3-4c17-8d17-c6b4a63e0097)/notes(ID=a40a9fd8-573d-4f41-1111-fa8ea0d8b1bc)/AdminService.activate`,
+            {
+                ActivationStatus_code: "VALID",
+            },
+        );
+        let changes = await SELECT.from(ChangeView).where({
+            entity: "sap.capire.bookshop.OrderItemNote",
+            attribute: "ActivationStatus",
+        });
+        expect(changes.length).to.equal(1);
+        expect(changes[0].valueChangedFrom).to.equal("");
+        expect(changes[0].valueChangedTo).to.equal("VALID");
+        expect(changes[0].entityKey).to.equal("0a41a187-a2ff-4df6-bd12-fae8996e6e31");
+        expect(changes[0].parentKey).to.equal("9a61178f-bfb3-4c17-8d17-c6b4a63e0097");
+    });
 });

--- a/tests/integration/fiori-draft-enabled.test.js
+++ b/tests/integration/fiori-draft-enabled.test.js
@@ -1082,4 +1082,22 @@ describe("change log integration test", () => {
         expect(registryChange.parentKey).to.equal("8aaed432-8336-4b0d-be7e-3ef1ce7f13ea");
         expect(registryChange.parentObjectID).to.equal("City Lights Books");
     });
+
+    it("11.1 The change log should be captured when a child entity in draft-enabled mode triggers a custom action (ERP4SMEPREPWORKAPPPLAT-6211)", async () => {
+        await POST(
+            `/odata/v4/admin/BookStores(ID=64625905-c234-4d0d-9bc1-283ee8946770,IsActiveEntity=true)/books(ID=9d703c23-54a8-4eff-81c1-cdce6b8376b1,IsActiveEntity=true)/volumns(ID=dd1fdd7d-da2a-4600-940b-0baf2946c9bf,IsActiveEntity=true)/AdminService.activate`,
+            {
+                ActivationStatus_code: "VALID",
+            },
+        );
+        let changes = await SELECT.from(ChangeView).where({
+            entity: "sap.capire.bookshop.Volumns",
+            attribute: "ActivationStatus",
+        });
+        expect(changes.length).to.equal(1);
+        expect(changes[0].valueChangedFrom).to.equal("");
+        expect(changes[0].valueChangedTo).to.equal("VALID");
+        expect(changes[0].entityKey).to.equal("64625905-c234-4d0d-9bc1-283ee8946770");
+        expect(changes[0].parentKey).to.equal("9d703c23-54a8-4eff-81c1-cdce6b8376b1");
+    });
 });


### PR DESCRIPTION
This PR is to solve the problem that when the custom action of the child entity is triggered, the corresponding change log will not be correctly captured.