### PR TITLE
use dataloader to collect calls to DB fixes #30

### DIFF
--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -167,12 +167,12 @@ const _getChildChangeObjId = async function (
 const _formatCompositionContext = async function (changes, reqData) {
   const childNodeChanges = []
 
-  for (const change of changes) {
+  await Promise.all(changes.map(async (change) => {
     if (typeof change.valueChangedTo === "object") {
       if (!Array.isArray(change.valueChangedTo)) {
         change.valueChangedTo = [change.valueChangedTo]
       }
-      for (const childNodeChange of change.valueChangedTo) {
+      await Promise.all(change.valueChangedTo.map(async (childNodeChange) => {
         const curChange = Object.assign({}, change)
         const path = childNodeChange._path.split('/')
         const curNodePathVal = path.pop()
@@ -184,10 +184,10 @@ const _formatCompositionContext = async function (changes, reqData) {
           reqData
         )
         _formatCompositionValue(curChange, objId, childNodeChange, childNodeChanges)
-      }
+      }))
       change.valueChangedTo = undefined
     }
-  }
+  }))
   changes.push(...childNodeChanges)
 }
 
@@ -248,7 +248,7 @@ const _getObjectIdByPath = async function (
 
 const _formatObjectID = async function (changes, reqData) {
   const objectIdCache = new Map()
-  for (const change of changes) {
+  await Promise.all(changes.map(async (change) => {
     const path = change.serviceEntityPath.split('/')
     const curNodePathVal = path.pop()
     const parentNodePathVal = path.pop()
@@ -276,7 +276,7 @@ const _formatObjectID = async function (changes, reqData) {
     change.entityID = curNodeObjId
     change.parentEntityID = parentNodeObjId
     change.parentKey = getUUIDFromPathVal(parentNodePathVal)
-  }
+  }))
 }
 
 const _isCompositionContextPath = function (aPath, hasComp) {
@@ -290,6 +290,7 @@ const _isCompositionContextPath = function (aPath, hasComp) {
 }
 
 const _formatChangeLog = async function (changes, req) {
+  cds.context.dataloaders = {}
   await _formatObjectID(changes, req.data)
   await _formatAssociationContext(changes, req.data)
   await _formatCompositionContext(changes, req.data)

--- a/lib/entity-helper.js
+++ b/lib/entity-helper.js
@@ -1,4 +1,5 @@
 const cds = require("@sap/cds")
+const DataLoader = require("dataloader");
 const LOG = cds.log("change-log")
 
 
@@ -29,11 +30,21 @@ const getObjIdElementNamesInArray = function (elements) {
   else return []
 }
 
-const getCurObjFromDbQuery = async function (entityName, queryVal, /**optional*/ queryKey='ID') {
+const getCurObjFromDbQuery = async function (entityName, queryVal, /**optional*/ queryKey = 'ID') {
+  if (!(entityName in cds.context.dataloaders)) {
+    cds.context.dataloaders[entityName] = new DataLoader(async (keys) => {
+      // REVISIT: This always reads all elements -> should read required ones only!
+      const results = await SELECT.from(entityName).where(queryKey, 'in', keys)
+      const resultsByKey = results.reduce((acc, instance) => {
+        const key = instance[queryKey]
+        acc[key] = instance
+        return acc
+      }, {})
+      return keys.map(key => resultsByKey[key] || {})
+    })
+  }
   if (!queryVal) return {}
-  // REVISIT: This always reads all elements -> should read required ones only!
-  const obj = await SELECT.one.from(entityName).where({[queryKey]: queryVal})
-  return obj || {}
+  return cds.context.dataloaders[entityName].load(queryVal)
 }
 
 const getCurObjFromReqData = function (reqData, nodePathVal, pathVal) {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
         "model": "@cap-js/change-tracking"
       }
     }
+  },
+  "dependencies": {
+    "dataloader": "^2.2.2"
   }
 }


### PR DESCRIPTION
Using the [dataloder](https://www.npmjs.com/package/dataloader) module the calls to the DB are minimized without needing to refactor the code too much.

This fixes the performance issues which occur in drafActivate ( see #30  )

I would love to write a test, but it seems jest is not fully supported in this project.
```js
it("should only optimize reads to the DB", async () => {
    const action1 = POST.bind(
      {},
      `/odata/v4/admin/BookStores(ID=64625905-c234-4d0d-9bc1-283ee8946770,IsActiveEntity=false)/books`,
      {
        ID: "9d703c23-54a8-4eff-81c1-cdce6b8376b2",
        title: "test title 1",
        descr: "test descr",
        author_ID: "d4d4a1b3-5b83-4814-8a20-f039af6f0387",
        stock: 1,
        price: 1.0,
        isUsed: true
      }
    );
    const action2 = POST.bind(
      {},
      `/odata/v4/admin/BookStores(ID=64625905-c234-4d0d-9bc1-283ee8946770,IsActiveEntity=false)/books`,
      {
        ID: "3e53bf3b-53f7-4db8-87ce-8bb0818574d8",
        title: "test title 2",
        descr: "test descr",
        author_ID: "d4d4a1b3-5b83-4814-8a20-f039af6f0387",
        stock: 1,
        price: 1.0,
        isUsed: true
      }
    );
    const cdsRunSpy = jest.spyOn(cds.db, "run")
    await utils.apiAction("admin", "BookStores", "64625905-c234-4d0d-9bc1-283ee8946770", "AdminService", [action1, action2]);
    // `toHaveBeenCalledWith` is not working in this project
    expect(cdsRunSpy).toHaveBeenCalledWith([expect.objectContaining({
      SELECT: {
        from: expect.objectContaining({ref: ["AdminService.Books"]}),
        where: [expect.objectContaining({ref: ["ID"]}), "in", {list: [{val: "9d703c23-54a8-4eff-81c1-cdce6b8376b2"}, {val: "3e53bf3b-53f7-4db8-87ce-8bb0818574d8"}]}]
      }
    })])
  });
```