### PR TITLE
Format date properties

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -84,7 +84,8 @@ annotate ChangeView with @(UI: {
     RequestAtLeast: [
       parentKey,
       serviceEntity,
-      serviceEntityPath
+      serviceEntityPath,
+      valueDataType
     ],
     SortOrder     : [{
       Property  : createdAt,

--- a/lib/localization.js
+++ b/lib/localization.js
@@ -101,6 +101,20 @@ const _getLabelI18nKeyOnEntity = function (entityName, /** optinal */ attribute)
     return def['@Common.Label'] || def['@title'];
 };
 
+const dateFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+}
+const _localizeDates = (change, locale) => {
+    if (change.valueDataType === 'cds.Date') {
+        if (change.valueChangedFrom)
+            change.valueChangedFrom = new Date(change.valueChangedFrom).toLocaleDateString(locale.replaceAll('_', '-'), dateFormatOptions) //locale.replace because en_GB is unknown to function and it has to be en-GB
+        if (change.valueChangedTo)
+            change.valueChangedTo = new Date(change.valueChangedTo).toLocaleDateString(locale.replaceAll('_', '-'), dateFormatOptions)
+    }
+}
+
 const localizeLogFields = function (data, locale) {
     if (!locale) return
     for (const change of data) {
@@ -108,6 +122,7 @@ const localizeLogFields = function (data, locale) {
         _localizeAttribute(change, locale);
         _localizeEntityType(change, locale);
         _localizeDefaultObjectID(change, locale);
+        _localizeDates(change, locale);
     }
 };
 module.exports = {


### PR DESCRIPTION
Hi colleagues,

currently if a cds.Date property is modified it is shown as '2022-12-01' in the change log. This is not really user friendly and thus this PR adds date formatting so the dates show up as they would in UI5, e.g. '01 Dec 2022'

BR,
Marten