### PR TITLE
fix: If no key attribute is defined for the entity, the logic to add association to ChangeView should be skipped.

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -40,6 +40,11 @@ cds.on('loaded', m => {
       const keys = [], { elements: elms } = entity
       for (let e in elms) if (elms[e].key) keys.push(e)
 
+      // If no key attribute is defined for the entity, the logic to add association to ChangeView should be skipped.
+      if(keys.length === 0) {
+        return;
+      }
+
       // Add association to ChangeView...
       const on = [...changes.on]; keys.forEach((k, i) => { i && on.push('||'); on.push({
         ref: k === 'up_' ? [k,'ID'] : [k] // REVISIT: up_ handling is a dirty hack for now

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -42,7 +42,7 @@ cds.on('loaded', m => {
 
       // If no key attribute is defined for the entity, the logic to add association to ChangeView should be skipped.
       if(keys.length === 0) {
-        return;
+        continue;
       }
 
       // Add association to ChangeView...


### PR DESCRIPTION
Adopting "Change-tracking" library:
BEM project repo: https://github.tools.sap/Climate-21/c21-networkcalculation-srv

Reproduce PR:
https://github.tools.sap/Climate-21/c21-networkcalculation-srv/pull/2386

The step “npm run build” fails currently at entity FlowModelService.senderNodeEnergyCarrier (https://github.tools.sap/Climate-21/c21-networkcalculation-srv/blob/94cb4d6048aa69a5a368e02c2311b17d30d9da94/srv/model/FlowModelService.cds#L478).

Error Message:
<img width="1020" alt="image" src="https://github.com/cap-js/change-tracking/assets/132032144/32c82991-0d04-43fb-ae50-26ff5277f659">

Best Regards
Jocelyn