### PR TITLE
chore: adapt license entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "main": "cds-plugin.js",
   "files": [
     "lib",


### PR DESCRIPTION
Replaces the placeholder value "SEE LICENSE IN LICENSE" with "Apache-2.0" as the project is licensed under Apache 2.0, and the LICENSE file contains the full license text.