### PR TITLE
chore: Prepare for cds9

### DIFF
--- a/tests/integration/fiori-draft-disabled.test.js
+++ b/tests/integration/fiori-draft-disabled.test.js
@@ -2,6 +2,9 @@ const cds = require("@sap/cds");
 const bookshop = require("path").resolve(__dirname, "./../bookshop");
 const { expect, data, POST, PATCH, DELETE } = cds.test(bookshop);
 
+// Enable locale fallback to simulate end user requests
+cds.env.features.locale_fallback = true
+
 jest.setTimeout(5 * 60 * 1000);
 
 let adminService = null;
@@ -94,7 +97,7 @@ describe("change log draft disabled test", () => {
 
     it("1.4 When the global switch is on, all changelogs should be retained after the root entity is deleted, and a changelog for the deletion operation should be generated", async () => {
         cds.env.requires["change-tracking"].preserveDeletes = true;
-        
+
         cds.services.AdminService.entities.RootObject["@changelog"] = [
             { "=": "title" }
         ];
@@ -133,8 +136,8 @@ describe("change log draft disabled test", () => {
         const afterChanges = await adminService.run(SELECT.from(ChangeView));
         expect(afterChanges.length).to.equal(8);
 
-        const changelogCreated = afterChanges.filter(ele=> ele.modification === "Create"); 
-        const changelogDeleted = afterChanges.filter(ele=> ele.modification === "Delete"); 
+        const changelogCreated = afterChanges.filter(ele=> ele.modification === "Create");
+        const changelogDeleted = afterChanges.filter(ele=> ele.modification === "Delete");
 
         const compareAttributes = ['keys', 'attribute', 'entity', 'serviceEntity', 'parentKey', 'serviceEntityPath', 'valueDataType', 'objectID', 'parentObjectID', 'entityKey'];
 
@@ -157,7 +160,7 @@ describe("change log draft disabled test", () => {
         cds.env.requires["change-tracking"].preserveDeletes = true;
         cds.services.AdminService.entities.Order.elements.netAmount["@changelog"] = true;
         cds.services.AdminService.entities.Order.elements.isUsed["@changelog"] = true;
-        
+
         await POST(`/odata/v4/admin/Order`, {
             ID: "3e745e35-5974-4383-b60a-2f5c9bdd31ac",
             isUsed: false,
@@ -231,7 +234,7 @@ describe("change log draft disabled test", () => {
               valueChangedTo: ""
             },
         ]);
-        
+
         delete cds.services.AdminService.entities.Order.elements.netAmount["@changelog"];
         delete cds.services.AdminService.entities.Order.elements.isUsed["@changelog"];
     });
@@ -341,7 +344,7 @@ describe("change log draft disabled test", () => {
         });
 
         const changes = await adminService.run(SELECT.from(ChangeView));
-        
+
         expect(changes.length).to.equal(1);
         const change = changes[0];
         expect(change.attribute).to.equal("quantity");

--- a/tests/integration/fiori-draft-enabled.test.js
+++ b/tests/integration/fiori-draft-enabled.test.js
@@ -3,6 +3,9 @@ const bookshop = require("path").resolve(__dirname, "./../bookshop");
 const { expect, data, POST, PATCH, DELETE } = cds.test(bookshop);
 const { RequestSend } = require("../utils/api");
 
+// Enable locale fallback to simulate end user requests
+cds.env.features.locale_fallback = true
+
 jest.setTimeout(5 * 60 * 1000);
 
 let adminService = null;
@@ -27,7 +30,7 @@ describe("change log integration test", () => {
         await data.reset();
     });
 
-    
+
     it("1.5 When the global switch is on, all changelogs should be retained after the root entity is deleted, and a changelog for the deletion operation should be generated", async () => {
         cds.env.requires["change-tracking"].preserveDeletes = true;
 
@@ -63,14 +66,14 @@ describe("change log integration test", () => {
             true,
         );
         const beforeChanges = await adminService.run(SELECT.from(ChangeView));
-        expect(beforeChanges.length > 0).to.be.true; 
-    
+        expect(beforeChanges.length > 0).to.be.true;
+
         await DELETE(`/odata/v4/admin/RootEntity(ID=01234567-89ab-cdef-0123-987654fedcba,IsActiveEntity=true)`);
 
         const afterChanges = await adminService.run(SELECT.from(ChangeView));
 
-        const changelogCreated = afterChanges.filter(ele=> ele.modification === "Create"); 
-        const changelogDeleted = afterChanges.filter(ele=> ele.modification === "Delete"); 
+        const changelogCreated = afterChanges.filter(ele=> ele.modification === "Create");
+        const changelogDeleted = afterChanges.filter(ele=> ele.modification === "Delete");
 
         const compareAttributes = ['keys', 'attribute', 'entity', 'serviceEntity', 'parentKey', 'serviceEntityPath', 'valueDataType', 'objectID', 'parentObjectID', 'entityKey'];
 
@@ -279,7 +282,7 @@ describe("change log integration test", () => {
 
     it("2.2 Child entity update - should log basic data type changes (ERP4SMEPREPWORKAPPPLAT-32 ERP4SMEPREPWORKAPPPLAT-613)", async () => {
         cds.services.AdminService.entities.Books.elements.price["@changelog"] = true;
-        
+
         const action = PATCH.bind({}, `/odata/v4/admin/Books(ID=9d703c23-54a8-4eff-81c1-cdce6b8376b1,IsActiveEntity=false)`, {
             title: "new title",
             author_ID: "47f97f40-4f41-488a-b10b-a5725e762d5e",
@@ -549,7 +552,7 @@ describe("change log integration test", () => {
         await utils.apiAction("admin", "BookStores", "64625905-c234-4d0d-9bc1-283ee8946770", "AdminService", action);
 
         const changes = await adminService.run(SELECT.from(ChangeView));
-        
+
         expect(changes.length).to.equal(1);
         const change = changes[0];
         expect(change.attribute).to.equal("title");
@@ -1038,7 +1041,7 @@ describe("change log integration test", () => {
 
     it("7.1 Annotate fields from chained associated entities as objectID (ERP4SMEPREPWORKAPPPLAT-993)", async () => {
         cds.services.AdminService.entities.BookStores["@changelog"].push({ "=": "city.name" })
-        
+
         const createBookStoresAction = POST.bind({}, `/odata/v4/admin/BookStores`, {
             ID: "9d703c23-54a8-4eff-81c1-cdce6b6587c4",
             name: "new name",

--- a/tests/integration/service-api.test.js
+++ b/tests/integration/service-api.test.js
@@ -2,6 +2,9 @@ const cds = require("@sap/cds");
 const bookshop = require("path").resolve(__dirname, "./../bookshop");
 const { expect, data } = cds.test(bookshop);
 
+// Enable locale fallback to simulate end user requests
+cds.env.features.locale_fallback = true
+
 jest.setTimeout(5 * 60 * 1000);
 
 let adminService = null;

--- a/tests/unit/util.test.js
+++ b/tests/unit/util.test.js
@@ -3,6 +3,9 @@ const { expect } = cds.test
 const templateProcessor = require("../../lib/template-processor");
 const { getEntityByContextPath } = require("../../lib/entity-helper");
 
+// Enable locale fallback to simulate end user requests
+cds.env.features.locale_fallback = true
+
 const _processorFn = (changeMap) => {
     return ({ row, key, element }) => {
         if (!row || !key || !element) {


### PR DESCRIPTION
This is required for the tests in here to work with cds9. 
It is not required for actual use of the plugin at runtime, or in production.