### PR TITLE
Disable Facet with annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The system now uses the SAPUI5 default setting `![@UI.PartOfPreview]: true`, suc
 
 ### Disable Facet
 
-To not show the changelog facet on compositions subsites, you can use `@changelog.disale_facet` for the facet to not show up.
+To not show the changelog facet on compositions subsites, you can use `@changelog.disable_facet` for the facet to not show up.
 
 
 ## Modelling Samples

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ annotate sap.changelog.aspect @(UI.Facets: [{
 
 The system now uses the SAPUI5 default setting `![@UI.PartOfPreview]: true`, such that the table will always shown when navigating to that respective Object page.
 
+### Disable Facet
+
+To not show the changelog facet on compositions subsites, you can use `@changelog.disale_facet` for the facet to not show up.
+
 
 ## Modelling Samples
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -58,7 +58,8 @@ cds.on('loaded', m => {
       }
 
       // Add UI.Facet for Change History List
-      entity['@UI.Facets']?.push(facet)
+      if(!entity['@changelog.disable_facet'])
+        entity['@UI.Facets']?.push(facet)
 
       // The changehistory list should be refreshed after the custom action is triggered
       if (entity.actions) {


### PR DESCRIPTION
Hello everyone,

with this patch I suggest adding the annotation `@changelog.disable_facet` to disable the facet on an entity completely.
This might be useful if we have deep fiori UIs where a lot of the entities are tracked. Depending on the configuration, I want all of them tracked on the main entity, yet empty facets are shown on the subpages anyway.

Have a nice weekend and feel free to ask questions.

Kind regards