### PR TITLE
Add limitations about CAP Feature toggles to the documentation / readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ a [CDS plugin](https://cap.cloud.sap/docs/node.js/cds-plugins#cds-plugin-package
   - [Specify Object ID](#specify-object-id)
   - [Tracing Changes](#tracing-changes)
   - [Don&#39;ts](#donts)
+- [Limitations](#limitations)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Licensing](#licensing)
@@ -573,6 +574,23 @@ this.on("UpdateActivationStatus", async (req) =>
 ```
 
 The reason is that: Application level services are by design the only place where business logic is enforced. This by extension means, that it also is the only point where e.g. change-tracking would be enabled. The underlying method used to do change tracking is `req.diff` which is responsible to read the necessary before-image from the database, and this method is not available on DB level.
+
+## Limitations
+
+Currently, change-tracking is not fully compatible with the [@sap/cds-mtxs](https://www.npmjs.com/package/@sap/cds-mtxs) package which is used to provide [CAP Feature Toggles](https://cap.cloud.sap/docs/guides/extensibility/feature-toggles#enable-feature-toggles). 
+
+When activating the features toggles in the `package.json` or `.cdsrc.json` using:
+
+```json
+"cds":{
+  "requires": {
+    "toggles": true
+  }
+}
+```
+
+The generated facets and associations will not be present in the metadata provided by the service. Therefore, it will not work out of the box. 
+A possible mitigation is to add the association and facet manually to the service entity. *Beware* that the association cannot be named `changes` as it conflicts with the generated one.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ a [CDS plugin](https://cap.cloud.sap/docs/node.js/cds-plugins#cds-plugin-package
 > 
 > See the changelog for a full list of changes
 
+> [!Warning]
+>
+>Currently, change-tracking is not fully compatible with the [@sap/cds-mtxs](https://www.npmjs.com/package/@sap/cds-mtxs) package which is used to provide extensibility and [CAP Feature Toggles](https://cap.cloud.sap/docs/guides/extensibility/feature-toggles#enable-feature-toggles). 
+>
+>When using multi-tenancy with MTX, the generated facets and associations will not be present in the metadata provided by the service. Therefore, it will not work out of the box. 
+>Until this gap in MTX is closed, we suggest using the `@changelog.disable_assoc` ([see here](#disable-association-to-changes-generation)) for all tracked entities and to add the association and facet manually to the service entity.
+
 
 ### Table of Contents
 
@@ -28,7 +35,6 @@ a [CDS plugin](https://cap.cloud.sap/docs/node.js/cds-plugins#cds-plugin-package
   - [Specify Object ID](#specify-object-id)
   - [Tracing Changes](#tracing-changes)
   - [Don&#39;ts](#donts)
-- [Limitations](#limitations)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Licensing](#licensing)
@@ -575,22 +581,6 @@ this.on("UpdateActivationStatus", async (req) =>
 
 The reason is that: Application level services are by design the only place where business logic is enforced. This by extension means, that it also is the only point where e.g. change-tracking would be enabled. The underlying method used to do change tracking is `req.diff` which is responsible to read the necessary before-image from the database, and this method is not available on DB level.
 
-## Limitations
-
-Currently, change-tracking is not fully compatible with the [@sap/cds-mtxs](https://www.npmjs.com/package/@sap/cds-mtxs) package which is used to provide [CAP Feature Toggles](https://cap.cloud.sap/docs/guides/extensibility/feature-toggles#enable-feature-toggles). 
-
-When activating the features toggles in the `package.json` or `.cdsrc.json` using:
-
-```json
-"cds":{
-  "requires": {
-    "toggles": true
-  }
-}
-```
-
-The generated facets and associations will not be present in the metadata provided by the service. Therefore, it will not work out of the box. 
-A possible mitigation is to add the association and facet manually to the service entity. *Beware* that the association cannot be named `changes` as it conflicts with the generated one.
 
 ## Contributing
 


### PR DESCRIPTION
As discussed in [issue 116](https://github.com/cap-js/change-tracking/issues/116).

I think it's worth to add this to the readme, as it cost us quite some time to find this.