### PR TITLE
fix: do not look up the ChangeLog through the service

### DIFF
--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -12,8 +12,7 @@
       }
     },
     "features": {
-      "serve_on_root": true,
-      "restrict_service_scope": false
+      "serve_on_root": true
     }
   }
 }

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -12,7 +12,8 @@
       }
     },
     "features": {
-      "serve_on_root": true
+      "serve_on_root": true,
+      "restrict_service_scope": false
     }
   }
 }

--- a/tests/integration/fiori-draft-disabled.test.js
+++ b/tests/integration/fiori-draft-disabled.test.js
@@ -258,7 +258,7 @@ describe("change log draft disabled test", () => {
         expect(orderChange.parentObjectID).to.equal("sap.capire.bookshop.OrderItem");
 
         // Check the changeLog to make sure the entity information is root
-        let changeLogs = await adminService.run(SELECT.from(ChangeLog));
+        let changeLogs = await SELECT.from(ChangeLog);
 
         expect(changeLogs.length).to.equal(1);
         expect(changeLogs[0].entity).to.equal("sap.capire.bookshop.Order");
@@ -289,7 +289,7 @@ describe("change log draft disabled test", () => {
         expect(orderChange.parentObjectID).to.equal("sap.capire.bookshop.OrderItem");
 
         // Check the changeLog to make sure the entity information is root
-        let changeLogs = await adminService.run(SELECT.from(ChangeLog));
+        let changeLogs = await SELECT.from(ChangeLog);
 
         expect(changeLogs.length).to.equal(1);
         expect(changeLogs[0].entity).to.equal("sap.capire.bookshop.Order");


### PR DESCRIPTION
Related link:
[rel/8.9.0 - Changed](https://github.tools.sap/cap/cds/releases/tag/rel%2F8.9.0)