### PR TITLE
Revert unit test of service api for draft-enabled entity.

### DIFF
--- a/tests/integration/service-api.test.js
+++ b/tests/integration/service-api.test.js
@@ -143,10 +143,9 @@ describe("change log integration test", () => {
                 },
             ],
         };
-        await INSERT.into(adminService.entities.BookStores).entries(bookStoreData);
 
-        // REVISIT: CAP currently does not support run queries on the draft-enabled entity on application service (details in CAP/Issue#16292)
-        // await adminService.run(INSERT.into(adminService.entities.BookStores).entries(bookStoreData));
+        // CAP currently support run queries on the draft-enabled entity on application service, so we can re-enable it. (details in CAP/Issue#16292)
+        await adminService.run(INSERT.into(adminService.entities.BookStores).entries(bookStoreData));
 
         let changes = await SELECT.from(ChangeView).where({
             entity: "sap.capire.bookshop.BookStores",
@@ -432,10 +431,9 @@ describe("change log integration test", () => {
                 validOn: "2022-01-01",
             },
         };
-        await INSERT.into(adminService.entities.BookStores).entries(bookStoreData);
 
-        // REVISIT: CAP currently does not support run queries on the draft-enabled entity on application service (details in CAP/Issue#16292)
-        // await adminService.run(INSERT.into(adminService.entities.BookStores).entries(bookStoreData));
+        // CAP currently support run queries on the draft-enabled entity on application service, so we can re-enable it. (details in CAP/Issue#16292)
+        await adminService.run(INSERT.into(adminService.entities.BookStores).entries(bookStoreData));
 
         let changes = await SELECT.from(ChangeView).where({
             entity: "sap.capire.bookshop.BookStoreRegistry",


### PR DESCRIPTION
Because after internal discussions within CAP, it seems they now support running queries on the draft-enabled entity in the application service, we can revert the previous tests for the service API.

Related issue:
https://github.tools.sap/cap/issues/issues/16292
