### PR TITLE
Consider `@changelog: false` on an entity level

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -7,6 +7,7 @@ const hasParent = 'change-tracking-parentEntity';
 
 const isChangeTracked = (entity) => {
 	if (entity.query?.SET?.op === 'union') return false; // REVISIT: should that be an error or warning?
+	if (entity['@changelog'] === false) return false;
 	if (entity['@changelog']) return true;
 	if (Object.values(entity.elements).some((e) => e['@changelog'])) return true;
 	return false;

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -2,6 +2,7 @@ using {sap.change_tracking as my} from '../db/index';
 using {sap.changelog as change} from '@cap-js/change-tracking';
 
 service VariantTesting {
+  @cds.redirection.target
   entity DifferentFieldTypes as projection on my.DifferentFieldTypes;
 
   entity RootSample as projection on my.RootSample;
@@ -14,5 +15,8 @@ service VariantTesting {
   entity ComposedEntities as projection on my.ComposedEntities;
 
   entity ChangeView as projection on change.ChangeView;
+
+  @changelog: false
+  entity NotTrackedDifferentFieldTypes as projection on my.DifferentFieldTypes;
 
 }


### PR DESCRIPTION
Consider `@changelog: false` on an entity level to disable change tracking and the changes association for the entity.

The scenario is that in a readonly app the changes association might be undesired and as such the changes association should not be exposed. `@changelog: false` is more intuitive compared to `@changelog.disable_assoc` in this scenario.