### PR TITLE
feat: Support change logs for bulk insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.0.9 - TBD
+
+### Added
+
+- 
+
+### Fixed
+
+- Handling of multiple records in one request
+
+
+### Changed
+
+- 
+
 ## Version 1.0.8 - 28.03.25
 
 ### Added

--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -166,20 +166,20 @@ const _formatAssociationContext = async function (changes, reqData) {
 }
 
 const _getChildChangeObjId = async function (
-    change,
-    childNodeChange,
-    curNodePathVal,
-    reqData
+  change,
+  childNodeChange,
+  curNodePathVal,
+  reqData
 ) {
   const composition = cds.model.definitions[change.serviceEntity].elements[change.attribute]
   const objIdElements = composition ? composition["@changelog"] : null
   const objIdElementNames = getObjIdElementNamesInArray(objIdElements)
 
   return _getObjectIdByPath(
-      reqData,
-      curNodePathVal,
-      childNodeChange._path,
-      objIdElementNames
+    reqData,
+    curNodePathVal,
+    childNodeChange._path,
+    objIdElementNames
   )
 }
 
@@ -197,10 +197,10 @@ const _formatCompositionContext = async function (changes, reqData) {
         const curNodePathVal = path.pop()
         curChange.modification = childNodeChange._op
         const objId = await _getChildChangeObjId(
-            change,
-            childNodeChange,
-            curNodePathVal,
-            reqData
+          change,
+          childNodeChange,
+          curNodePathVal,
+          reqData
         )
         _formatCompositionValue(curChange, objId, childNodeChange, childNodeChanges)
       }
