### PR TITLE
Added `@UI.MultiLineText` to value fields

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -54,8 +54,8 @@ entity Changes {
   key ID                : UUID                     @UI.Hidden;
       keys              : String                   @title: '{i18n>Changes.keys}';
       attribute         : String                   @title: '{i18n>Changes.attribute}';
-      valueChangedFrom  : String                   @title: '{i18n>Changes.valueChangedFrom}';
-      valueChangedTo    : String                   @title: '{i18n>Changes.valueChangedTo}';
+      valueChangedFrom  : String                   @title: '{i18n>Changes.valueChangedFrom}' @UI.MultiLineText;
+      valueChangedTo    : String                   @title: '{i18n>Changes.valueChangedTo}' @UI.MultiLineText;
 
       // Business meaningful object id
       entityID          : String                   @title: '{i18n>Changes.entityID}';


### PR DESCRIPTION
Hi @Sv7enNowitzki,

if a String field is currently modified and tracked via a change log, which contains a long string, it is not properly rendered on the UI due to the missing `@UI.MultiLineText` annotation. With that it basically renders as before, just that after 4/5 lines a show more button appears instead of rendering the whole value, which looks strange in a table.

BR,
Marten