### PR TITLE
chore: prepare for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish-npm:
@@ -14,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
         registry-url: https://registry.npmjs.org/
     - name: run tests
       run: |


### PR DESCRIPTION
Allows token-less publishing.
See https://docs.npmjs.com/trusted-publishers