@@ -211,10 +211,10 @@ const _formatCompositionContext = async function (changes, reqData) {
 }
 
 const _formatCompositionValue = function (
-    curChange,
-    objId,
-    childNodeChange,
-    childNodeChanges
+  curChange,
+  objId,
+  childNodeChange,
+  childNodeChanges
 ) {
   if (curChange.modification === undefined) {
     return
@@ -254,10 +254,10 @@ const _formatCompositionEntityType = function (change) {
 }
 
 const _getObjectIdByPath = async function (
-    reqData,
-    nodePathVal,
-    serviceEntityPath,
-    /**optional*/ objIdElementNames
+  reqData,
+  nodePathVal,
+  serviceEntityPath,
+  /**optional*/ objIdElementNames
 ) {
   const curObjFromReqData = getCurObjFromReqData(reqData, nodePathVal, serviceEntityPath)
   const entityName = getNameFromPathVal(nodePathVal)
@@ -277,9 +277,9 @@ const _formatObjectID = async function (changes, reqData) {
     let curNodeObjId = objectIdCache.get(curNodePathVal)
     if (!curNodeObjId) {
       curNodeObjId = await _getObjectIdByPath(
-          reqData,
-          curNodePathVal,
-          change.serviceEntityPath
+        reqData,
+        curNodePathVal,
+        change.serviceEntityPath
       )
       objectIdCache.set(curNodePathVal, curNodeObjId)
     }
@@ -287,9 +287,9 @@ const _formatObjectID = async function (changes, reqData) {
     let parentNodeObjId = objectIdCache.get(parentNodePathVal)
     if (!parentNodeObjId && parentNodePathVal) {
       parentNodeObjId = await _getObjectIdByPath(
-          reqData,
-          parentNodePathVal,
-          change.serviceEntityPath
+        reqData,
+        parentNodePathVal,
+        change.serviceEntityPath
       )
       objectIdCache.set(parentNodePathVal, parentNodeObjId)
     }
@@ -338,21 +338,21 @@ function _trackedChanges4 (srv, target, diff) {
       if (from === to) return
 
       /**
-       *
+       * 
        * HANA driver always filling up the defined decimal places with zeros,
        * need to skip the change log if the value is not changed.
        * Example:
        * entity Books : cuid {
        *   price     : Decimal(11, 4);
        * }
-       * When price is updated from 3000.0000 to 3000,
+       * When price is updated from 3000.0000 to 3000, 
        * the change log should not be created.
        */
       if (
-          row._op === "update" &&
-          element.type === "cds.Decimal" &&
-          cds.db.kind === "hana" &&
-          typeof to === "number"
+        row._op === "update" &&
+        element.type === "cds.Decimal" &&
+        cds.db.kind === "hana" &&
+        typeof to === "number"
       ) {
         const scaleNum = element.scale || 0;
         if (from === formatDecimal(to, scaleNum))
@@ -360,9 +360,9 @@ function _trackedChanges4 (srv, target, diff) {
       }
 
       /**
-       *
-       * For the Inline entity such as Items,
-       * further filtering is required on the keys
+       * 
+       * For the Inline entity such as Items, 
+       * further filtering is required on the keys 
        * within the 'association' and 'foreign key' to ultimately retain the keys of the entity itself.
        * entity Order : cuid {
        *   title      : String;
@@ -373,11 +373,11 @@ function _trackedChanges4 (srv, target, diff) {
        * }
        */
       const keys = Object.keys(eleParentKeys)
-          .filter(k => k !== "IsActiveEntity")
-          .filter(k => eleParentKeys[k]?.type !== "cds.Association") // Skip association
-          .filter(k => !eleParentKeys[k]?.["@odata.foreignKey4"]) // Skip foreign key
-          .map(k => `${k}=${row[k]}`)
-          .join(', ')
+        .filter(k => k !== "IsActiveEntity")
+        .filter(k => eleParentKeys[k]?.type !== "cds.Association") // Skip association
+        .filter(k => !eleParentKeys[k]?.["@odata.foreignKey4"]) // Skip foreign key
+        .map(k => `${k}=${row[k]}`)
+        .join(', ')
 
       changes.push({
         serviceEntityPath: row._path,
@@ -408,8 +408,8 @@ const _prepareChangeLogForComposition = async function (entity, entityKey, chang
   const parentKey = getUUIDFromPathVal(parentEntityPathVal)
   const serviceEntityPath = rootEntityPathVals.join('/')
   const parentServiceEntityPath = _getAllPathVals(req.context)
-      .slice(0, rootEntityPathVals.length - 2)
-      .join('/')
+    .slice(0, rootEntityPathVals.length - 2)
+    .join('/')
 
   for (const change of changes) {
     change.parentEntityID = await _getObjectIdByPath(req.data, parentEntityPathVal, parentServiceEntityPath)
@@ -431,11 +431,11 @@ async function generatePathAndParams (req, entityKey) {
 
   let compContext = {
     path: hasParentAndForeignKey
-        ? `${parentEntity.name}/${target.name}`
-        : `${target.name}`,
+      ? `${parentEntity.name}/${target.name}`
+      : `${target.name}`,
     params: hasParentAndForeignKey
-        ? [{ [ID]: data[foreignKey] }, { [ID]: entityKey }]
-        : [{ [ID]: entityKey }],
+      ? [{ [ID]: data[foreignKey] }, { [ID]: entityKey }]
+      : [{ [ID]: entityKey }],
     hasComp: true
   };
 
@@ -446,9 +446,9 @@ async function generatePathAndParams (req, entityKey) {
   let parentAssoc = await processEntity(targetEntity, targetKey, compContext);
   while (parentAssoc && !parentAssoc.entity[isRoot]) {
     parentAssoc = await processEntity(
-        parentAssoc.entity,
-        parentAssoc.ID,
-        compContext
+      parentAssoc.entity,
+      parentAssoc.ID,
+      compContext
     );
   }
   return compContext;
@@ -459,10 +459,10 @@ async function processEntity (entity, entityKey, compContext) {
 
   if (foreignKey && parentEntity) {
     const parentResult =
-        (await SELECT.one
-            .from(entity.name)
-            .where({ [ID]: entityKey })
-            .columns(foreignKey)) || {};
+      (await SELECT.one
+        .from(entity.name)
+        .where({ [ID]: entityKey })
+        .columns(foreignKey)) || {};
     const hasForeignKey = parentResult[foreignKey];
     if (!hasForeignKey) return;
     compContext.path = `${parentEntity.name}/${compContext.path}`;
@@ -492,9 +492,9 @@ async function track_changes (req) {
   const config = cds.env.requires["change-tracking"];
 
   if (
-      (req.event === 'UPDATE' && config?.disableUpdateTracking) ||
-      (req.event === 'CREATE' && config?.disableCreateTracking) ||
-      (req.event === 'DELETE' && config?.disableDeleteTracking)
+    (req.event === 'UPDATE' && config?.disableUpdateTracking) ||
+    (req.event === 'CREATE' && config?.disableCreateTracking) ||
+    (req.event === 'DELETE' && config?.disableDeleteTracking)
   ) {
     return;
   }
@@ -502,18 +502,12 @@ async function track_changes (req) {
   let diff = await req.diff()
   if (!diff) return
 
-  const changes = [];
-  if( Array.isArray(diff) ) {
-    for (const item of diff) {
-      const change = await trackChangesForDiff(item, req, this)
-      if( change ) changes.push(change);
-    }
-  } else {
-    const change = await trackChangesForDiff(diff, req, this)
-    if( change ) changes.push(change);
-  }
+  const diffs = Array.isArray(diff) ? diff : [diff];
+  const changes = (
+    await Promise.all(diffs.map(item => trackChangesForDiff(item, req, this)))
+  ).filter(Boolean);
 
-  if( changes.length > 0 ) {
+  if (changes.length > 0) {
     await INSERT.into("sap.changelog.ChangeLog").entries(changes);
   }
 
@@ -528,20 +522,20 @@ async function trackChangesForDiff(diff, req, that){
     compContext = await generatePathAndParams(req, entityKey);
   }
   let isComposition = _isCompositionContextPath(
-      compContext?.path || req.path,
-      compContext?.hasComp
+    compContext?.path || req.path,
+    compContext?.hasComp
   );
   if (
-      req.event === "DELETE" &&
-      target[isRoot] &&
-      !cds.env.requires["change-tracking"]?.preserveDeletes
+    req.event === "DELETE" &&
+    target[isRoot] &&
+    !cds.env.requires["change-tracking"]?.preserveDeletes
   ) {
     await DELETE.from(`sap.changelog.ChangeLog`).where({ entityKey });
     return;
   }
 
   let changes = _trackedChanges4(that, target, diff)
-  if (!changes) return;
+  if (!changes) return
 
   await _formatChangeLog(changes, req)
   if (isComposition) {

--- a/lib/change-log.js
+++ b/lib/change-log.js
@@ -166,20 +166,20 @@ const _formatAssociationContext = async function (changes, reqData) {
 }
 
 const _getChildChangeObjId = async function (
-  change,
-  childNodeChange,
-  curNodePathVal,
-  reqData
+    change,
+    childNodeChange,
+    curNodePathVal,
+    reqData
 ) {
   const composition = cds.model.definitions[change.serviceEntity].elements[change.attribute]
   const objIdElements = composition ? composition["@changelog"] : null
   const objIdElementNames = getObjIdElementNamesInArray(objIdElements)
 
   return _getObjectIdByPath(
-    reqData,
-    curNodePathVal,
-    childNodeChange._path,
-    objIdElementNames
+      reqData,
+      curNodePathVal,
+      childNodeChange._path,
+      objIdElementNames
   )
 }
 
@@ -197,10 +197,10 @@ const _formatCompositionContext = async function (changes, reqData) {
         const curNodePathVal = path.pop()
         curChange.modification = childNodeChange._op
         const objId = await _getChildChangeObjId(
-          change,
-          childNodeChange,
-          curNodePathVal,
-          reqData
+            change,
+            childNodeChange,
+            curNodePathVal,
+            reqData
         )
         _formatCompositionValue(curChange, objId, childNodeChange, childNodeChanges)
       }
@@ -211,10 +211,10 @@ const _formatCompositionContext = async function (changes, reqData) {
 }
 
 const _formatCompositionValue = function (
-  curChange,
-  objId,
-  childNodeChange,
-  childNodeChanges
+    curChange,
+    objId,
+    childNodeChange,
+    childNodeChanges
 ) {
   if (curChange.modification === undefined) {
     return
@@ -254,10 +254,10 @@ const _formatCompositionEntityType = function (change) {
 }
 
 const _getObjectIdByPath = async function (
-  reqData,
-  nodePathVal,
-  serviceEntityPath,
-  /**optional*/ objIdElementNames
+    reqData,
+    nodePathVal,
+    serviceEntityPath,
+    /**optional*/ objIdElementNames
 ) {
   const curObjFromReqData = getCurObjFromReqData(reqData, nodePathVal, serviceEntityPath)
   const entityName = getNameFromPathVal(nodePathVal)
@@ -277,9 +277,9 @@ const _formatObjectID = async function (changes, reqData) {
     let curNodeObjId = objectIdCache.get(curNodePathVal)
     if (!curNodeObjId) {
       curNodeObjId = await _getObjectIdByPath(
-        reqData,
-        curNodePathVal,
-        change.serviceEntityPath
+          reqData,
+          curNodePathVal,
+          change.serviceEntityPath
       )
       objectIdCache.set(curNodePathVal, curNodeObjId)
     }
@@ -287,9 +287,9 @@ const _formatObjectID = async function (changes, reqData) {
     let parentNodeObjId = objectIdCache.get(parentNodePathVal)
     if (!parentNodeObjId && parentNodePathVal) {
       parentNodeObjId = await _getObjectIdByPath(
-        reqData,
-        parentNodePathVal,
-        change.serviceEntityPath
+          reqData,
+          parentNodePathVal,
+          change.serviceEntityPath
       )
       objectIdCache.set(parentNodePathVal, parentNodeObjId)
     }
@@ -338,21 +338,21 @@ function _trackedChanges4 (srv, target, diff) {
       if (from === to) return
 
       /**
-       * 
+       *
        * HANA driver always filling up the defined decimal places with zeros,
        * need to skip the change log if the value is not changed.
        * Example:
        * entity Books : cuid {
        *   price     : Decimal(11, 4);
        * }
-       * When price is updated from 3000.0000 to 3000, 
+       * When price is updated from 3000.0000 to 3000,
        * the change log should not be created.
        */
       if (
-        row._op === "update" &&
-        element.type === "cds.Decimal" &&
-        cds.db.kind === "hana" &&
-        typeof to === "number"
+          row._op === "update" &&
+          element.type === "cds.Decimal" &&
+          cds.db.kind === "hana" &&
+          typeof to === "number"
       ) {
         const scaleNum = element.scale || 0;
         if (from === formatDecimal(to, scaleNum))
@@ -360,9 +360,9 @@ function _trackedChanges4 (srv, target, diff) {
       }
 
       /**
-       * 
-       * For the Inline entity such as Items, 
-       * further filtering is required on the keys 
+       *
+       * For the Inline entity such as Items,
+       * further filtering is required on the keys
        * within the 'association' and 'foreign key' to ultimately retain the keys of the entity itself.
        * entity Order : cuid {
        *   title      : String;
@@ -373,11 +373,11 @@ function _trackedChanges4 (srv, target, diff) {
        * }
        */
       const keys = Object.keys(eleParentKeys)
-        .filter(k => k !== "IsActiveEntity")
-        .filter(k => eleParentKeys[k]?.type !== "cds.Association") // Skip association
-        .filter(k => !eleParentKeys[k]?.["@odata.foreignKey4"]) // Skip foreign key
-        .map(k => `${k}=${row[k]}`)
-        .join(', ')
+          .filter(k => k !== "IsActiveEntity")
+          .filter(k => eleParentKeys[k]?.type !== "cds.Association") // Skip association
+          .filter(k => !eleParentKeys[k]?.["@odata.foreignKey4"]) // Skip foreign key
+          .map(k => `${k}=${row[k]}`)
+          .join(', ')
 
       changes.push({
         serviceEntityPath: row._path,
@@ -408,8 +408,8 @@ const _prepareChangeLogForComposition = async function (entity, entityKey, chang
   const parentKey = getUUIDFromPathVal(parentEntityPathVal)
   const serviceEntityPath = rootEntityPathVals.join('/')
   const parentServiceEntityPath = _getAllPathVals(req.context)
-    .slice(0, rootEntityPathVals.length - 2)
-    .join('/')
+      .slice(0, rootEntityPathVals.length - 2)
+      .join('/')
 
   for (const change of changes) {
     change.parentEntityID = await _getObjectIdByPath(req.data, parentEntityPathVal, parentServiceEntityPath)
@@ -431,11 +431,11 @@ async function generatePathAndParams (req, entityKey) {
 
   let compContext = {
     path: hasParentAndForeignKey
-      ? `${parentEntity.name}/${target.name}`
-      : `${target.name}`,
+        ? `${parentEntity.name}/${target.name}`
+        : `${target.name}`,
     params: hasParentAndForeignKey
-      ? [{ [ID]: data[foreignKey] }, { [ID]: entityKey }]
-      : [{ [ID]: entityKey }],
+        ? [{ [ID]: data[foreignKey] }, { [ID]: entityKey }]
+        : [{ [ID]: entityKey }],
     hasComp: true
   };
 
@@ -446,9 +446,9 @@ async function generatePathAndParams (req, entityKey) {
   let parentAssoc = await processEntity(targetEntity, targetKey, compContext);
   while (parentAssoc && !parentAssoc.entity[isRoot]) {
     parentAssoc = await processEntity(
-      parentAssoc.entity,
-      parentAssoc.ID,
-      compContext
+        parentAssoc.entity,
+        parentAssoc.ID,
+        compContext
     );
   }
   return compContext;
@@ -459,10 +459,10 @@ async function processEntity (entity, entityKey, compContext) {
 
   if (foreignKey && parentEntity) {
     const parentResult =
-      (await SELECT.one
-        .from(entity.name)
-        .where({ [ID]: entityKey })
-        .columns(foreignKey)) || {};
+        (await SELECT.one
+            .from(entity.name)
+            .where({ [ID]: entityKey })
+            .columns(foreignKey)) || {};
     const hasForeignKey = parentResult[foreignKey];
     if (!hasForeignKey) return;
     compContext.path = `${parentEntity.name}/${compContext.path}`;
@@ -492,9 +492,9 @@ async function track_changes (req) {
   const config = cds.env.requires["change-tracking"];
 
   if (
-    (req.event === 'UPDATE' && config?.disableUpdateTracking) ||
-    (req.event === 'CREATE' && config?.disableCreateTracking) ||
-    (req.event === 'DELETE' && config?.disableDeleteTracking)
+      (req.event === 'UPDATE' && config?.disableUpdateTracking) ||
+      (req.event === 'CREATE' && config?.disableCreateTracking) ||
+      (req.event === 'DELETE' && config?.disableDeleteTracking)
   ) {
     return;
   }
@@ -502,6 +502,24 @@ async function track_changes (req) {
   let diff = await req.diff()
   if (!diff) return
 
+  const changes = [];
+  if( Array.isArray(diff) ) {
+    for (const item of diff) {
+      const change = await trackChangesForDiff(item, req, this)
+      if( change ) changes.push(change);
+    }
+  } else {
+    const change = await trackChangesForDiff(diff, req, this)
+    if( change ) changes.push(change);
+  }
+
+  if( changes.length > 0 ) {
+    await INSERT.into("sap.changelog.ChangeLog").entries(changes);
+  }
+
+}
+
+async function trackChangesForDiff(diff, req, that){
   let target = req.target
   let compContext = null;
   let entityKey = diff.ID
@@ -510,19 +528,20 @@ async function track_changes (req) {
     compContext = await generatePathAndParams(req, entityKey);
   }
   let isComposition = _isCompositionContextPath(
-    compContext?.path || req.path,
-    compContext?.hasComp
+      compContext?.path || req.path,
+      compContext?.hasComp
   );
   if (
-    req.event === "DELETE" &&
-    target[isRoot] &&
-    !cds.env.requires["change-tracking"]?.preserveDeletes
+      req.event === "DELETE" &&
+      target[isRoot] &&
+      !cds.env.requires["change-tracking"]?.preserveDeletes
   ) {
-    return await DELETE.from(`sap.changelog.ChangeLog`).where({ entityKey });
+    await DELETE.from(`sap.changelog.ChangeLog`).where({ entityKey });
+    return;
   }
 
-  let changes = _trackedChanges4(this, target, diff)
-  if (!changes) return
+  let changes = _trackedChanges4(that, target, diff)
+  if (!changes) return;
 
   await _formatChangeLog(changes, req)
   if (isComposition) {
@@ -538,7 +557,7 @@ async function track_changes (req) {
     [ target, entityKey ] = await _prepareChangeLogForComposition(target, entityKey, changes, reqInfo)
   }
   const dbEntity = getDBEntity(target)
-  await INSERT.into("sap.changelog.ChangeLog").entries({
+  return {
     entity: dbEntity.name,
     entityKey: entityKey,
     serviceEntity: target.name || target,
@@ -547,7 +566,7 @@ async function track_changes (req) {
       valueChangedFrom: `${c.valueChangedFrom ?? ''}`,
       valueChangedTo: `${c.valueChangedTo ?? ''}`,
     })),
-  })
+  };
 }
 
 module.exports = { track_changes, _afterReadChangeView }

--- a/tests/integration/service-api.test.js
+++ b/tests/integration/service-api.test.js
@@ -61,29 +61,29 @@ describe("change log integration test", () => {
         expect(changes).to.have.length(2);
         expect(
             changes.map((change) => ({
-                entityKey: change.entityKey,
-                entity: change.entity,
-                valueChangedFrom: change.valueChangedFrom,
-                valueChangedTo: change.valueChangedTo,
-                modification: change.modification,
-                attribute: change.attribute
+              entityKey: change.entityKey,
+              entity: change.entity,
+              valueChangedFrom: change.valueChangedFrom,
+              valueChangedTo: change.valueChangedTo,
+              modification: change.modification,
+              attribute: change.attribute
             }))
-        ).to.have.deep.members([
+          ).to.have.deep.members([
             {
-                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-                modification: "Create",
-                entity: "sap.capire.bookshop.Order",
-                attribute: "netAmount",
-                valueChangedFrom: "",
-                valueChangedTo: "0"
+              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+              modification: "Create",
+              entity: "sap.capire.bookshop.Order",
+              attribute: "netAmount",
+              valueChangedFrom: "",
+              valueChangedTo: "0"
             },
             {
-                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-                modification: "Create",
-                entity: "sap.capire.bookshop.Order",
-                attribute: "isUsed",
-                valueChangedFrom: "",
-                valueChangedTo: "false"
+              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+              modification: "Create",
+              entity: "sap.capire.bookshop.Order",
+              attribute: "isUsed",
+              valueChangedFrom: "",
+              valueChangedTo: "false"
             },
         ]);
 
@@ -97,29 +97,29 @@ describe("change log integration test", () => {
         expect(changes).to.have.length(2);
         expect(
             changes.map((change) => ({
-                entityKey: change.entityKey,
-                entity: change.entity,
-                valueChangedFrom: change.valueChangedFrom,
-                valueChangedTo: change.valueChangedTo,
-                modification: change.modification,
-                attribute: change.attribute
+              entityKey: change.entityKey,
+              entity: change.entity,
+              valueChangedFrom: change.valueChangedFrom,
+              valueChangedTo: change.valueChangedTo,
+              modification: change.modification,
+              attribute: change.attribute
             }))
-        ).to.have.deep.members([
+          ).to.have.deep.members([
             {
-                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-                modification: "Delete",
-                entity: "sap.capire.bookshop.Order",
-                attribute: "netAmount",
-                valueChangedFrom: "0",
-                valueChangedTo: ""
+              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+              modification: "Delete",
+              entity: "sap.capire.bookshop.Order",
+              attribute: "netAmount",
+              valueChangedFrom: "0",
+              valueChangedTo: ""
             },
             {
-                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-                modification: "Delete",
-                entity: "sap.capire.bookshop.Order",
-                attribute: "isUsed",
-                valueChangedFrom: "false",
-                valueChangedTo: ""
+              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+              modification: "Delete",
+              entity: "sap.capire.bookshop.Order",
+              attribute: "isUsed",
+              valueChangedFrom: "false",
+              valueChangedTo: ""
             },
         ]);
 
@@ -254,12 +254,12 @@ describe("change log integration test", () => {
         expect(createBookStoresChange.objectID).to.equal("new name");
 
         await UPDATE(adminService.entities.BookStores)
-            .where({
-                ID: "9d703c23-54a8-4eff-81c1-cdce6b6587c4"
-            })
-            .with({
-                name: "BookStores name changed"
-            });
+        .where({
+            ID: "9d703c23-54a8-4eff-81c1-cdce6b6587c4"
+        })
+        .with({
+            name: "BookStores name changed"
+        });
         const updateBookStoresChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.BookStores",
@@ -365,24 +365,24 @@ describe("change log integration test", () => {
 
         // Test the object id when the parent node and child node are modified at the same time
         await UPDATE(adminService.entities.RootEntity)
-            .with({
-                ID: "01234567-89ab-cdef-0123-987654fedcba",
-                name: "RootEntity name changed",
-                lifecycleStatus_code: "AC",
-                child: [
-                    {
-                        ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                        parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
-                        child: [
-                            {
-                                ID: "12ed5dd8-d45b-11ed-afa1-0242ac124446",
-                                parent_ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                                title : "Level2Entity title changed"
-                            },
-                        ],
-                    },
-                ],
-            });
+        .with({
+            ID: "01234567-89ab-cdef-0123-987654fedcba",
+            name: "RootEntity name changed",
+            lifecycleStatus_code: "AC",
+            child: [
+                {
+                    ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                    parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
+                    child: [
+                        {
+                            ID: "12ed5dd8-d45b-11ed-afa1-0242ac124446",
+                            parent_ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                            title : "Level2Entity title changed"
+                        },
+                    ],
+                },
+            ],
+        });
         const updateEntityChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.Level2Entity",
@@ -396,18 +396,18 @@ describe("change log integration test", () => {
 
         // Tests the object id when the parent node update and child node deletion occur simultaneously
         await UPDATE(adminService.entities.RootEntity)
-            .with({
-                ID: "01234567-89ab-cdef-0123-987654fedcba",
-                name: "RootEntity name del",
-                lifecycleStatus_code: "CL",
-                child: [
-                    {
-                        ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                        parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
-                        child: [],
-                    },
-                ],
-            });
+        .with({
+            ID: "01234567-89ab-cdef-0123-987654fedcba",
+            name: "RootEntity name del",
+            lifecycleStatus_code: "CL",
+            child: [
+                {
+                    ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                    parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
+                    child: [],
+                },
+            ],
+        });
         const deleteEntityChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.Level2Entity",
@@ -621,7 +621,7 @@ describe("change log integration test", () => {
         expect(changes.length).to.equal(0);
     });
 
-    it("When creating multiple records, changelog for each entity should also be generated", async () => {
+    it("When creating multiple root records, change tracking for each entity should also be generated", async () => {
         cds.env.requires["change-tracking"].preserveDeletes = true;
         cds.services.AdminService.entities.Order.elements.netAmount["@changelog"] = true;
         cds.services.AdminService.entities.Order.elements.isUsed["@changelog"] = true;
@@ -630,24 +630,54 @@ describe("change log integration test", () => {
             {
                 ID: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
                 isUsed: false,
-                netAmount: 0
+                netAmount: 0,
+                orderItems: [
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a0d1a",
+                        quantity: 10,
+                    },
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a1c2b",
+                        quantity: 12,
+                    }
+                ],
             },
             {
                 ID: "ec365b25-b346-4444-8f03-8f5b7d94f040",
                 isUsed: true,
-                netAmount: 10
+                netAmount: 10,
+                orderItems: [
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a2c2a",
+                        quantity: 10,
+                    },
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a2b3b",
+                        quantity: 12,
+                    }
+                ],
             },
             {
                 ID: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
                 isUsed: false,
-                netAmount: 20
+                netAmount: 20,
+                orderItems: [
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a2c1a",
+                        quantity: 10,
+                    },
+                    {
+                        ID: "f35b2d4c-9b21-4b9a-9b3c-ca1ad32a4c1b",
+                        quantity: 12,
+                    }
+                ],
             }
         ];
 
         await INSERT.into(adminService.entities.Order).entries(ordersData);
         let changes = await adminService.run(SELECT.from(ChangeView));
 
-        expect(changes).to.have.length(6);
+        expect(changes).to.have.length(12);
         expect(
             changes.map((change) => ({
                 entityKey: change.entityKey,
@@ -675,6 +705,22 @@ describe("change log integration test", () => {
                 valueChangedTo: "false"
             },
             {
+                entityKey: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "10"
+            },
+            {
+                entityKey: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "12"
+            },
+            {
                 entityKey: "ec365b25-b346-4444-8f03-8f5b7d94f040",
                 modification: "Create",
                 entity: "sap.capire.bookshop.Order",
@@ -691,6 +737,22 @@ describe("change log integration test", () => {
                 valueChangedTo: "true"
             },
             {
+                entityKey: "ec365b25-b346-4444-8f03-8f5b7d94f040",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "10"
+            },
+            {
+                entityKey: "ec365b25-b346-4444-8f03-8f5b7d94f040",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "12"
+            },
+            {
                 entityKey: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
                 modification: "Create",
                 entity: "sap.capire.bookshop.Order",
@@ -705,11 +767,27 @@ describe("change log integration test", () => {
                 attribute: "isUsed",
                 valueChangedFrom: "",
                 valueChangedTo: "false"
+            },
+            {
+                entityKey: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "10"
+            },
+            {
+                entityKey: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
+                modification: "Create",
+                entity: "sap.capire.bookshop.OrderItem",
+                attribute: "quantity",
+                valueChangedFrom: "",
+                valueChangedTo: "12"
             }
         ]);
 
+        cds.env.requires["change-tracking"].preserveDeletes = false;
         delete cds.services.AdminService.entities.Order.elements.netAmount["@changelog"];
         delete cds.services.AdminService.entities.Order.elements.isUsed["@changelog"];
     });
-
 });

--- a/tests/integration/service-api.test.js
+++ b/tests/integration/service-api.test.js
@@ -61,29 +61,29 @@ describe("change log integration test", () => {
         expect(changes).to.have.length(2);
         expect(
             changes.map((change) => ({
-              entityKey: change.entityKey,
-              entity: change.entity,
-              valueChangedFrom: change.valueChangedFrom,
-              valueChangedTo: change.valueChangedTo,
-              modification: change.modification,
-              attribute: change.attribute
+                entityKey: change.entityKey,
+                entity: change.entity,
+                valueChangedFrom: change.valueChangedFrom,
+                valueChangedTo: change.valueChangedTo,
+                modification: change.modification,
+                attribute: change.attribute
             }))
-          ).to.have.deep.members([
+        ).to.have.deep.members([
             {
-              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-              modification: "Create",
-              entity: "sap.capire.bookshop.Order",
-              attribute: "netAmount",
-              valueChangedFrom: "",
-              valueChangedTo: "0"
+                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "netAmount",
+                valueChangedFrom: "",
+                valueChangedTo: "0"
             },
             {
-              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-              modification: "Create",
-              entity: "sap.capire.bookshop.Order",
-              attribute: "isUsed",
-              valueChangedFrom: "",
-              valueChangedTo: "false"
+                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "isUsed",
+                valueChangedFrom: "",
+                valueChangedTo: "false"
             },
         ]);
 
@@ -97,29 +97,29 @@ describe("change log integration test", () => {
         expect(changes).to.have.length(2);
         expect(
             changes.map((change) => ({
-              entityKey: change.entityKey,
-              entity: change.entity,
-              valueChangedFrom: change.valueChangedFrom,
-              valueChangedTo: change.valueChangedTo,
-              modification: change.modification,
-              attribute: change.attribute
+                entityKey: change.entityKey,
+                entity: change.entity,
+                valueChangedFrom: change.valueChangedFrom,
+                valueChangedTo: change.valueChangedTo,
+                modification: change.modification,
+                attribute: change.attribute
             }))
-          ).to.have.deep.members([
+        ).to.have.deep.members([
             {
-              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-              modification: "Delete",
-              entity: "sap.capire.bookshop.Order",
-              attribute: "netAmount",
-              valueChangedFrom: "0",
-              valueChangedTo: ""
+                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+                modification: "Delete",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "netAmount",
+                valueChangedFrom: "0",
+                valueChangedTo: ""
             },
             {
-              entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
-              modification: "Delete",
-              entity: "sap.capire.bookshop.Order",
-              attribute: "isUsed",
-              valueChangedFrom: "false",
-              valueChangedTo: ""
+                entityKey: "0faaff2d-7e0e-4494-97fe-c815ee973fa1",
+                modification: "Delete",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "isUsed",
+                valueChangedFrom: "false",
+                valueChangedTo: ""
             },
         ]);
 
@@ -254,12 +254,12 @@ describe("change log integration test", () => {
         expect(createBookStoresChange.objectID).to.equal("new name");
 
         await UPDATE(adminService.entities.BookStores)
-        .where({
-            ID: "9d703c23-54a8-4eff-81c1-cdce6b6587c4"
-        })
-        .with({
-            name: "BookStores name changed"
-        });
+            .where({
+                ID: "9d703c23-54a8-4eff-81c1-cdce6b6587c4"
+            })
+            .with({
+                name: "BookStores name changed"
+            });
         const updateBookStoresChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.BookStores",
@@ -365,24 +365,24 @@ describe("change log integration test", () => {
 
         // Test the object id when the parent node and child node are modified at the same time
         await UPDATE(adminService.entities.RootEntity)
-        .with({
-            ID: "01234567-89ab-cdef-0123-987654fedcba",
-            name: "RootEntity name changed",
-            lifecycleStatus_code: "AC",
-            child: [
-                {
-                    ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                    parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
-                    child: [
-                        {
-                            ID: "12ed5dd8-d45b-11ed-afa1-0242ac124446",
-                            parent_ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                            title : "Level2Entity title changed"
-                        },
-                    ],
-                },
-            ],
-        });
+            .with({
+                ID: "01234567-89ab-cdef-0123-987654fedcba",
+                name: "RootEntity name changed",
+                lifecycleStatus_code: "AC",
+                child: [
+                    {
+                        ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                        parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
+                        child: [
+                            {
+                                ID: "12ed5dd8-d45b-11ed-afa1-0242ac124446",
+                                parent_ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                                title : "Level2Entity title changed"
+                            },
+                        ],
+                    },
+                ],
+            });
         const updateEntityChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.Level2Entity",
@@ -396,18 +396,18 @@ describe("change log integration test", () => {
 
         // Tests the object id when the parent node update and child node deletion occur simultaneously
         await UPDATE(adminService.entities.RootEntity)
-        .with({
-            ID: "01234567-89ab-cdef-0123-987654fedcba",
-            name: "RootEntity name del",
-            lifecycleStatus_code: "CL",
-            child: [
-                {
-                    ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
-                    parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
-                    child: [],
-                },
-            ],
-        });
+            .with({
+                ID: "01234567-89ab-cdef-0123-987654fedcba",
+                name: "RootEntity name del",
+                lifecycleStatus_code: "CL",
+                child: [
+                    {
+                        ID: "12ed5dd8-d45b-11ed-afa1-0242ac120003",
+                        parent_ID: "01234567-89ab-cdef-0123-987654fedcba",
+                        child: [],
+                    },
+                ],
+            });
         const deleteEntityChanges = await adminService.run(
             SELECT.from(ChangeView).where({
                 entity: "sap.capire.bookshop.Level2Entity",
@@ -620,4 +620,96 @@ describe("change log integration test", () => {
 
         expect(changes.length).to.equal(0);
     });
+
+    it("When creating multiple records, changelog for each entity should also be generated", async () => {
+        cds.env.requires["change-tracking"].preserveDeletes = true;
+        cds.services.AdminService.entities.Order.elements.netAmount["@changelog"] = true;
+        cds.services.AdminService.entities.Order.elements.isUsed["@changelog"] = true;
+
+        const ordersData = [
+            {
+                ID: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
+                isUsed: false,
+                netAmount: 0
+            },
+            {
+                ID: "ec365b25-b346-4444-8f03-8f5b7d94f040",
+                isUsed: true,
+                netAmount: 10
+            },
+            {
+                ID: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
+                isUsed: false,
+                netAmount: 20
+            }
+        ];
+
+        await INSERT.into(adminService.entities.Order).entries(ordersData);
+        let changes = await adminService.run(SELECT.from(ChangeView));
+
+        expect(changes).to.have.length(6);
+        expect(
+            changes.map((change) => ({
+                entityKey: change.entityKey,
+                entity: change.entity,
+                valueChangedFrom: change.valueChangedFrom,
+                valueChangedTo: change.valueChangedTo,
+                modification: change.modification,
+                attribute: change.attribute
+            }))
+        ).to.have.deep.members([
+            {
+                entityKey: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "netAmount",
+                valueChangedFrom: "",
+                valueChangedTo: "0"
+            },
+            {
+                entityKey: "fa4d0140-efdd-4c32-aafd-efb7f1d0c8e1",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "isUsed",
+                valueChangedFrom: "",
+                valueChangedTo: "false"
+            },
+            {
+                entityKey: "ec365b25-b346-4444-8f03-8f5b7d94f040",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "netAmount",
+                valueChangedFrom: "",
+                valueChangedTo: "10"
+            },
+            {
+                entityKey: "ec365b25-b346-4444-8f03-8f5b7d94f040",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "isUsed",
+                valueChangedFrom: "",
+                valueChangedTo: "true"
+            },
+            {
+                entityKey: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "netAmount",
+                valueChangedFrom: "",
+                valueChangedTo: "20"
+            },
+            {
+                entityKey: "ab9e5510-a60b-4dfc-b026-161c5c2d4056",
+                modification: "Create",
+                entity: "sap.capire.bookshop.Order",
+                attribute: "isUsed",
+                valueChangedFrom: "",
+                valueChangedTo: "false"
+            }
+        ]);
+
+        delete cds.services.AdminService.entities.Order.elements.netAmount["@changelog"];
+        delete cds.services.AdminService.entities.Order.elements.isUsed["@changelog"];
+    });
+
 });


### PR DESCRIPTION
Addresses- https://github.com/cap-js/change-tracking/issues/145

- [x] Capture change log for each row
- [x] Add test

Currently on bulk insert diff comes as an array instead of object, so extracting properties like ID (for entity key), or old_value (for change detection) returns undefined, since they need to be extracted from element of array. Updated the logic to iterate over diff if array, to treat each diff (row) individually, accumulating the changes and doing a bulk insert in ChangeLog entity.