### PR TITLE
Fix the issue where change tracking compilation errors occur when an association is used as a key.

### DIFF
--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -261,3 +261,21 @@ entity City : cuid {
 entity Country : cuid {
   countryName : CountryName;
 }
+
+entity FirstEntity : managed, cuid {
+  name : String;
+  children : Association to one Children;
+}
+
+entity SecondEntity : managed, cuid {
+  name : String;
+  children : Association to one Children;
+}
+
+@changelog : [one_ID]
+entity Children : managed {
+  @changelog
+  key one : Association to one FirstEntity;
+  @changelog
+  key two : Association to one SecondEntity;
+}


### PR DESCRIPTION
Although we currently do not support the use of associations as keys, it should not cause compilation errors in this case, leading to the project being halted. Therefore, this fix is needed to ensure that the project does not stop.