### PR TITLE
refactor: Change HANA trigger to be statement based

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -181,6 +181,12 @@ jobs:
               exit 0
             fi
 
+            if [ "$STATUS" = "Failed" ]; then
+              echo "❌ Performance tests failed."
+              kubectl get testruns "$PERF_TEST_RUN_NAME" -o json | jq '.status'
+              exit 1
+            fi
+
             if [ "$i" -eq 15 ]; then
               echo "❌ performance tests did not reach 'Succeeded' after 15 attempts."
               kubectl get testruns "$PERF_TEST_RUN_NAME" -o json | jq '.status'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,2 +1,16 @@
 import cds from '@sap/cds/eslint.config.mjs';
-export default [...cds];
+export default [
+	...cds,
+	{
+		files: ['tests/**/*.test.js'],
+		rules: {
+			'no-restricted-syntax': [
+				'error',
+				{
+					selector: "MemberExpression[property.name='only']",
+					message: '.only is not allowed in tests.'
+				}
+			]
+		}
+	}
+];

--- a/index.cds
+++ b/index.cds
@@ -233,12 +233,6 @@ entity i18nKeys {
       text   : String(5000);
 }
 
-// Dummy table necessary for HANA triggers because DUMMY cannot be used in HDI
-@cds.persistence.skip
-entity CHANGE_TRACKING_DUMMY {
-  key X : String(5);
-}
-
 entity Changes : cuid {
   parent                : Association to one Changes;
   children              : Composition of many Changes

--- a/lib/TriggerCQN2SQL.js
+++ b/lib/TriggerCQN2SQL.js
@@ -1,14 +1,11 @@
 /**
- * Custom CQN2SQL implementation that handles trigger-specific columns (:old.*, :new.*)
+ * Custom CQN2SQL implementation that handles trigger-specific columns
  * without wrapping them in quotes.
  *
  * Overrides the `val` method to handle trigger row references:
- * - HANA: :old.column, :new.column
+ * - HANA (statement-level): nt.column, ot.column (transition table aliases)
  * - Postgres: OLD.column, NEW.column, rec.column
  * - SQLite: old.column, new.column
- *
- * Also provides a dummy table definition for SAP_CHANGELOG_CHANGE_TRACKING_DUMMY
- * to allow generating WHERE conditions without model validation.
  */
 
 function createTriggerCQN2SQL(BaseCQN2SQL) {
@@ -16,7 +13,7 @@ function createTriggerCQN2SQL(BaseCQN2SQL) {
 		val(x) {
 			// Check if this is a trigger row reference
 			if (x && x.val && typeof x.val === 'string') {
-				const triggerRefPattern = /^:?(?:old|new|OLD|NEW|rec)\.\w+$/;
+				const triggerRefPattern = /^:?(?:old|new|OLD|NEW|rec|nt|ot)\.\w+$/;
 				if (triggerRefPattern.test(x.val)) {
 					return x.val;
 				}
@@ -24,17 +21,6 @@ function createTriggerCQN2SQL(BaseCQN2SQL) {
 
 			// Fall back to the base implementation for all other cases
 			return super.val(x);
-		}
-
-		from(q) {
-			// Check if this is our dummy table
-			if (q && q.ref && q.ref[0] === 'SAP_CHANGELOG_CHANGE_TRACKING_DUMMY') {
-				// Return a minimal FROM clause without validation
-				return 'SAP_CHANGELOG_CHANGE_TRACKING_DUMMY';
-			}
-
-			// Fall back to the base implementation
-			return super.from(q);
 		}
 	};
 }

--- a/lib/TriggerCQN2SQL.js
+++ b/lib/TriggerCQN2SQL.js
@@ -6,15 +6,23 @@
  * - HANA (statement-level): nt.column, ot.column (transition table aliases)
  * - Postgres: OLD.column, NEW.column, rec.column
  * - SQLite: old.column, new.column
+ *
+ * Also supports `{ val: '...', literal: 'sql' }` for embedding raw SQL expressions
+ * (e.g., subquery expressions) without quoting.
  */
 
 function createTriggerCQN2SQL(BaseCQN2SQL) {
 	return class TriggerCQN2SQL extends BaseCQN2SQL {
 		val(x) {
-			// Check if this is a trigger row reference
 			if (x && x.val && typeof x.val === 'string') {
+				// Check if this is a trigger row reference
 				const triggerRefPattern = /^:?(?:old|new|OLD|NEW|rec|nt|ot)\.\w+$/;
 				if (triggerRefPattern.test(x.val)) {
+					return x.val;
+				}
+
+				// Check if this is a raw SQL expression (e.g., subquery)
+				if (x.literal === 'sql') {
 					return x.val;
 				}
 			}

--- a/lib/TriggerCQN2SQL.js
+++ b/lib/TriggerCQN2SQL.js
@@ -3,7 +3,7 @@
  * without wrapping them in quotes.
  *
  * Overrides the `val` method to handle trigger row references:
- * - HANA (statement-level): nt.column, ot.column (transition table aliases)
+ * - HANA (statement-level): newTable.column, oldTable.column (transition table aliases)
  * - Postgres: OLD.column, NEW.column, rec.column
  * - SQLite: old.column, new.column
  *
@@ -16,7 +16,7 @@ function createTriggerCQN2SQL(BaseCQN2SQL) {
 		val(x) {
 			if (x && x.val && typeof x.val === 'string') {
 				// Check if this is a trigger row reference
-				const triggerRefPattern = /^:?(?:old|new|OLD|NEW|rec|nt|ot)\.\w+$/;
+				const triggerRefPattern = /^:?(?:old|new|OLD|NEW|rec|newTable|oldTable)\.\w+$/;
 				if (triggerRefPattern.test(x.val)) {
 					return x.val;
 				}

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -22,10 +22,10 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 	for (const oid of rootObjectIDs) {
 		if (oid.expression) {
 			const exprColumn = utils.buildExpressionColumn(oid.expression);
-			const query = SELECT.one.from(rootEntity.name).columns(exprColumn).where(where);
+			const query = SELECT.from(rootEntity.name).columns(exprColumn).where(where);
 			parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
 		} else {
-			const query = SELECT.one.from(rootEntity.name).columns(oid.name).where(where);
+			const query = SELECT.from(rootEntity.name).columns(oid.name).where(where);
 			parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
 		}
 	}
@@ -68,9 +68,9 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 				const exprColumn = utils.buildExpressionColumn(oid.expression);
 				const where = {};
 				for (let i = 0; i < parentFKFields.length; i++) {
-					where[parentFKFields[i]] = { val: `:${rowRef}.${childKeys[i]}` };
+					where[parentFKFields[i]] = { val: `${rowRef}.${childKeys[i]}` };
 				}
-				const q = SELECT.one.from(parentEntityName).columns(exprColumn).where(where);
+				const q = SELECT.from(parentEntityName).columns(exprColumn).where(where);
 				return `(${toSQL(q, model)})`;
 			}
 			return `(SELECT ${oid.name} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`;

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -1,20 +1,23 @@
 const utils = require('../utils/change-tracking.js');
-const { toSQL, compositeKeyExpr, buildGrandParentObjectIDExpr } = require('./sql-expressions.js');
+const { toSQL, compositeKeyExpr } = require('./sql-expressions.js');
 
 /**
  * Builds rootObjectID select for composition of many.
  */
-function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model) {
-	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `${refRow}.${k}`));
+function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
+	const keyValues = keyValueExprs ?? binding.map((k) => `${refRow}.${k}`);
+	const rootEntityKeyExpr = compositeKeyExpr(keyValues);
 
 	if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
 
 	const rootKeys = utils.extractKeys(rootEntity.keys);
-	if (rootKeys.length !== binding.length) return rootEntityKeyExpr;
+	if (rootKeys.length !== keyValues.length) return rootEntityKeyExpr;
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = { val: `${refRow}.${binding[i]}` };
+		where[rootKeys[i]] = keyValueExprs
+			? { val: keyValues[i], literal: 'sql' }
+			: { val: keyValues[i] };
 	}
 
 	const parts = [];
@@ -53,27 +56,11 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${rowRef}.${childKeys[i]}`).join(' AND ');
 
 	// Build the parent key expression via subquery (reverse lookup)
-	const parentKeyExpr = compositeKeyExpr(parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`));
+	const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
+	const parentKeyExpr = compositeKeyExpr(parentKeySubqueries);
 
-	// Build rootObjectID expression for the parent entity
-	let rootObjectIDExpr;
-	if (rootObjectIDs?.length > 0) {
-		const oidSelects = rootObjectIDs.map((oid) => {
-			if (oid.expression) {
-				const exprColumn = utils.buildExpressionColumn(oid.expression);
-				const where = {};
-				for (let i = 0; i < parentFKFields.length; i++) {
-					where[parentFKFields[i]] = { val: `${rowRef}.${childKeys[i]}` };
-				}
-				const q = SELECT.from(parentEntityName).columns(exprColumn).where(where);
-				return `(${toSQL(q, model)})`;
-			}
-			return `(SELECT ${oid.name} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`;
-		});
-		rootObjectIDExpr = oidSelects.length > 1 ? oidSelects.join(" || ', ' || ") : oidSelects[0];
-	} else {
-		rootObjectIDExpr = parentKeyExpr;
-	}
+	// Build rootObjectID expression for the parent entity (reuse buildCompOfManyRootObjectIDSelect with subquery key values)
+	const rootObjectIDExpr = buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
 
 	// Build the FROM clause referencing the transition table
 	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
@@ -124,7 +111,7 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
-function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, grandParentCompositionInfo = null) {
+function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = []) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 
 	// Handle composition of one (parent has FK to child - need reverse lookup)
@@ -142,81 +129,109 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
 	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
 
-	let declares, insertSQL;
+	let insertSQL;
 
-	if (grandParentCompositionInfo) {
-		// When we have grandparent info, we need to:
-		// 1. Create grandparent entry (Order.orderItems) for current transaction if not exists
-		// 2. Create parent entry (OrderItem.notes) linking to the grandparent entry
-		const { grandParentEntityName, grandParentCompositionFieldName, grandParentKeyBinding } = grandParentCompositionInfo;
+	if (ancestorCompositionChain.length > 0) {
+		// Build the full chain of ancestor levels.
+		// levels[0] = immediate parent (compositionParentInfo)
+		// levels[1] = grandparent (ancestorCompositionChain[0])
+		// levels[2] = great-grandparent (ancestorCompositionChain[1])
+		const levels = [
+			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
+			...ancestorCompositionChain
+		];
 
-		// Build grandparent key expression by looking up from parent entity
-		const parentEntity = model.definitions[parentEntityName];
-		const parentKeys = utils.extractKeys(parentEntity.keys);
-		const parentWhere = parentKeys.map((pk, i) => `${pk} = ${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
-		const grandParentKeyExpr = compositeKeyExpr(grandParentKeyBinding.map((k) => `(SELECT ${k} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`));
+		// Build key expressions for each level.
+		const keyExprs = [parentKeyExpr]; // level 0
+		const ancestorKeyValues = [parentKeyBinding.map((k) => `${rowRef}.${k}`)]; // level 0
 
-		// Build grandparent objectID expression
-		const grandParentEntity = model.definitions[grandParentEntityName];
-		const grandParentObjectIDs = utils.getObjectIDs(grandParentEntity, model);
-		const grandParentObjectIDExpr = grandParentObjectIDs?.length > 0 ? buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, parentEntityName, parentKeyBinding, grandParentKeyBinding, rowRef, model) : grandParentKeyExpr;
+		// childWhereClauses[i] = WHERE clause on level[i]'s table to find the record for this trigger row
+		const childWhereClauses = [];
+		const childEntity0 = model.definitions[levels[0].entityName];
+		const childKeys0 = utils.extractKeys(childEntity0.keys);
+		childWhereClauses.push(childKeys0.map((pk, j) => `${pk} = ${rowRef}.${levels[0].keyBinding[j]}`).join(' AND '));
 
-		declares = '';
+		for (let i = 1; i < levels.length; i++) {
+			const childLevel = levels[i - 1];
+			const ancestorLevel = levels[i];
+			const prevWhere = childWhereClauses[i - 1];
 
-		// Step 1: Bulk-insert distinct grandparent entries that don't exist yet
-		// Step 2: Bulk-insert distinct parent entries linking to grandparent entries
-		// SYSUUID is outside the DISTINCT subquery to allow proper deduplication
-		insertSQL = `INSERT INTO SAP_CHANGELOG_CHANGES
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
+				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
+			);
+
+			const ancestorEntity = model.definitions[ancestorLevel.entityName];
+			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
+			const thisWhere = ancestorKeys.map((pk, j) => `${pk} = ${whereForAncestor[j]}`).join(' AND ');
+			childWhereClauses.push(thisWhere);
+
+			ancestorKeyValues.push(whereForAncestor);
+			keyExprs.push(compositeKeyExpr(whereForAncestor));
+		}
+
+		// Generate INSERT statements from outermost ancestor down to the immediate parent
+		const insertStatements = [];
+
+		for (let i = levels.length - 1; i >= 0; i--) {
+			const level = levels[i];
+			const levelKeyExpr = keyExprs[i];
+			const isOutermost = i === levels.length - 1;
+			const isImmediateParent = i === 0;
+
+			// parent_ID: NULL for outermost, lookup for inner levels
+			let parentIDExpr;
+			if (isOutermost) {
+				parentIDExpr = 'NULL';
+			} else {
+				const parentLevel = levels[i + 1];
+				const parentLevelKeyExpr = keyExprs[i + 1];
+				parentIDExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES
+					WHERE entity = '${parentLevel.entityName}'
+					AND entityKey = ${parentLevelKeyExpr}
+					AND attribute = '${parentLevel.compositionFieldName}'
+					AND valueDataType = 'cds.Composition'
+					AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+			}
+
+			const modExpr = isImmediateParent ? `'${modification}'` : "'update'";
+
+			// objectID: resolve from the entity's @changelog annotation via buildCompOfManyRootObjectIDSelect
+			let objectIDExpr;
+			if (isImmediateParent) {
+				objectIDExpr = rootObjectIDExpr;
+			} else {
+				const ancestorEntity = model.definitions[level.entityName];
+				objectIDExpr = buildCompOfManyRootObjectIDSelect(ancestorEntity, level.objectIDs, null, null, model, ancestorKeyValues[i]);
+			}
+
+			insertStatements.push(`INSERT INTO SAP_CHANGELOG_CHANGES
 				(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
 				SELECT SYSUUID, sub.* FROM (
 					SELECT DISTINCT
-						NULL AS parent_ID,
-						'${grandParentCompositionFieldName}' AS attribute,
-						'${grandParentEntityName}' AS entity,
-						${grandParentKeyExpr} AS entityKey,
-						${grandParentObjectIDExpr} AS objectID,
+						${parentIDExpr} AS parent_ID,
+						'${level.compositionFieldName}' AS attribute,
+						'${level.entityName}' AS entity,
+						${levelKeyExpr} AS entityKey,
+						${objectIDExpr} AS objectID,
 						CURRENT_TIMESTAMP AS createdAt,
 						SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
 						'cds.Composition' AS valueDataType,
-						'update' AS modification,
+						${modExpr} AS modification,
 						CURRENT_UPDATE_TRANSACTION() AS transactionID
 					FROM ${transitionTable} ${transitionAlias}
 					WHERE NOT EXISTS (
 						SELECT 1 FROM SAP_CHANGELOG_CHANGES
-						WHERE entity = '${grandParentEntityName}'
-						AND entityKey = ${grandParentKeyExpr}
-						AND attribute = '${grandParentCompositionFieldName}'
+						WHERE entity = '${level.entityName}'
+						AND entityKey = ${levelKeyExpr}
+						AND attribute = '${level.compositionFieldName}'
 						AND valueDataType = 'cds.Composition'
 						AND transactionID = CURRENT_UPDATE_TRANSACTION()
 					)
-				) sub;
-		INSERT INTO SAP_CHANGELOG_CHANGES
-			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT SYSUUID, sub.* FROM (
-				SELECT DISTINCT
-					(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${grandParentEntityName}' AND entityKey = ${grandParentKeyExpr} AND attribute = '${grandParentCompositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION()) AS parent_ID,
-					'${compositionFieldName}' AS attribute,
-					'${parentEntityName}' AS entity,
-					${parentKeyExpr} AS entityKey,
-					${rootObjectIDExpr} AS objectID,
-					CURRENT_TIMESTAMP AS createdAt,
-					SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-					'cds.Composition' AS valueDataType,
-					'${modification}' AS modification,
-					CURRENT_UPDATE_TRANSACTION() AS transactionID
-				FROM ${transitionTable} ${transitionAlias}
-				WHERE NOT EXISTS (
-					SELECT 1 FROM SAP_CHANGELOG_CHANGES
-					WHERE entity = '${parentEntityName}'
-					AND entityKey = ${parentKeyExpr}
-					AND attribute = '${compositionFieldName}'
-					AND valueDataType = 'cds.Composition'
-					AND transactionID = CURRENT_UPDATE_TRANSACTION()
-				)
-			) sub;`;
-	} else {
-		declares = '';
+				) sub;`);
+		}
 
+		insertSQL = insertStatements.join('\n\t\t');
+	} else {
 		// Bulk-insert parent entries for all affected rows.
 		// SYSUUID is outside the DISTINCT subquery to allow proper deduplication.
 		insertSQL = `
@@ -255,7 +270,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 	// Parent lookup expression: correlated subquery to find the parent changelog entry ID per row
 	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
 
-	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
+	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
 /**

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -2,10 +2,11 @@ const utils = require('../utils/change-tracking.js');
 const { toSQL, compositeKeyExpr, buildGrandParentObjectIDExpr } = require('./sql-expressions.js');
 
 /**
- * Builds rootObjectID select for composition of many
+ * Builds rootObjectID select for composition of many.
+ * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model) {
-	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `:${refRow}.${k}`));
+	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `${refRow}.${k}`));
 
 	if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
 
@@ -14,12 +15,12 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = { val: `:${refRow}.${binding[i]}` };
+		where[rootKeys[i]] = { val: `${refRow}.${binding[i]}` };
 	}
 
 	const parts = [];
 	for (const oid of rootObjectIDs) {
-		const query = SELECT.one.from(rootEntity.name).columns(oid.name).where(where);
+		const query = SELECT.from(rootEntity.name).columns(oid.name).where(where);
 		parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
 	}
 
@@ -32,6 +33,9 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
  * Builds context for composition of one parent changelog entry.
  * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
  * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
+ *
+ * For statement-level triggers, rowRef is a table alias (e.g., 'nt' or 'ot').
+ * The parent WHERE clause references columns from the transition table via the alias.
  */
 function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
@@ -42,9 +46,10 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	const parentFKFields = childKeys.map((k) => `${compositionName}_${k}`);
 
 	// Build WHERE clause to find the parent entity that has this child
+	// Uses table alias (e.g., nt.ID or ot.ID) for statement-level triggers
 	const parentEntity = model.definitions[parentEntityName];
 	const parentKeys = utils.extractKeys(parentEntity.keys);
-	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = :${rowRef}.${childKeys[i]}`).join(' AND ');
+	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${rowRef}.${childKeys[i]}`).join(' AND ');
 
 	// Build the parent key expression via subquery (reverse lookup)
 	const parentKeyExpr = compositeKeyExpr(parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`));
@@ -58,47 +63,53 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 		rootObjectIDExpr = parentKeyExpr;
 	}
 
-	// Add parent_modification to declares for dynamic determination
-	const declares = 'DECLARE parent_id NVARCHAR(36); DECLARE parent_modification NVARCHAR(10);';
+	// Build the FROM clause referencing the transition table
+	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
+	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
 
-	// Determine modification dynamically: 'create' if parent was just created, 'update' otherwise
-	// Note: For composition of one, we check if a composition entry already exists for this transaction
-	// to avoid duplicates when both parent UPDATE and child DELETE triggers fire
+	// For statement-level triggers: bulk-insert parent entries for all affected rows.
+	// SYSUUID must be outside the DISTINCT subquery since it generates unique values per row,
+	// which would defeat deduplication. The inner SELECT DISTINCT deduplicates by parent key,
+	// then the outer SELECT adds unique IDs per distinct row.
 	const insertSQL = `
-		SELECT CASE WHEN COUNT(*) > 0 THEN 'create' ELSE 'update' END INTO parent_modification
-			FROM SAP_CHANGELOG_CHANGES
-			WHERE entity = '${parentEntityName}'
-			AND entityKey = ${parentKeyExpr}
-			AND modification = 'create'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();
 		INSERT INTO SAP_CHANGELOG_CHANGES
 			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT
-				parent_id,
-				NULL,
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${rootObjectIDExpr},
-				CURRENT_TIMESTAMP,
-				SESSION_CONTEXT('APPLICATIONUSER'),
-				'cds.Composition',
-				parent_modification,
-				CURRENT_UPDATE_TRANSACTION()
-			FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY
-			WHERE EXISTS (
-				SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
-			)
-			AND NOT EXISTS (
-				SELECT 1 FROM SAP_CHANGELOG_CHANGES
-				WHERE entity = '${parentEntityName}'
-				AND entityKey = ${parentKeyExpr}
-				AND attribute = '${compositionFieldName}'
-				AND valueDataType = 'cds.Composition'
-				AND transactionID = CURRENT_UPDATE_TRANSACTION()
-			);`;
+			SELECT SYSUUID, sub.* FROM (
+				SELECT DISTINCT
+					NULL AS parent_ID,
+					'${compositionFieldName}' AS attribute,
+					'${parentEntityName}' AS entity,
+					${parentKeyExpr} AS entityKey,
+					${rootObjectIDExpr} AS objectID,
+					CURRENT_TIMESTAMP AS createdAt,
+					SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+					'cds.Composition' AS valueDataType,
+					CASE WHEN EXISTS (
+						SELECT 1 FROM SAP_CHANGELOG_CHANGES
+						WHERE entity = '${parentEntityName}'
+						AND entityKey = ${parentKeyExpr}
+						AND modification = 'create'
+						AND transactionID = CURRENT_UPDATE_TRANSACTION()
+					) THEN 'create' ELSE 'update' END AS modification,
+					CURRENT_UPDATE_TRANSACTION() AS transactionID
+				FROM ${transitionTable} ${transitionAlias}
+				WHERE EXISTS (
+					SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
+				)
+				AND NOT EXISTS (
+					SELECT 1 FROM SAP_CHANGELOG_CHANGES
+					WHERE entity = '${parentEntityName}'
+					AND entityKey = ${parentKeyExpr}
+					AND attribute = '${compositionFieldName}'
+					AND valueDataType = 'cds.Composition'
+					AND transactionID = CURRENT_UPDATE_TRANSACTION()
+				)
+			) sub;`;
 
-	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr };
+	// Parent lookup expression: correlated subquery to find the parent changelog entry ID
+	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+
+	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
 function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, grandParentCompositionInfo = null) {
@@ -109,11 +120,15 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 		return buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model);
 	}
 
-	const parentKeyExpr = compositeKeyExpr(parentKeyBinding.map((k) => `:${rowRef}.${k}`));
+	const parentKeyExpr = compositeKeyExpr(parentKeyBinding.map((k) => `${rowRef}.${k}`));
 
 	// Build rootObjectID expression for the parent entity
 	const rootEntity = model.definitions[parentEntityName];
 	const rootObjectIDExpr = buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, parentKeyBinding, rowRef, model);
+
+	// Build the FROM clause referencing the transition table
+	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
+	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
 
 	let declares, insertSQL;
 
@@ -126,7 +141,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 		// Build grandparent key expression by looking up from parent entity
 		const parentEntity = model.definitions[parentEntityName];
 		const parentKeys = utils.extractKeys(parentEntity.keys);
-		const parentWhere = parentKeys.map((pk, i) => `${pk} = :${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
+		const parentWhere = parentKeys.map((pk, i) => `${pk} = ${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
 		const grandParentKeyExpr = compositeKeyExpr(grandParentKeyBinding.map((k) => `(SELECT ${k} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`));
 
 		// Build grandparent objectID expression
@@ -134,106 +149,119 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 		const grandParentObjectIDs = utils.getObjectIDs(grandParentEntity, model);
 		const grandParentObjectIDExpr = grandParentObjectIDs?.length > 0 ? buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, parentEntityName, parentKeyBinding, grandParentKeyBinding, rowRef, model) : grandParentKeyExpr;
 
-		// Add grandparent_id to declares
-		declares = 'DECLARE parent_id NVARCHAR(36);\n\tDECLARE grandparent_id NVARCHAR(36);';
+		declares = '';
 
-		insertSQL = `SELECT MAX(ID) INTO grandparent_id FROM SAP_CHANGELOG_CHANGES
-			WHERE entity = '${grandParentEntityName}'
-			AND entityKey = ${grandParentKeyExpr}
-			AND attribute = '${grandParentCompositionFieldName}'
-			AND valueDataType = 'cds.Composition'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();
-		IF grandparent_id IS NULL THEN
-			grandparent_id := SYSUUID;
-			INSERT INTO SAP_CHANGELOG_CHANGES
+		// Step 1: Bulk-insert distinct grandparent entries that don't exist yet
+		// Step 2: Bulk-insert distinct parent entries linking to grandparent entries
+		// SYSUUID is outside the DISTINCT subquery to allow proper deduplication
+		insertSQL = `INSERT INTO SAP_CHANGELOG_CHANGES
 				(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-				VALUES (
-					grandparent_id,
-					NULL,
-					'${grandParentCompositionFieldName}',
-					'${grandParentEntityName}',
-					${grandParentKeyExpr},
-					${grandParentObjectIDExpr},
-					CURRENT_TIMESTAMP,
-					SESSION_CONTEXT('APPLICATIONUSER'),
-					'cds.Composition',
-					'update',
-					CURRENT_UPDATE_TRANSACTION()
-				);
-		END IF;
-		
+				SELECT SYSUUID, sub.* FROM (
+					SELECT DISTINCT
+						NULL AS parent_ID,
+						'${grandParentCompositionFieldName}' AS attribute,
+						'${grandParentEntityName}' AS entity,
+						${grandParentKeyExpr} AS entityKey,
+						${grandParentObjectIDExpr} AS objectID,
+						CURRENT_TIMESTAMP AS createdAt,
+						SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+						'cds.Composition' AS valueDataType,
+						'update' AS modification,
+						CURRENT_UPDATE_TRANSACTION() AS transactionID
+					FROM ${transitionTable} ${transitionAlias}
+					WHERE NOT EXISTS (
+						SELECT 1 FROM SAP_CHANGELOG_CHANGES
+						WHERE entity = '${grandParentEntityName}'
+						AND entityKey = ${grandParentKeyExpr}
+						AND attribute = '${grandParentCompositionFieldName}'
+						AND valueDataType = 'cds.Composition'
+						AND transactionID = CURRENT_UPDATE_TRANSACTION()
+					)
+				) sub;
 		INSERT INTO SAP_CHANGELOG_CHANGES
 			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			VALUES (
-				parent_id,
-				grandparent_id,
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${rootObjectIDExpr},
-				CURRENT_TIMESTAMP,
-				SESSION_CONTEXT('APPLICATIONUSER'),
-				'cds.Composition',
-				'${modification}',
-				CURRENT_UPDATE_TRANSACTION()
-			);`;
+			SELECT SYSUUID, sub.* FROM (
+				SELECT DISTINCT
+					(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${grandParentEntityName}' AND entityKey = ${grandParentKeyExpr} AND attribute = '${grandParentCompositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION()) AS parent_ID,
+					'${compositionFieldName}' AS attribute,
+					'${parentEntityName}' AS entity,
+					${parentKeyExpr} AS entityKey,
+					${rootObjectIDExpr} AS objectID,
+					CURRENT_TIMESTAMP AS createdAt,
+					SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+					'cds.Composition' AS valueDataType,
+					'${modification}' AS modification,
+					CURRENT_UPDATE_TRANSACTION() AS transactionID
+				FROM ${transitionTable} ${transitionAlias}
+				WHERE NOT EXISTS (
+					SELECT 1 FROM SAP_CHANGELOG_CHANGES
+					WHERE entity = '${parentEntityName}'
+					AND entityKey = ${parentKeyExpr}
+					AND attribute = '${compositionFieldName}'
+					AND valueDataType = 'cds.Composition'
+					AND transactionID = CURRENT_UPDATE_TRANSACTION()
+				)
+			) sub;`;
 	} else {
-		// Add parent_modification to declares for dynamic determination
-		declares = 'DECLARE parent_id NVARCHAR(36);\n\tDECLARE parent_modification NVARCHAR(10);';
+		declares = '';
 
-		// Determine modification dynamically: 'create' if parent was just created, 'update' otherwise
-		// This handles both deep insert (parent created in same tx) and independent insert (parent already existed)
+		// For statement-level triggers: bulk-insert parent entries for all affected rows.
+		// SYSUUID is outside the DISTINCT subquery to allow proper deduplication.
 		insertSQL = `
-		SELECT CASE WHEN COUNT(*) > 0 THEN 'create' ELSE 'update' END INTO parent_modification
-			FROM SAP_CHANGELOG_CHANGES
-			WHERE entity = '${parentEntityName}'
-			AND entityKey = ${parentKeyExpr}
-			AND modification = 'create'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();
 		INSERT INTO SAP_CHANGELOG_CHANGES
 			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			VALUES (
-				parent_id,
-				NULL,
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${rootObjectIDExpr},
-				CURRENT_TIMESTAMP,
-				SESSION_CONTEXT('APPLICATIONUSER'),
-				'cds.Composition',
-				parent_modification,
-				CURRENT_UPDATE_TRANSACTION()
-			);`;
+			SELECT SYSUUID, sub.* FROM (
+				SELECT DISTINCT
+					NULL AS parent_ID,
+					'${compositionFieldName}' AS attribute,
+					'${parentEntityName}' AS entity,
+					${parentKeyExpr} AS entityKey,
+					${rootObjectIDExpr} AS objectID,
+					CURRENT_TIMESTAMP AS createdAt,
+					SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+					'cds.Composition' AS valueDataType,
+					CASE WHEN EXISTS (
+						SELECT 1 FROM SAP_CHANGELOG_CHANGES
+						WHERE entity = '${parentEntityName}'
+						AND entityKey = ${parentKeyExpr}
+						AND modification = 'create'
+						AND transactionID = CURRENT_UPDATE_TRANSACTION()
+					) THEN 'create' ELSE 'update' END AS modification,
+					CURRENT_UPDATE_TRANSACTION() AS transactionID
+				FROM ${transitionTable} ${transitionAlias}
+				WHERE NOT EXISTS (
+					SELECT 1 FROM SAP_CHANGELOG_CHANGES
+					WHERE entity = '${parentEntityName}'
+					AND entityKey = ${parentKeyExpr}
+					AND attribute = '${compositionFieldName}'
+					AND valueDataType = 'cds.Composition'
+					AND transactionID = CURRENT_UPDATE_TRANSACTION()
+				)
+			) sub;`;
 	}
 
-	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr };
+	// Parent lookup expression: correlated subquery to find the parent changelog entry ID per row
+	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+
+	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
-function buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName) {
-	return `SELECT MAX(ID) INTO parent_id FROM SAP_CHANGELOG_CHANGES
-			WHERE entity = '${parentEntityName}'
-			AND entityKey = ${parentKeyExpr}
-			AND attribute = '${compositionFieldName}'
-			AND valueDataType = 'cds.Composition'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();`;
-}
-
+/**
+ * Builds parent lookup/create SQL for statement-level triggers.
+ * The insertSQL now contains set-based INSERT ... SELECT statements
+ * that handle bulk creation of parent entries.
+ */
 function buildParentLookupOrCreateSQL(compositionParentContext) {
-	const { insertSQL: compInsertSQL, parentEntityName, compositionFieldName, parentKeyExpr } = compositionParentContext;
-	return `${buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName)}
-		IF parent_id IS NULL THEN
-			parent_id := SYSUUID;
-			${compInsertSQL}
-		END IF;`;
+	const { insertSQL: compInsertSQL } = compositionParentContext;
+	return compInsertSQL;
 }
 
 function buildCompositionOnlyBody(entityName, compositionParentContext, prefixSQL = '') {
 	const { getSkipCheckCondition } = require('./sql-expressions.js');
 	const { declares } = compositionParentContext;
+	const declareBlock = declares ? `${declares}\n\t` : '';
 	const prefix = prefixSQL ? `\n\t\t${prefixSQL}` : '';
-	return `${declares}
-	IF ${getSkipCheckCondition(entityName)} THEN${prefix}
+	return `${declareBlock}IF ${getSkipCheckCondition(entityName)} THEN${prefix}
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 	END IF;`;
 }
@@ -242,7 +270,6 @@ module.exports = {
 	buildCompOfManyRootObjectIDSelect,
 	buildCompositionOfOneParentContext,
 	buildCompositionParentContext,
-	buildParentLookupSQL,
 	buildParentLookupOrCreateSQL,
 	buildCompositionOnlyBody
 };

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -64,7 +64,7 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 
 	// Build the FROM clause referencing the transition table
 	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
-	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
+	const transitionAlias = modification === 'delete' ? 'oldTable' : 'newTable';
 
 	// Bulk-insert parent entries for all affected rows.
 	// SYSUUID must be outside the DISTINCT subquery since it generates unique values per row,
@@ -127,7 +127,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 
 	// Build the FROM clause referencing the transition table
 	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
-	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
+	const transitionAlias = modification === 'delete' ? 'oldTable' : 'newTable';
 
 	let insertSQL;
 

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -3,7 +3,6 @@ const { toSQL, compositeKeyExpr, buildGrandParentObjectIDExpr } = require('./sql
 
 /**
  * Builds rootObjectID select for composition of many.
- * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model) {
 	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `${refRow}.${k}`));
@@ -39,9 +38,6 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
  * Builds context for composition of one parent changelog entry.
  * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
  * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
- *
- * For statement-level triggers, rowRef is a table alias (e.g., 'nt' or 'ot').
- * The parent WHERE clause references columns from the transition table via the alias.
  */
 function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
@@ -52,7 +48,6 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	const parentFKFields = childKeys.map((k) => `${compositionName}_${k}`);
 
 	// Build WHERE clause to find the parent entity that has this child
-	// Uses table alias (e.g., nt.ID or ot.ID) for statement-level triggers
 	const parentEntity = model.definitions[parentEntityName];
 	const parentKeys = utils.extractKeys(parentEntity.keys);
 	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${rowRef}.${childKeys[i]}`).join(' AND ');
@@ -84,7 +79,7 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
 	const transitionAlias = modification === 'delete' ? 'ot' : 'nt';
 
-	// For statement-level triggers: bulk-insert parent entries for all affected rows.
+	// Bulk-insert parent entries for all affected rows.
 	// SYSUUID must be outside the DISTINCT subquery since it generates unique values per row,
 	// which would defeat deduplication. The inner SELECT DISTINCT deduplicates by parent key,
 	// then the outer SELECT adds unique IDs per distinct row.
@@ -222,7 +217,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 	} else {
 		declares = '';
 
-		// For statement-level triggers: bulk-insert parent entries for all affected rows.
+		// Bulk-insert parent entries for all affected rows.
 		// SYSUUID is outside the DISTINCT subquery to allow proper deduplication.
 		insertSQL = `
 		INSERT INTO SAP_CHANGELOG_CHANGES
@@ -264,8 +259,8 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 }
 
 /**
- * Builds parent lookup/create SQL for statement-level triggers.
- * The insertSQL now contains set-based INSERT ... SELECT statements
+ * Builds parent lookup/create SQL.
+ * The insertSQL contains set-based INSERT ... SELECT statements
  * that handle bulk creation of parent entries.
  */
 function buildParentLookupOrCreateSQL(compositionParentContext) {

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -15,9 +15,7 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = keyValueExprs
-			? { val: keyValues[i], literal: 'sql' }
-			: { val: keyValues[i] };
+		where[rootKeys[i]] = keyValueExprs ? { val: keyValues[i], literal: 'sql' } : { val: keyValues[i] };
 	}
 
 	const parts = [];
@@ -136,10 +134,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 		// levels[0] = immediate parent (compositionParentInfo)
 		// levels[1] = grandparent (ancestorCompositionChain[0])
 		// levels[2] = great-grandparent (ancestorCompositionChain[1])
-		const levels = [
-			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
-			...ancestorCompositionChain
-		];
+		const levels = [{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding }, ...ancestorCompositionChain];
 
 		// Build key expressions for each level.
 		const keyExprs = [parentKeyExpr]; // level 0
@@ -156,9 +151,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 			const ancestorLevel = levels[i];
 			const prevWhere = childWhereClauses[i - 1];
 
-			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
-				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
-			);
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
 
 			const ancestorEntity = model.definitions[ancestorLevel.entityName];
 			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -23,13 +23,11 @@ function registerHDICompilerHook() {
 			const rows = labels.map((row) => `${escape(row.ID)};${escape(row.locale)};${escape(row.text)}`);
 			const i18nContent = [header, ...rows].join('\n') + '\n';
 
-			data.push(
-				{
-					name: 'sap.changelog-i18nKeys',
-					sql: i18nContent,
-					suffix: '.csv'
-				}
-			);
+			data.push({
+				name: 'sap.changelog-i18nKeys',
+				sql: i18nContent,
+				suffix: '.csv'
+			});
 		}
 
 		const ret = _hdi_migration(csn, options, beforeImage);

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -12,7 +12,6 @@ function registerHDICompilerHook() {
 		const triggers = generateTriggersForEntities(runtimeCSN, hierarchy, entities, generateHANATriggers);
 		const data = [];
 		if (triggers.length > 0) {
-			delete csn.definitions['sap.changelog.CHANGE_TRACKING_DUMMY']['@cds.persistence.skip'];
 			ensureUndeployJsonHasTriggerPattern();
 
 			const labels = getLabelTranslations(entities, runtimeCSN);
@@ -25,11 +24,6 @@ function registerHDICompilerHook() {
 			const i18nContent = [header, ...rows].join('\n') + '\n';
 
 			data.push(
-				{
-					name: 'sap.changelog-CHANGE_TRACKING_DUMMY',
-					sql: 'X\n1',
-					suffix: '.csv'
-				},
 				{
 					name: 'sap.changelog-i18nKeys',
 					sql: i18nContent,

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -137,7 +137,7 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
 
 const { buildExpressionSQL } = require('../utils/expression-sql.js');
 
-const _hanaRefFormat = (refRow, col) => `:${refRow}.${col}`;
+const _hanaRefFormat = (refRow, col) => `${refRow}.${col}`;
 
 /**
  * Returns SQL expression for a column's label (looked-up value for associations).
@@ -192,7 +192,7 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const parts = [];
 	for (const oid of objectIDs) {
 		if (oid.included) {
-			parts.push(`COALESCE(TO_NVARCHAR(:${rowRef}.${oid.name}), '<empty>')`);
+			parts.push(`COALESCE(TO_NVARCHAR(${rowRef}.${oid.name}), '<empty>')`);
 		} else if (oid.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -137,8 +137,6 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
 
 const { buildExpressionSQL } = require('../utils/expression-sql.js');
 
-const _hanaRefFormat = (refRow, col) => `${refRow}.${col}`;
-
 /**
  * Returns SQL expression for a column's label (looked-up value for associations).
  * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
@@ -148,7 +146,7 @@ function getLabelExpr(col, refRow, model, entityName = null) {
 	if (col.altExpression && entityName) {
 		const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
 		// Cast to NVARCHAR to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL, _hanaRefFormat)})`;
+		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL)})`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -196,7 +194,7 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 		} else if (oid.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-			const sql = buildExpressionSQL(oid.expression, entity.name, rowRef, model, CQN2SQLClass, toSQL, _hanaRefFormat);
+			const sql = buildExpressionSQL(oid.expression, entity.name, rowRef, model, CQN2SQLClass, toSQL);
 			parts.push(`COALESCE(TO_NVARCHAR(${sql}), '')`);
 		} else {
 			const where = keys.reduce((acc, k) => {

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -69,8 +69,8 @@ function getValueExpr(col, refRow) {
  */
 function nullSafeChanged(column, isLob = false) {
 	// For LOB types, convert to NVARCHAR before comparison
-	const o = isLob ? `TO_NVARCHAR(ot.${column})` : `ot.${column}`;
-	const n = isLob ? `TO_NVARCHAR(nt.${column})` : `nt.${column}`;
+	const o = isLob ? `TO_NVARCHAR(oldTable.${column})` : `oldTable.${column}`;
+	const n = isLob ? `TO_NVARCHAR(newTable.${column})` : `newTable.${column}`;
 	return `(${o} <> ${n} OR ${o} IS NULL OR ${n} IS NULL) AND NOT (${o} IS NULL AND ${n} IS NULL)`;
 }
 
@@ -84,7 +84,7 @@ function getWhereCondition(col, modification) {
 		return checkCols.map((k) => nullSafeChanged(k, isLob)).join(' OR ');
 	}
 	// CREATE or DELETE: check value is not null
-	const rowRef = modification === 'create' ? 'nt' : 'ot';
+	const rowRef = modification === 'create' ? 'newTable' : 'oldTable';
 	if (col.target && col.foreignKeys) {
 		return col.foreignKeys.map((fk) => `${rowRef}.${col.name}_${fk} IS NOT NULL`).join(' OR ');
 	}

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -204,38 +204,6 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	return `COALESCE(NULLIF(${concatLogic}, ''), ${entityKeyExpr})`;
 }
 
-/**
- * Builds SQL expression for grandparent entity's objectID.
- * Used when creating grandparent composition entries for deep linking.
- */
-function buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, parentEntityName, parentKeyBinding, grandParentKeyBinding, rowRef, model) {
-	// Build WHERE clause to find the parent entity record (e.g., OrderItem from OrderItemNote's FK)
-	const parentEntity = model.definitions[parentEntityName];
-	const parentKeys = utils.extractKeys(parentEntity.keys);
-	const parentWhere = parentKeys.map((pk, i) => `${pk} = ${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
-
-	// Build WHERE clause to find the grandparent entity record from parent
-	const grandParentKeys = utils.extractKeys(grandParentEntity.keys);
-
-	// Build grandparent objectID using CQN for proper association path resolution
-	const grandParentWhere = {};
-	for (let i = 0; i < grandParentKeys.length; i++) {
-		const fkField = grandParentKeyBinding[i];
-		grandParentWhere[grandParentKeys[i]] = { val: `(SELECT ${fkField} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})` };
-	}
-
-	const parts = [];
-	for (const oid of grandParentObjectIDs) {
-		const query = SELECT.from(grandParentEntity.name).columns(oid.name).where(grandParentWhere);
-		parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
-	}
-
-	const concatLogic = parts.join(" || ', ' || ");
-	const grandParentKeyExpr = compositeKeyExpr(grandParentKeyBinding.map((k) => `(SELECT ${k} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`));
-
-	return `COALESCE(NULLIF(${concatLogic}, ''), ${grandParentKeyExpr})`;
-}
-
 module.exports = {
 	toSQL,
 	getSkipCheckCondition,
@@ -245,6 +213,5 @@ module.exports = {
 	getValueExpr,
 	getWhereCondition,
 	getLabelExpr,
-	buildObjectIDExpr,
-	buildGrandParentObjectIDExpr
+	buildObjectIDExpr
 };

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -210,12 +210,6 @@ function buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, p
 
 	// Build WHERE clause to find the grandparent entity record from parent
 	const grandParentKeys = utils.extractKeys(grandParentEntity.keys);
-	const grandParentWhereSubquery = grandParentKeys
-		.map((gk, i) => {
-			const fkField = grandParentKeyBinding[i];
-			return `${gk} = (SELECT ${fkField} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`;
-		})
-		.join(' AND ');
 
 	// Build grandparent objectID using CQN for proper association path resolution
 	const grandParentWhere = {};

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -42,7 +42,6 @@ function wrapLargeString(val, isLob = false) {
 
 /**
  * Returns SQL expression for a column's raw value.
- * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function getValueExpr(col, refRow) {
 	if (col.type === 'cds.Boolean') {
@@ -67,7 +66,6 @@ function getValueExpr(col, refRow) {
 
 /**
  * Null-safe change detection: (old <> new OR old IS NULL OR new IS NULL) AND NOT (old IS NULL AND new IS NULL)
- * Uses table aliases (e.g., 'ot' and 'nt') for statement-level triggers.
  */
 function nullSafeChanged(column, isLob = false) {
 	// For LOB types, convert to NVARCHAR before comparison
@@ -78,7 +76,6 @@ function nullSafeChanged(column, isLob = false) {
 
 /**
  * Returns SQL WHERE condition for detecting column changes (null-safe comparison).
- * For statement-level triggers, uses table aliases 'nt' and 'ot'.
  */
 function getWhereCondition(col, modification) {
 	const isLob = col.type === 'cds.LargeString';
@@ -103,7 +100,6 @@ function getWhereCondition(col, modification) {
 
 /**
  * Builds scalar subselect for association label lookup with locale awareness.
- * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function buildAssocLookup(col, assocPaths, refRow, model) {
 	let where = {};
@@ -139,7 +135,6 @@ const { buildExpressionSQL } = require('../utils/expression-sql.js');
 
 /**
  * Returns SQL expression for a column's label (looked-up value for associations).
- * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function getLabelExpr(col, refRow, model, entityName = null) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
@@ -176,8 +171,7 @@ function getLabelExpr(col, refRow, model, entityName = null) {
 
 /**
  * Builds SQL expression for objectID (entity display name).
- * Uses @changelog annotation fields, falling back to entity name.
- * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
+ * Uses @changelog annotation fields, falling back to entity keys.
  */
 function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
@@ -213,7 +207,6 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 /**
  * Builds SQL expression for grandparent entity's objectID.
  * Used when creating grandparent composition entries for deep linking.
- * parentKeyBinding uses table alias references (e.g., 'nt.col') for statement-level triggers.
  */
 function buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, parentEntityName, parentKeyBinding, grandParentKeyBinding, rowRef, model) {
 	// Build WHERE clause to find the parent entity record (e.g., OrderItem from OrderItemNote's FK)

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -42,20 +42,21 @@ function wrapLargeString(val, isLob = false) {
 }
 
 /**
- * Returns SQL expression for a column's raw value
+ * Returns SQL expression for a column's raw value.
+ * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function getValueExpr(col, refRow) {
 	if (col.type === 'cds.Boolean') {
-		return `:${refRow}.${col.name}`;
+		return `${refRow}.${col.name}`;
 	}
 	if (col.target && col.foreignKeys) {
-		return col.foreignKeys.map((fk) => `TO_NVARCHAR(:${refRow}.${col.name}_${fk})`).join(" || ' ' || ");
+		return col.foreignKeys.map((fk) => `TO_NVARCHAR(${refRow}.${col.name}_${fk})`).join(" || ' ' || ");
 	}
 	if (col.target && col.on) {
-		return col.on.map((m) => `TO_NVARCHAR(:${refRow}.${m.foreignKeyField})`).join(" || ' ' || ");
+		return col.on.map((m) => `TO_NVARCHAR(${refRow}.${m.foreignKeyField})`).join(" || ' ' || ");
 	}
 	// Scalar value
-	let raw = `:${refRow}.${col.name}`;
+	let raw = `${refRow}.${col.name}`;
 	if (col.type === 'cds.LargeString') {
 		return wrapLargeString(raw, true);
 	}
@@ -67,16 +68,18 @@ function getValueExpr(col, refRow) {
 
 /**
  * Null-safe change detection: (old <> new OR old IS NULL OR new IS NULL) AND NOT (old IS NULL AND new IS NULL)
+ * Uses table aliases (e.g., 'ot' and 'nt') for statement-level triggers.
  */
 function nullSafeChanged(column, isLob = false) {
 	// For LOB types, convert to NVARCHAR before comparison
-	const o = isLob ? `TO_NVARCHAR(:old.${column})` : `:old.${column}`;
-	const n = isLob ? `TO_NVARCHAR(:new.${column})` : `:new.${column}`;
+	const o = isLob ? `TO_NVARCHAR(ot.${column})` : `ot.${column}`;
+	const n = isLob ? `TO_NVARCHAR(nt.${column})` : `nt.${column}`;
 	return `(${o} <> ${n} OR ${o} IS NULL OR ${n} IS NULL) AND NOT (${o} IS NULL AND ${n} IS NULL)`;
 }
 
 /**
- * Returns SQL WHERE condition for detecting column changes (null-safe comparison)
+ * Returns SQL WHERE condition for detecting column changes (null-safe comparison).
+ * For statement-level triggers, uses table aliases 'nt' and 'ot'.
  */
 function getWhereCondition(col, modification) {
 	const isLob = col.type === 'cds.LargeString';
@@ -85,33 +88,34 @@ function getWhereCondition(col, modification) {
 		return checkCols.map((k) => nullSafeChanged(k, isLob)).join(' OR ');
 	}
 	// CREATE or DELETE: check value is not null
-	const rowRef = modification === 'create' ? 'new' : 'old';
+	const rowRef = modification === 'create' ? 'nt' : 'ot';
 	if (col.target && col.foreignKeys) {
-		return col.foreignKeys.map((fk) => `:${rowRef}.${col.name}_${fk} IS NOT NULL`).join(' OR ');
+		return col.foreignKeys.map((fk) => `${rowRef}.${col.name}_${fk} IS NOT NULL`).join(' OR ');
 	}
 	if (col.target && col.on) {
-		return col.on.map((m) => `:${rowRef}.${m.foreignKeyField} IS NOT NULL`).join(' OR ');
+		return col.on.map((m) => `${rowRef}.${m.foreignKeyField} IS NOT NULL`).join(' OR ');
 	}
 	// For LOB types, convert to NVARCHAR before null check
 	if (isLob) {
-		return `TO_NVARCHAR(:${rowRef}.${col.name}) IS NOT NULL`;
+		return `TO_NVARCHAR(${rowRef}.${col.name}) IS NOT NULL`;
 	}
-	return `:${rowRef}.${col.name} IS NOT NULL`;
+	return `${rowRef}.${col.name} IS NOT NULL`;
 }
 
 /**
- * Builds scalar subselect for association label lookup with locale awareness
+ * Builds scalar subselect for association label lookup with locale awareness.
+ * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function buildAssocLookup(col, assocPaths, refRow, model) {
 	let where = {};
 	if (col.foreignKeys) {
 		where = col.foreignKeys.reduce((acc, k) => {
-			acc[k] = { val: `:${refRow}.${col.name}_${k}` };
+			acc[k] = { val: `${refRow}.${col.name}_${k}` };
 			return acc;
 		}, {});
 	} else if (col.on) {
 		where = col.on.reduce((acc, mapping) => {
-			acc[mapping.targetKey] = { val: `:${refRow}.${mapping.foreignKeyField}` };
+			acc[mapping.targetKey] = { val: `${refRow}.${mapping.foreignKeyField}` };
 			return acc;
 		}, {});
 	}
@@ -123,17 +127,18 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
 	const localizedInfo = utils.getLocalizedLookupInfo(col.target, assocPaths, model);
 	if (localizedInfo) {
 		const textsWhere = { ...where, locale: { func: 'SESSION_CONTEXT', args: [{ val: 'LOCALE' }] } };
-		const textsQuery = SELECT.one.from(localizedInfo.textsEntity).columns(columns).where(textsWhere);
-		const baseQuery = SELECT.one.from(col.target).columns(columns).where(where);
+		const textsQuery = SELECT.from(localizedInfo.textsEntity).columns(columns).where(textsWhere);
+		const baseQuery = SELECT.from(col.target).columns(columns).where(where);
 		return `COALESCE((${toSQL(textsQuery, model)}), (${toSQL(baseQuery, model)}))`;
 	}
 
-	const query = SELECT.one.from(col.target).columns(columns).where(where);
+	const query = SELECT.from(col.target).columns(columns).where(where);
 	return `(${toSQL(query, model)})`;
 }
 
 /**
- * Returns SQL expression for a column's label (looked-up value for associations)
+ * Returns SQL expression for a column's label (looked-up value for associations).
+ * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function getLabelExpr(col, refRow, model) {
 	if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -153,7 +158,7 @@ function getLabelExpr(col, refRow, model) {
 			assocBatch.push(entry.path);
 		} else {
 			flushAssocBatch();
-			parts.push(`TO_NVARCHAR(:${refRow}.${entry.path})`);
+			parts.push(`TO_NVARCHAR(${refRow}.${entry.path})`);
 		}
 	}
 	flushAssocBatch();
@@ -162,12 +167,13 @@ function getLabelExpr(col, refRow, model) {
 }
 
 /**
- * Builds SQL expression for objectID (entity display name)
- * Uses @changelog annotation fields, falling back to entity name
+ * Builds SQL expression for objectID (entity display name).
+ * Uses @changelog annotation fields, falling back to entity name.
+ * rowRef is a table alias (e.g., 'nt' or 'ot') for statement-level triggers.
  */
 function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
-	const entityKeyExpr = compositeKeyExpr(keys.map((k) => `:${rowRef}.${k}`));
+	const entityKeyExpr = compositeKeyExpr(keys.map((k) => `${rowRef}.${k}`));
 
 	if (!objectIDs || objectIDs.length === 0) {
 		return entityKeyExpr;
@@ -176,13 +182,13 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const parts = [];
 	for (const oid of objectIDs) {
 		if (oid.included) {
-			parts.push(`COALESCE(TO_NVARCHAR(:${rowRef}.${oid.name}), '<empty>')`);
+			parts.push(`COALESCE(TO_NVARCHAR(${rowRef}.${oid.name}), '<empty>')`);
 		} else {
 			const where = keys.reduce((acc, k) => {
-				acc[k] = { val: `:${rowRef}.${k}` };
+				acc[k] = { val: `${rowRef}.${k}` };
 				return acc;
 			}, {});
-			const query = SELECT.one.from(entity.name).columns(oid.name).where(where);
+			const query = SELECT.from(entity.name).columns(oid.name).where(where);
 			parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
 		}
 	}
@@ -192,14 +198,15 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 }
 
 /**
- * Builds SQL expression for grandparent entity's objectID
- * Used when creating grandparent composition entries for deep linking
+ * Builds SQL expression for grandparent entity's objectID.
+ * Used when creating grandparent composition entries for deep linking.
+ * parentKeyBinding uses table alias references (e.g., 'nt.col') for statement-level triggers.
  */
 function buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, parentEntityName, parentKeyBinding, grandParentKeyBinding, rowRef, model) {
 	// Build WHERE clause to find the parent entity record (e.g., OrderItem from OrderItemNote's FK)
 	const parentEntity = model.definitions[parentEntityName];
 	const parentKeys = utils.extractKeys(parentEntity.keys);
-	const parentWhere = parentKeys.map((pk, i) => `${pk} = :${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
+	const parentWhere = parentKeys.map((pk, i) => `${pk} = ${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
 
 	// Build WHERE clause to find the grandparent entity record from parent
 	const grandParentKeys = utils.extractKeys(grandParentEntity.keys);
@@ -210,11 +217,17 @@ function buildGrandParentObjectIDExpr(grandParentObjectIDs, grandParentEntity, p
 		})
 		.join(' AND ');
 
+	// Build grandparent objectID using CQN for proper association path resolution
+	const grandParentWhere = {};
+	for (let i = 0; i < grandParentKeys.length; i++) {
+		const fkField = grandParentKeyBinding[i];
+		grandParentWhere[grandParentKeys[i]] = { val: `(SELECT ${fkField} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})` };
+	}
+
 	const parts = [];
 	for (const oid of grandParentObjectIDs) {
-		// Since we're using a raw WHERE string, we need to construct this manually
-		const selectSQL = `SELECT ${oid.name} FROM ${utils.transformName(grandParentEntity.name)} WHERE ${grandParentWhereSubquery}`;
-		parts.push(`COALESCE(TO_NVARCHAR((${selectSQL})), '')`);
+		const query = SELECT.from(grandParentEntity.name).columns(oid.name).where(grandParentWhere);
+		parts.push(`COALESCE(TO_NVARCHAR((${toSQL(query, model)})), '')`);
 	}
 
 	const concatLogic = parts.join(" || ', ' || ");

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -7,21 +7,21 @@ const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompos
 
 /**
  * Returns the FROM clause for statement-level trigger sub-SELECTs.
- * - For 'create': FROM :new_tab nt
- * - For 'delete': FROM :old_tab ot
- * - For 'update': FROM :new_tab nt INNER JOIN :old_tab ot ON nt.key1 = ot.key1 [AND nt.key2 = ot.key2 ...]
+ * - For 'create': FROM :new_tab newTable
+ * - For 'delete': FROM :old_tab oldTable
+ * - For 'update': FROM :new_tab newTable INNER JOIN :old_tab oldTable ON newTable.key1 = oldTable.key1 [AND ...]
  */
 function getFromClause(entity, modification) {
 	const keys = utils.extractKeys(entity.keys);
 	if (modification === 'create') {
-		return 'FROM :new_tab nt';
+		return 'FROM :new_tab newTable';
 	}
 	if (modification === 'delete') {
-		return 'FROM :old_tab ot';
+		return 'FROM :old_tab oldTable';
 	}
 	// update: join new and old tables on keys
-	const joinCondition = keys.map((k) => `nt.${k} = ot.${k}`).join(' AND ');
-	return `FROM :new_tab nt INNER JOIN :old_tab ot ON ${joinCondition}`;
+	const joinCondition = keys.map((k) => `newTable.${k} = oldTable.${k}`).join(' AND ');
+	return `FROM :new_tab newTable INNER JOIN :old_tab oldTable ON ${joinCondition}`;
 }
 
 function buildTriggerContext(entity, objectIDs, rowRef, model) {
@@ -57,10 +57,10 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 		)`;
 			}
 
-			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'ot');
-			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'nt');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'ot', model, entity.name);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'nt', model, entity.name);
+			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'oldTable');
+			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'newTable');
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'oldTable', model, entity.name);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'newTable', model, entity.name);
 
 			const dataType = col.altExpression ? 'cds.String' : col.type;
 
@@ -88,10 +88,10 @@ function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null)
 }
 
 function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'nt', model, ancestorCompositionChain) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'newTable', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -117,10 +117,10 @@ END;`,
 }
 
 function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'nt', model, ancestorCompositionChain) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'newTable', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -155,10 +155,10 @@ END;`,
 }
 
 function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'oldTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, ancestorCompositionChain) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -185,12 +185,12 @@ END;`,
 
 function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const keys = utils.extractKeys(entity.keys);
-	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'oldTable', model);
 
-	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${compositeKeyExpr(keys.map((k) => `ot.${k}`))} FROM :old_tab ot);`;
+	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${compositeKeyExpr(keys.map((k) => `oldTable.${k}`))} FROM :old_tab oldTable);`;
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, ancestorCompositionChain) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Special wrapping for delete - need variable declared if using composition

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -183,8 +183,6 @@ END;`,
 
 function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
 	const keys = utils.extractKeys(entity.keys);
-	const entityKey = compositeKeyExpr(keys.map((k) => `ot.${k}`));
-
 	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
 
 	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${compositeKeyExpr(keys.map((k) => `ot.${k}`))} FROM :old_tab ot);`;

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const utils = require('../utils/change-tracking.js');
 const config = cds.env.requires['change-tracking'];
-const { getCompositionParentInfo, getGrandParentCompositionInfo } = require('../utils/composition-helpers.js');
+const { getCompositionParentInfo, getAncestorCompositionChain } = require('../utils/composition-helpers.js');
 const { getSkipCheckCondition, getElementSkipCondition, compositeKeyExpr, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr } = require('./sql-expressions.js');
 const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody } = require('./composition.js');
 
@@ -87,11 +87,11 @@ function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null)
 	END IF;`;
 }
 
-function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
+function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'nt', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'nt', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -116,11 +116,11 @@ END;`,
 	};
 }
 
-function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
+function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'nt', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'nt', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -154,11 +154,11 @@ END;`,
 	};
 }
 
-function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
+function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
@@ -183,14 +183,14 @@ END;`,
 	};
 }
 
-function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
+function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const keys = utils.extractKeys(entity.keys);
 	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
 
 	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${compositeKeyExpr(keys.map((k) => `ot.${k}`))} FROM :old_tab ot);`;
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, ancestorCompositionChain) : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Special wrapping for delete - need variable declared if using composition
@@ -240,23 +240,23 @@ function generateHANATriggers(csn, entity, rootEntity = null, mergedAnnotations 
 	// Check if this entity is a composition target with @changelog on the composition field
 	const compositionParentInfo = getCompositionParentInfo(entity, rootEntity, rootMergedAnnotations);
 
-	// Get grandparent info for deep linking (e.g., OrderItemNote -> OrderItem.notes -> Order.orderItems)
-	const { grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField } = grandParentContext;
-	const grandParentCompositionInfo = getGrandParentCompositionInfo(rootEntity, grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField);
+	// Resolve full ancestor composition chain for deep linking
+	const { ancestorChain } = grandParentContext;
+	const ancestorCompositionChain = getAncestorCompositionChain(rootEntity, ancestorChain ?? [], csn);
 
 	// Skip if no tracked columns and not a composition target with tracked composition
 	if (trackedColumns.length === 0 && !compositionParentInfo) return triggers;
 
 	// Generate triggers - either for tracked columns or for composition-only tracking
 	if (!config?.disableCreateTracking) {
-		triggers.push(generateCreateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+		triggers.push(generateCreateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 	}
 	if (!config?.disableUpdateTracking) {
-		triggers.push(generateUpdateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+		triggers.push(generateUpdateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 	}
 	if (!config?.disableDeleteTracking) {
 		const generateDeleteTriggerFunc = config?.preserveDeletes ? generateDeleteTriggerPreserve : generateDeleteTrigger;
-		triggers.push(generateDeleteTriggerFunc(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+		triggers.push(generateDeleteTriggerFunc(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 	}
 
 	return triggers;

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -5,17 +5,39 @@ const { getCompositionParentInfo, getGrandParentCompositionInfo } = require('../
 const { getSkipCheckCondition, getElementSkipCondition, compositeKeyExpr, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr } = require('./sql-expressions.js');
 const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody } = require('./composition.js');
 
-function buildTriggerContext(entity, objectIDs, rowRef, model, compositionParentInfo = null) {
+/**
+ * Returns the FROM clause for statement-level trigger sub-SELECTs.
+ * - For 'create': FROM :new_tab nt
+ * - For 'delete': FROM :old_tab ot
+ * - For 'update': FROM :new_tab nt INNER JOIN :old_tab ot ON nt.key1 = ot.key1 [AND nt.key2 = ot.key2 ...]
+ */
+function getFromClause(entity, modification) {
+	const keys = utils.extractKeys(entity.keys);
+	if (modification === 'create') {
+		return 'FROM :new_tab nt';
+	}
+	if (modification === 'delete') {
+		return 'FROM :old_tab ot';
+	}
+	// update: join new and old tables on keys
+	const joinCondition = keys.map((k) => `nt.${k} = ot.${k}`).join(' AND ');
+	return `FROM :new_tab nt INNER JOIN :old_tab ot ON ${joinCondition}`;
+}
+
+function buildTriggerContext(entity, objectIDs, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
 	return {
-		entityKeyExpr: compositeKeyExpr(keys.map((k) => `:${rowRef}.${k}`)),
+		entityKeyExpr: compositeKeyExpr(keys.map((k) => `${rowRef}.${k}`)),
 		objectIDExpr: buildObjectIDExpr(objectIDs, entity, rowRef, model),
-		parentLookupExpr: compositionParentInfo !== null ? 'parent_id' : null
+		parentLookupExpr: null
 	};
 }
 
 function buildInsertSQL(entity, columns, modification, ctx, model) {
+	const fromClause = getFromClause(entity, modification);
+
 	// Generate single UNION ALL query for all changed columns
+	// Each sub-SELECT produces all columns needed for the INSERT, including per-row entity key and objectID
 	const unionQuery = columns
 		.map((col) => {
 			const whereCondition = getWhereCondition(col, modification);
@@ -35,43 +57,25 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 		)`;
 			}
 
-			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
-			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model);
+			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'ot');
+			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'nt');
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'ot', model);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'nt', model);
 
-			return `SELECT '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${col.type}' AS valueDataType FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY WHERE ${fullWhere}`;
+			return `SELECT SYSUUID AS ID, ${ctx.parentLookupExpr} AS parent_ID, '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${entity.name}' AS entity, ${ctx.entityKeyExpr} AS entityKey, ${ctx.objectIDExpr} AS objectID, CURRENT_TIMESTAMP AS createdAt, SESSION_CONTEXT('APPLICATIONUSER') AS createdBy, '${col.type}' AS valueDataType, '${modification}' AS modification, CURRENT_UPDATE_TRANSACTION() AS transactionID ${fromClause} WHERE ${fullWhere}`;
 		})
 		.join('\nUNION ALL\n');
 
 	return `INSERT INTO SAP_CHANGELOG_CHANGES
 		(ID, parent_ID, attribute, valueChangedFrom, valueChangedTo, valueChangedFromLabel, valueChangedToLabel, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-		SELECT
-			SYSUUID,
-			${ctx.parentLookupExpr},
-			attribute,
-			valueChangedFrom,
-			valueChangedTo,
-			valueChangedFromLabel,
-			valueChangedToLabel,
-			'${entity.name}',
-			${ctx.entityKeyExpr},
-			${ctx.objectIDExpr},
-			CURRENT_TIMESTAMP,
-			SESSION_CONTEXT('APPLICATIONUSER'),
-			valueDataType,
-			'${modification}',
-			CURRENT_UPDATE_TRANSACTION()
-		FROM (
-			${unionQuery}
-		);`;
+		${unionQuery};`;
 }
 
 function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null) {
 	if (compositionParentContext) {
 		const { declares } = compositionParentContext;
-		return `${declares}
-	IF ${getSkipCheckCondition(entityName)} THEN
+		const declareBlock = declares ? `${declares}\n\t` : '';
+		return `${declareBlock}IF ${getSkipCheckCondition(entityName)} THEN
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 		${insertSQL}
 	END IF;`;
@@ -82,10 +86,11 @@ function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null)
 }
 
 function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
+	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'new', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'nt', model, grandParentCompositionInfo) : null;
+	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
@@ -100,7 +105,8 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_CREATE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_CREATE AFTER INSERT
 ON ${utils.transformName(entity.name)}
-REFERENCING NEW ROW new
+REFERENCING NEW TABLE new_tab
+FOR EACH STATEMENT
 BEGIN
 	${body}
 END;`,
@@ -109,10 +115,11 @@ END;`,
 }
 
 function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
+	const ctx = buildTriggerContext(entity, objectIDs, 'nt', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'new', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'nt', model, grandParentCompositionInfo) : null;
+	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
@@ -136,7 +143,8 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_UPDATE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_UPDATE AFTER UPDATE ${ofClause}
 ON ${utils.transformName(entity.name)}
-REFERENCING NEW ROW new, OLD ROW old
+REFERENCING NEW TABLE new_tab, OLD TABLE old_tab
+FOR EACH STATEMENT
 BEGIN
 	${body}
 END;`,
@@ -145,10 +153,11 @@ END;`,
 }
 
 function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
+	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, grandParentCompositionInfo) : null;
+	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
@@ -163,7 +172,8 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 		name: entity.name + '_CT_DELETE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_DELETE AFTER DELETE
 ON ${utils.transformName(entity.name)}
-REFERENCING OLD ROW old
+REFERENCING OLD TABLE old_tab
+FOR EACH STATEMENT
 BEGIN
 	${body}
 END;`,
@@ -173,14 +183,15 @@ END;`,
 
 function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
 	const keys = utils.extractKeys(entity.keys);
-	const entityKey = compositeKeyExpr(keys.map((k) => `:old.${k}`));
+	const entityKey = compositeKeyExpr(keys.map((k) => `ot.${k}`));
 
-	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
+	const ctx = buildTriggerContext(entity, objectIDs, 'ot', model);
 
-	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey = ${entityKey};`;
+	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${compositeKeyExpr(keys.map((k) => `ot.${k}`))} FROM :old_tab ot);`;
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, grandParentCompositionInfo) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'ot', model, grandParentCompositionInfo) : null;
+	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
 
 	// Special wrapping for delete - need variable declared if using composition
 	let body;
@@ -191,8 +202,8 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		// Mixed case: both composition parent entry and child column inserts
 		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
 		const { declares } = compositionParentContext;
-		body = `${declares}
-	IF ${getSkipCheckCondition(entity.name)} THEN
+		const declareBlock = declares ? `${declares}\n\t` : '';
+		body = `${declareBlock}IF ${getSkipCheckCondition(entity.name)} THEN
 		${deleteSQL}
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 		${insertSQL}
@@ -207,7 +218,8 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_DELETE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_DELETE AFTER DELETE
 ON ${utils.transformName(entity.name)}
-REFERENCING OLD ROW old
+REFERENCING OLD TABLE old_tab
+FOR EACH STATEMENT
 BEGIN
 	${body}
 END;`,

--- a/lib/postgres/composition.js
+++ b/lib/postgres/composition.js
@@ -4,17 +4,20 @@ const { toSQL, compositeKeyExpr } = require('./sql-expressions.js');
 /**
  * Builds rootObjectID select for composition of many
  */
-function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model) {
-	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `${refRow}.${k}`));
+function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
+	const keyValues = keyValueExprs ?? binding.map((k) => `${refRow}.${k}`);
+	const rootEntityKeyExpr = compositeKeyExpr(keyValues);
 
 	if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
 
 	const rootKeys = utils.extractKeys(rootEntity.keys);
-	if (rootKeys.length !== binding.length) return rootEntityKeyExpr;
+	if (rootKeys.length !== keyValues.length) return rootEntityKeyExpr;
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = { val: `${refRow}.${binding[i]}` };
+		where[rootKeys[i]] = keyValueExprs
+			? { val: keyValues[i], literal: 'sql' }
+			: { val: keyValues[i] };
 	}
 
 	const parts = [];
@@ -44,27 +47,11 @@ function buildCompositionOfOneParentBlock(compositionParentInfo, rootObjectIDs, 
 	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = rec.${childKeys[i]}`).join(' AND ');
 
 	// Build the parent key expression via subquery (reverse lookup)
-	const parentKeyExpr = compositeKeyExpr(parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`));
+	const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
+	const parentKeyExpr = compositeKeyExpr(parentKeySubqueries);
 
-	// Build rootObjectID expression for the parent entity
-	let rootObjectIDExpr;
-	if (rootObjectIDs?.length > 0) {
-		const oidSelects = rootObjectIDs.map((oid) => {
-			if (oid.expression) {
-				const exprColumn = utils.buildExpressionColumn(oid.expression);
-				const where = {};
-				for (let i = 0; i < parentFKFields.length; i++) {
-					where[parentFKFields[i]] = { val: `rec.${childKeys[i]}` };
-				}
-				const q = SELECT.one.from(parentEntityName).columns(exprColumn).where(where);
-				return `(${toSQL(q, model)})::TEXT`;
-			}
-			return `(SELECT ${oid.name}::TEXT FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`;
-		});
-		rootObjectIDExpr = oidSelects.length > 1 ? `CONCAT_WS(', ', ${oidSelects.join(', ')})` : oidSelects[0];
-	} else {
-		rootObjectIDExpr = parentKeyExpr;
-	}
+	// Build rootObjectID expression for the parent entity (reuse buildCompOfManyRootObjectIDSelect with subquery key values)
+	const rootObjectIDExpr = buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
 
 	// Build the composition parent block with dynamic modification determination
 	return `SELECT CASE WHEN COUNT(*) > 0 THEN 'create' ELSE 'update' END INTO comp_parent_modification
@@ -101,7 +88,7 @@ function buildCompositionOfOneParentBlock(compositionParentInfo, rootObjectIDs, 
             END IF;`;
 }
 
-function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modification, model, grandParentCompositionInfo = null) {
+function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modification, model, ancestorCompositionChain = []) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 
 	// Handle composition of one (parent has FK to child - need reverse lookup)
@@ -115,57 +102,111 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
 	const rootEntity = model.definitions[parentEntityName];
 	const rootObjectIDExpr = buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, parentKeyBinding, 'rec', model);
 
-	let grandparentBlock = '';
-	let grandparentLookupExpr = 'NULL';
+	if (ancestorCompositionChain.length > 0) {
+		// Build the full chain of ancestor levels.
+		// levels[0] = immediate parent, levels[1] = grandparent, levels[2] = great-grandparent, etc.
+		const levels = [
+			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
+			...ancestorCompositionChain
+		];
 
-	if (grandParentCompositionInfo) {
-		// When we have grandparent info, we need to:
-		// 1. Create grandparent entry (Order.orderItems) for current transaction if not exists
-		// 2. Create parent entry (OrderItem.notes) linking to the grandparent entry
-		const { grandParentEntityName, grandParentCompositionFieldName, grandParentKeyBinding } = grandParentCompositionInfo;
+		// Build key expressions for each level.
+		const keyExprs = [parentKeyExpr]; // level 0
+		const ancestorKeyValues = [parentKeyBinding.map((k) => `rec.${k}`)]; // level 0
 
-		// Build WHERE clause to find the parent entity record
-		const parentEntity = model.definitions[parentEntityName];
-		const parentKeys = utils.extractKeys(parentEntity.keys);
-		const parentWhere = parentKeys.map((pk, i) => `${pk} = rec.${parentKeyBinding[i]}`).join(' AND ');
+		const childWhereClauses = [];
+		const childEntity0 = model.definitions[levels[0].entityName];
+		const childKeys0 = utils.extractKeys(childEntity0.keys);
+		childWhereClauses.push(childKeys0.map((pk, j) => `${pk} = rec.${levels[0].keyBinding[j]}`).join(' AND '));
 
-		// Build the grandparent key expression from the parent record
-		const grandParentKeyExpr = compositeKeyExpr(grandParentKeyBinding.map((k) => `(SELECT ${k} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`));
+		for (let i = 1; i < levels.length; i++) {
+			const childLevel = levels[i - 1];
+			const ancestorLevel = levels[i];
+			const prevWhere = childWhereClauses[i - 1];
 
-		// Create grandparent entry if not exists in this transaction
-		grandparentBlock = `-- First ensure grandparent entry exists for this transaction
-            SELECT id INTO comp_grandparent_id FROM sap_changelog_changes WHERE entity = '${grandParentEntityName}'
-                AND entitykey = ${grandParentKeyExpr}
-                AND attribute = '${grandParentCompositionFieldName}'
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
+				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
+			);
+
+			const ancestorEntity = model.definitions[ancestorLevel.entityName];
+			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
+			const thisWhere = ancestorKeys.map((pk, j) => `${pk} = ${whereForAncestor[j]}`).join(' AND ');
+			childWhereClauses.push(thisWhere);
+
+			ancestorKeyValues.push(whereForAncestor);
+			keyExprs.push(compositeKeyExpr(whereForAncestor));
+		}
+
+		// Generate PL/pgSQL blocks from outermost ancestor down to the immediate parent.
+		// Each level uses a variable (comp_ancestor_N_id for ancestors, comp_parent_id for immediate parent)
+		// to hold its changelog entry ID.
+		const blocks = [];
+
+		for (let i = levels.length - 1; i >= 0; i--) {
+			const level = levels[i];
+			const levelKeyExpr = keyExprs[i];
+			const isOutermost = i === levels.length - 1;
+			const isImmediateParent = i === 0;
+
+			// Variable name for this level's changelog entry ID
+			const varName = isImmediateParent ? 'comp_parent_id' : `comp_ancestor_${i - 1}_id`;
+
+			// parent_id: NULL for outermost, variable from the level above for inner levels
+			let parentVarExpr;
+			if (isOutermost) {
+				parentVarExpr = 'NULL';
+			} else {
+				const parentIndex = i + 1;
+				parentVarExpr = parentIndex === levels.length - 1 && parentIndex !== 0
+					? `comp_ancestor_${parentIndex - 1}_id`
+					: `comp_ancestor_${parentIndex - 1}_id`;
+			}
+			// Simplify: outermost = NULL, immediate parent references ancestor_0, ancestor_0 references ancestor_1, etc.
+			if (!isOutermost) {
+				const parentLevelIndex = i + 1;
+				parentVarExpr = parentLevelIndex === 0 ? 'comp_parent_id' : `comp_ancestor_${parentLevelIndex - 1}_id`;
+			}
+
+			const modExpr = isImmediateParent ? `'${modification}'` : "'update'";
+
+			// objectID: resolve from the entity's @changelog annotation
+			let objectIDExpr;
+			if (isImmediateParent) {
+				objectIDExpr = rootObjectIDExpr;
+			} else {
+				const ancestorEntity = model.definitions[level.entityName];
+				objectIDExpr = buildCompOfManyRootObjectIDSelect(ancestorEntity, level.objectIDs, null, null, model, ancestorKeyValues[i]);
+			}
+
+			blocks.push(`SELECT id INTO ${varName} FROM sap_changelog_changes WHERE entity = '${level.entityName}'
+                AND entitykey = ${levelKeyExpr}
+                AND attribute = '${level.compositionFieldName}'
                 AND valuedatatype = 'cds.Composition'
                 AND transactionid = transaction_id;
-            IF comp_grandparent_id IS NULL THEN
-                comp_grandparent_id := gen_random_uuid();
+            IF ${varName} IS NULL THEN
+                ${varName} := gen_random_uuid();
                 INSERT INTO sap_changelog_changes
                     (ID, PARENT_ID, ATTRIBUTE, ENTITY, ENTITYKEY, OBJECTID, CREATEDAT, CREATEDBY, VALUEDATATYPE, MODIFICATION, TRANSACTIONID)
                     VALUES (
-                        comp_grandparent_id,
-                        NULL,
-                        '${grandParentCompositionFieldName}',
-                        '${grandParentEntityName}',
-                        ${grandParentKeyExpr},
-                        ${grandParentKeyExpr},
+                        ${varName},
+                        ${parentVarExpr},
+                        '${level.compositionFieldName}',
+                        '${level.entityName}',
+                        ${levelKeyExpr},
+                        ${objectIDExpr},
                         now(),
                         user_id,
                         'cds.Composition',
-                        'update',
+                        ${modExpr},
                         transaction_id
                     );
-            END IF;`;
-
-		grandparentLookupExpr = 'comp_grandparent_id';
+            END IF;`);
+		}
+		return blocks.join('\n            ');
 	}
 
-	// Determine modification dynamically: 'create' if parent was just created, 'update' otherwise
-	// This handles both deep insert (parent created in same tx) and independent insert (parent already existed)
-	const modificationExpr = grandParentCompositionInfo
-		? `'${modification}'` // When grandparent exists, use provided modification
-		: `CASE WHEN EXISTS (
+	// No ancestors — single parent level
+	const modificationExpr = `CASE WHEN EXISTS (
                     SELECT 1 FROM sap_changelog_changes
                     WHERE entity = '${parentEntityName}'
                     AND entitykey = ${parentKeyExpr}
@@ -173,9 +214,7 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
                     AND transactionid = transaction_id
                 ) THEN 'create' ELSE 'update' END`;
 
-	// PL/pgSQL block that checks for existing parent entry and creates one if needed
-	return `${grandparentBlock}
-            SELECT id INTO comp_parent_id FROM sap_changelog_changes WHERE entity = '${parentEntityName}'
+	return `SELECT id INTO comp_parent_id FROM sap_changelog_changes WHERE entity = '${parentEntityName}'
                 AND entitykey = ${parentKeyExpr}
                 AND attribute = '${compositionFieldName}'
                 AND valuedatatype = 'cds.Composition'
@@ -186,7 +225,7 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
                     (ID, PARENT_ID, ATTRIBUTE, ENTITY, ENTITYKEY, OBJECTID, CREATEDAT, CREATEDBY, VALUEDATATYPE, MODIFICATION, TRANSACTIONID)
                     VALUES (
                         comp_parent_id,
-                        ${grandparentLookupExpr},
+                        NULL,
                         '${compositionFieldName}',
                         '${parentEntityName}',
                         ${parentKeyExpr},

--- a/lib/postgres/composition.js
+++ b/lib/postgres/composition.js
@@ -15,9 +15,7 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = keyValueExprs
-			? { val: keyValues[i], literal: 'sql' }
-			: { val: keyValues[i] };
+		where[rootKeys[i]] = keyValueExprs ? { val: keyValues[i], literal: 'sql' } : { val: keyValues[i] };
 	}
 
 	const parts = [];
@@ -105,10 +103,7 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
 	if (ancestorCompositionChain.length > 0) {
 		// Build the full chain of ancestor levels.
 		// levels[0] = immediate parent, levels[1] = grandparent, levels[2] = great-grandparent, etc.
-		const levels = [
-			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
-			...ancestorCompositionChain
-		];
+		const levels = [{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding }, ...ancestorCompositionChain];
 
 		// Build key expressions for each level.
 		const keyExprs = [parentKeyExpr]; // level 0
@@ -124,9 +119,7 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
 			const ancestorLevel = levels[i];
 			const prevWhere = childWhereClauses[i - 1];
 
-			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
-				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
-			);
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
 
 			const ancestorEntity = model.definitions[ancestorLevel.entityName];
 			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
@@ -157,9 +150,7 @@ function buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, modif
 				parentVarExpr = 'NULL';
 			} else {
 				const parentIndex = i + 1;
-				parentVarExpr = parentIndex === levels.length - 1 && parentIndex !== 0
-					? `comp_ancestor_${parentIndex - 1}_id`
-					: `comp_ancestor_${parentIndex - 1}_id`;
+				parentVarExpr = parentIndex === levels.length - 1 && parentIndex !== 0 ? `comp_ancestor_${parentIndex - 1}_id` : `comp_ancestor_${parentIndex - 1}_id`;
 			}
 			// Simplify: outermost = NULL, immediate parent references ancestor_0, ancestor_0 references ancestor_1, etc.
 			if (!isOutermost) {

--- a/lib/postgres/triggers.js
+++ b/lib/postgres/triggers.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const utils = require('../utils/change-tracking.js');
-const { getCompositionParentInfo, getGrandParentCompositionInfo } = require('../utils/composition-helpers.js');
+const { getCompositionParentInfo, getAncestorCompositionChain } = require('../utils/composition-helpers.js');
 const { getSkipCheckCondition, compositeKeyExpr, buildObjectIDAssignment, buildInsertBlock, extractTrackedDbColumns } = require('./sql-expressions.js');
 const { buildCompositionParentBlock } = require('./composition.js');
 const config = cds.env.requires['change-tracking'];
@@ -8,7 +8,7 @@ const config = cds.env.requires['change-tracking'];
 /**
  * Generates the PL/pgSQL function body for the main change tracking trigger
  */
-function buildFunctionBody(entity, columns, objectIDs, rootEntity, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
+function buildFunctionBody(entity, columns, objectIDs, rootEntity, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const keys = utils.extractKeys(entity.keys);
 	const entityKeyExpr = compositeKeyExpr(keys.map((k) => `rec.${k}`));
 
@@ -20,9 +20,9 @@ function buildFunctionBody(entity, columns, objectIDs, rootEntity, rootObjectIDs
 	const deleteBlock = columns.length > 0 ? buildInsertBlock(columns, 'delete', entity, model, hasCompositionParent) : '';
 
 	// Build composition parent blocks if needed
-	const createParentBlock = compositionParentInfo && !config?.disableCreateTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'create', model, grandParentCompositionInfo) : '';
-	const updateParentBlock = compositionParentInfo && !config?.disableUpdateTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'update', model, grandParentCompositionInfo) : '';
-	const deleteParentBlock = compositionParentInfo && !config?.disableDeleteTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'delete', model, grandParentCompositionInfo) : '';
+	const createParentBlock = compositionParentInfo && !config?.disableCreateTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'create', model, ancestorCompositionChain) : '';
+	const updateParentBlock = compositionParentInfo && !config?.disableUpdateTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'update', model, ancestorCompositionChain) : '';
+	const deleteParentBlock = compositionParentInfo && !config?.disableDeleteTracking ? buildCompositionParentBlock(compositionParentInfo, rootObjectIDs, 'delete', model, ancestorCompositionChain) : '';
 
 	return `
         DECLARE
@@ -63,9 +63,9 @@ function generatePostgresTriggers(csn, entity, rootEntity, mergedAnnotations = n
 	// Check if this entity is a tracked composition target (composition-of-many)
 	const compositionParentInfo = getCompositionParentInfo(entity, rootEntity, rootMergedAnnotations);
 
-	// Get grandparent info for deep linking (e.g., OrderItemNote -> OrderItem.notes -> Order.orderItems)
-	const { grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField } = grandParentContext;
-	const grandParentCompositionInfo = getGrandParentCompositionInfo(rootEntity, grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField);
+	// Resolve full ancestor composition chain for deep linking
+	const { ancestorChain } = grandParentContext;
+	const ancestorCompositionChain = getAncestorCompositionChain(rootEntity, ancestorChain ?? [], csn);
 
 	// Generate triggers if we have tracked columns OR if this is a composition target
 	const shouldGenerateTriggers = trackedColumns.length > 0 || compositionParentInfo;
@@ -75,12 +75,12 @@ function generatePostgresTriggers(csn, entity, rootEntity, mergedAnnotations = n
 	const triggerName = `${tableName}_tr_change`;
 	const functionName = `${tableName}_func_change`;
 
-	const funcBody = buildFunctionBody(entity, trackedColumns, objectIDs, rootEntity, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo);
+	const funcBody = buildFunctionBody(entity, trackedColumns, objectIDs, rootEntity, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain);
 
-	// Include comp_parent_id, comp_parent_modification and comp_grandparent_id variable declarations if needed
+	// Include variable declarations for composition parent and ancestor IDs
 	const parentIdDecl = compositionParentInfo ? 'comp_parent_id UUID := NULL;' : '';
 	const parentModificationDecl = compositionParentInfo?.parentKeyBinding?.type === 'compositionOfOne' ? 'comp_parent_modification TEXT;' : '';
-	const grandparentIdDecl = grandParentCompositionInfo ? 'comp_grandparent_id UUID := NULL;' : '';
+	const ancestorIdDecls = ancestorCompositionChain.map((_, i) => `comp_ancestor_${i}_id UUID := NULL;`).join('\n        ');
 
 	const createFunction = `CREATE OR REPLACE FUNCTION ${functionName}() RETURNS TRIGGER AS $$
     DECLARE
@@ -91,7 +91,7 @@ function generatePostgresTriggers(csn, entity, rootEntity, mergedAnnotations = n
         transaction_id BIGINT := txid_current();
         ${parentIdDecl}
         ${parentModificationDecl}
-        ${grandparentIdDecl}
+        ${ancestorIdDecls}
     BEGIN
         ${funcBody}
         RETURN NULL;

--- a/lib/sqlite/composition.js
+++ b/lib/sqlite/composition.js
@@ -2,19 +2,30 @@ const utils = require('../utils/change-tracking.js');
 const { toSQL, compositeKeyExpr } = require('./sql-expressions.js');
 
 /**
- * Builds rootObjectID select for composition of many
+ * Builds rootObjectID select for composition of many.
+ * @param {object} rootEntity - The entity to look up objectIDs from
+ * @param {Array} rootObjectIDs - The @changelog objectID definitions
+ * @param {Array} binding - FK column names on the child entity (e.g., ['parent_ID'])
+ * @param {string} refRow - Trigger row reference (e.g., 'new' or 'old')
+ * @param {object} model - The CDS model
+ * @param {Array} [keyValueExprs] - Optional pre-built key value expressions (e.g., subquery strings).
+ *   When provided, used instead of computing `${refRow}.${binding[i]}` for each key.
+ *   Uses `literal: 'sql'` to prevent CQN from quoting subquery expressions as string literals.
  */
-function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model) {
-	const rootEntityKeyExpr = compositeKeyExpr(binding.map((k) => `${refRow}.${k}`));
+function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
+	const keyValues = keyValueExprs ?? binding.map((k) => `${refRow}.${k}`);
+	const rootEntityKeyExpr = compositeKeyExpr(keyValues);
 
 	if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
 
 	const rootKeys = utils.extractKeys(rootEntity.keys);
-	if (rootKeys.length !== binding.length) return rootEntityKeyExpr;
+	if (rootKeys.length !== keyValues.length) return rootEntityKeyExpr;
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = { val: `${refRow}.${binding[i]}` };
+		where[rootKeys[i]] = keyValueExprs
+			? { val: keyValues[i], literal: 'sql' }
+			: { val: keyValues[i] };
 	}
 
 	// Clone to avoid mutation
@@ -45,28 +56,11 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${rowRef}.${childKeys[i]}`).join(' AND ');
 
 	// Build the parent key expression via subquery (reverse lookup)
-	const parentKeyExpr = compositeKeyExpr(parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`));
+	const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${pk} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
+	const parentKeyExpr = compositeKeyExpr(parentKeySubqueries);
 
 	// Build rootObjectID expression for the parent entity
-	let rootObjectIDExpr;
-	if (rootObjectIDs?.length > 0) {
-		const oidSelects = rootObjectIDs.map((oid) => {
-			if (oid.expression) {
-				// Expression-based ObjectID: use CQN subquery
-				const exprColumn = utils.buildExpressionColumn(oid.expression);
-				const where = {};
-				for (let i = 0; i < parentFKFields.length; i++) {
-					where[parentFKFields[i]] = { val: `${rowRef}.${childKeys[i]}` };
-				}
-				const q = SELECT.one.from(parentEntityName).columns(exprColumn).where(where);
-				return `(${toSQL(q, model)})`;
-			}
-			return `(SELECT ${oid.name} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`;
-		});
-		rootObjectIDExpr = oidSelects.length > 1 ? oidSelects.join(" || ', ' || ") : oidSelects[0];
-	} else {
-		rootObjectIDExpr = parentKeyExpr;
-	}
+	const rootObjectIDExpr = buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
 
 	const modificationExpr = `CASE WHEN EXISTS (
 			SELECT 1 FROM sap_changelog_Changes
@@ -115,7 +109,7 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	return { insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
-function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, grandParentCompositionInfo = null) {
+function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = []) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 
 	// Handle composition of one (parent has FK to child - need reverse lookup)
@@ -131,75 +125,117 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 
 	let insertSQL;
 
-	if (grandParentCompositionInfo) {
-		const { grandParentEntityName, grandParentCompositionFieldName, grandParentKeyBinding } = grandParentCompositionInfo;
-		const parentEntity = model.definitions[parentEntityName];
-		const parentKeys = utils.extractKeys(parentEntity.keys);
-		const parentWhere = parentKeys.map((pk, i) => `${pk} = ${rowRef}.${parentKeyBinding[i]}`).join(' AND ');
+	if (ancestorCompositionChain.length > 0) {
+		// Build the full chain of ancestor levels.
+		// levels[0] = immediate parent (compositionParentInfo)
+		// levels[1] = grandparent (ancestorCompositionChain[0])
+		// levels[2] = great-grandparent (ancestorCompositionChain[1])
+		
+		const levels = [
+			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
+			...ancestorCompositionChain
+		];
 
-		// Build the grandparent key expression from the parent record
-		const grandParentKeyExpr = compositeKeyExpr(grandParentKeyBinding.map((k) => `(SELECT ${k} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhere})`));
+		// Build key expressions for each level.
+		const keyExprs = [parentKeyExpr]; // level 0
 
-		// Build expression for grandparent lookup (for linking parent entry to it)
-		// Must filter by createdAt to get entry from current transaction
-		const grandParentLookupExpr = `(SELECT ID FROM sap_changelog_Changes
-			WHERE entity = '${grandParentEntityName}'
-			AND entityKey = ${grandParentKeyExpr}
-			AND attribute = '${grandParentCompositionFieldName}'
-			AND valueDataType = 'cds.Composition'
-			AND createdBy = session_context('$user.id')
-			AND createdAt = session_context('$now')
-			ORDER BY createdAt DESC LIMIT 1)`;
+		// For each level, we also need to know the WHERE clause to find the child record
+		// childWhereClause[i] = WHERE clause on level[i]'s table to find the record for this trigger row
+		const childWhereClauses = [];
+		// ancestorKeyValues[i] = array of raw SQL expressions that resolve each key of level[i]'s entity
+		// Used for both keyExprs and objectID resolution via buildCompOfManyRootObjectIDSelect
+		const ancestorKeyValues = [parentKeyBinding.map((k) => `${rowRef}.${k}`)]; // level 0
 
-		// First insert grandparent entry if not exists
-		const grandParentInsertSQL = `INSERT INTO sap_changelog_Changes (ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT
-				hex(randomblob(16)),
-				NULL,
-				'${grandParentCompositionFieldName}',
-				'${grandParentEntityName}',
-				${grandParentKeyExpr},
-				${grandParentKeyExpr},
-				session_context('$now'),
-				session_context('$user.id'),
-				'cds.Composition',
-				'update',
-				session_context('$now')
-			WHERE NOT EXISTS (
-				SELECT 1 FROM sap_changelog_Changes
-				WHERE entity = '${grandParentEntityName}'
-				AND entityKey = ${grandParentKeyExpr}
-				AND attribute = '${grandParentCompositionFieldName}'
+		// Level 0: find Level1Sample record using trigger row FK
+		const childEntity0 = model.definitions[levels[0].entityName];
+		const childKeys0 = utils.extractKeys(childEntity0.keys);
+		childWhereClauses.push(childKeys0.map((pk, j) => `${pk} = ${rowRef}.${levels[0].keyBinding[j]}`).join(' AND '));
+
+		for (let i = 1; i < levels.length; i++) {
+			const childLevel = levels[i - 1];
+			const ancestorLevel = levels[i];
+
+			// WHERE clause to find the child level's record: use the previous level's WHERE to navigate up
+			const prevWhere = childWhereClauses[i - 1];
+
+			// The ancestor key is found by using preWhere
+			// SELECT ancestorLevel.keyBinding FROM childLevel.table WHERE prevWhere
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
+				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
+			);
+
+			const ancestorEntity = model.definitions[ancestorLevel.entityName];
+			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
+			const thisWhere = ancestorKeys.map((pk, j) => `${pk} = ${whereForAncestor[j]}`).join(' AND ');
+			childWhereClauses.push(thisWhere);
+
+			ancestorKeyValues.push(whereForAncestor);
+			keyExprs.push(compositeKeyExpr(whereForAncestor));
+		}
+
+		// Generate INSERT statements from outermost ancestor down to the immediate parent
+		const insertStatements = [];
+
+		for (let i = levels.length - 1; i >= 0; i--) {
+			const level = levels[i];
+			const levelKeyExpr = keyExprs[i];
+			const isOutermost = i === levels.length - 1;
+			const isImmediateParent = i === 0;
+
+			// parent_ID: NULL for outermost, lookup for inner levels
+			let parentIDExpr;
+			if (isOutermost) {
+				parentIDExpr = 'NULL';
+			} else {
+				const parentLevel = levels[i + 1];
+				const parentLevelKeyExpr = keyExprs[i + 1];
+				parentIDExpr = `(SELECT ID FROM sap_changelog_Changes
+				WHERE entity = '${parentLevel.entityName}'
+				AND entityKey = ${parentLevelKeyExpr}
+				AND attribute = '${parentLevel.compositionFieldName}'
 				AND valueDataType = 'cds.Composition'
 				AND createdBy = session_context('$user.id')
 				AND createdAt = session_context('$now')
-			);`;
+				ORDER BY createdAt DESC LIMIT 1)`;
+			}
 
-		// Then insert parent entry linking to grandparent
-		const parentInsertSQL = `INSERT INTO sap_changelog_Changes (ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+			// Immediate parent use the actual modification type, ancestors use 'update' (they are just being touched, not created/deleted)
+			const modExpr = isImmediateParent ? `'${modification}'` : "'update'";
+
+			// objectID: resolve from the entity's @changelog annotation via buildCompOfManyRootObjectIDSelect
+			let objectIDExpr;
+			if (isImmediateParent) {
+				objectIDExpr = rootObjectIDExpr;
+			} else {
+				const ancestorEntity = model.definitions[level.entityName];
+				objectIDExpr = buildCompOfManyRootObjectIDSelect(ancestorEntity, level.objectIDs, null, null, model, ancestorKeyValues[i]);
+			}
+
+			insertStatements.push(`INSERT INTO sap_changelog_Changes (ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
 			SELECT
 				hex(randomblob(16)),
-				${grandParentLookupExpr},
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${rootObjectIDExpr},
+				${parentIDExpr},
+				'${level.compositionFieldName}',
+				'${level.entityName}',
+				${levelKeyExpr},
+				${objectIDExpr},
 				session_context('$now'),
 				session_context('$user.id'),
 				'cds.Composition',
-				'${modification}',
+				${modExpr},
 				session_context('$now')
 			WHERE NOT EXISTS (
 				SELECT 1 FROM sap_changelog_Changes
-				WHERE entity = '${parentEntityName}'
-				AND entityKey = ${parentKeyExpr}
-				AND attribute = '${compositionFieldName}'
+				WHERE entity = '${level.entityName}'
+				AND entityKey = ${levelKeyExpr}
+				AND attribute = '${level.compositionFieldName}'
 				AND valueDataType = 'cds.Composition'
 				AND createdBy = session_context('$user.id')
 				AND createdAt = session_context('$now')
-			);`;
+			);`);
+		}
 
-		insertSQL = `${grandParentInsertSQL}\n        ${parentInsertSQL}`;
+		insertSQL = insertStatements.join('\n        ');
 	} else {
 		const modificationExpr = `CASE WHEN EXISTS (
 				SELECT 1 FROM sap_changelog_Changes

--- a/lib/sqlite/composition.js
+++ b/lib/sqlite/composition.js
@@ -23,9 +23,7 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 
 	const where = {};
 	for (let i = 0; i < rootKeys.length; i++) {
-		where[rootKeys[i]] = keyValueExprs
-			? { val: keyValues[i], literal: 'sql' }
-			: { val: keyValues[i] };
+		where[rootKeys[i]] = keyValueExprs ? { val: keyValues[i], literal: 'sql' } : { val: keyValues[i] };
 	}
 
 	// Clone to avoid mutation
@@ -130,11 +128,8 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 		// levels[0] = immediate parent (compositionParentInfo)
 		// levels[1] = grandparent (ancestorCompositionChain[0])
 		// levels[2] = great-grandparent (ancestorCompositionChain[1])
-		
-		const levels = [
-			{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding },
-			...ancestorCompositionChain
-		];
+
+		const levels = [{ entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding }, ...ancestorCompositionChain];
 
 		// Build key expressions for each level.
 		const keyExprs = [parentKeyExpr]; // level 0
@@ -160,9 +155,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 
 			// The ancestor key is found by using preWhere
 			// SELECT ancestorLevel.keyBinding FROM childLevel.table WHERE prevWhere
-			const whereForAncestor = ancestorLevel.keyBinding.map((fk) =>
-				`(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`
-			);
+			const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT ${fk} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
 
 			const ancestorEntity = model.definitions[ancestorLevel.entityName];
 			const ancestorKeys = utils.extractKeys(ancestorEntity.keys);

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -136,7 +136,13 @@ function getLabelExpr(col, refRow, entityKey, model, entityName = null) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
 	if (col.altExpression && entityName) {
 		const SQLiteService = require('@cap-js/sqlite');
-		return buildExpressionSQL(col.altExpression, entityName, refRow, model, SQLiteService.CQN2SQL, toSQL);
+		const exprSQL = buildExpressionSQL(col.altExpression, entityName, refRow, model, SQLiteService.CQN2SQL, toSQL);
+		// Preserve decimal scale for arithmetic expressions on Decimal columns
+		// SQLite loses fractional digits when evaluating numeric expressions (e.g. 50 * 2 → 100).
+		if (col.type === 'cds.Decimal' && col.scale != null) {
+			return `CASE WHEN (${exprSQL}) IS NOT NULL THEN PRINTF('%.${col.scale}f', ${exprSQL}) ELSE NULL END`;
+		}
+		return exprSQL;
 	}
 
 	if (!col.alt || col.alt.length === 0) return 'NULL';

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -1,11 +1,11 @@
 const utils = require('../utils/change-tracking.js');
 const config = require('@sap/cds').env.requires['change-tracking'];
-const { getCompositionParentInfo, getGrandParentCompositionInfo } = require('../utils/composition-helpers.js');
+const { getCompositionParentInfo, getAncestorCompositionChain } = require('../utils/composition-helpers.js');
 const { getSkipCheckCondition, buildTriggerContext, buildInsertSQL } = require('./sql-expressions.js');
 const { buildCompositionParentContext } = require('./composition.js');
 
-function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'new', model, grandParentCompositionInfo) : null;
+function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'new', model, ancestorCompositionChain) : null;
 	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
 
 	// Replace placeholder with actual parent lookup expression if needed
@@ -32,8 +32,8 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
     END;`;
 }
 
-function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'new', model, grandParentCompositionInfo) : null;
+function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'new', model, ancestorCompositionChain) : null;
 	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
 
 	// Replace placeholder with actual parent lookup expression if needed
@@ -69,8 +69,8 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
     END;`;
 }
 
-function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, grandParentCompositionInfo) : null;
+function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, ancestorCompositionChain) : null;
 	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
 
 	// Replace placeholder with actual parent lookup expression if needed
@@ -97,8 +97,8 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
     END;`;
 }
 
-function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, grandParentCompositionInfo = null) {
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, grandParentCompositionInfo) : null;
+function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, ancestorCompositionChain) : null;
 	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
 
 	// Replace placeholder with actual parent lookup expression if needed
@@ -137,23 +137,23 @@ function generateSQLiteTrigger(csn, entity, rootEntity, mergedAnnotations = null
 	// Check if this entity is a tracked composition target (composition-of-many)
 	const compositionParentInfo = getCompositionParentInfo(entity, rootEntity, rootMergedAnnotations);
 
-	// Get grandparent info for deep linking (e.g., OrderItemNote -> OrderItem.notes -> Order.orderItems)
-	const { grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField } = grandParentContext;
-	const grandParentCompositionInfo = getGrandParentCompositionInfo(rootEntity, grandParentEntity, grandParentMergedAnnotations, grandParentCompositionField);
+	// Resolve full ancestor composition chain for deep linking
+	const { ancestorChain } = grandParentContext;
+	const ancestorCompositionChain = getAncestorCompositionChain(rootEntity, ancestorChain ?? [], csn);
 
 	// Generate triggers if we have tracked columns OR if this is a composition target
 	const shouldGenerateTriggers = trackedColumns.length > 0 || compositionParentInfo;
 
 	if (shouldGenerateTriggers) {
 		if (!config?.disableCreateTracking) {
-			triggers.push(generateCreateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+			triggers.push(generateCreateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 		}
 		if (!config?.disableUpdateTracking) {
-			triggers.push(generateUpdateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+			triggers.push(generateUpdateTrigger(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 		}
 		if (!config?.disableDeleteTracking) {
 			const generateDeleteTriggerFunc = config?.preserveDeletes ? generateDeleteTriggerPreserve : generateDeleteTrigger;
-			triggers.push(generateDeleteTriggerFunc(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, grandParentCompositionInfo));
+			triggers.push(generateDeleteTriggerFunc(entity, trackedColumns, objectIDs, rootObjectIDs, csn, compositionParentInfo, ancestorCompositionChain));
 		}
 	}
 

--- a/lib/utils/composition-helpers.js
+++ b/lib/utils/composition-helpers.js
@@ -62,4 +62,37 @@ function getGrandParentCompositionInfo(rootEntity, grandParentEntity, grandParen
 	};
 }
 
-module.exports = { getCompositionParentInfo, getGrandParentCompositionInfo };
+/**
+ * Resolves the full ancestor composition chain for an entity.
+ * Each entry in the returned array represents one ancestor level with its key binding.
+ *
+ * @param {object} rootEntity - The immediate parent entity (composition owner)
+ * @param {Array} ancestorChain - Array of { entity, mergedAnnotations, compositionField } from trigger-utils
+ * @param {object} model - The CDS model (CSN) for resolving objectIDs
+ * @returns {Array} Array of { entityName, compositionFieldName, keyBinding, objectIDs } from innermost to outermost ancestor
+ */
+function getAncestorCompositionChain(rootEntity, ancestorChain, model) {
+	if (!ancestorChain || ancestorChain.length === 0) return [];
+
+	const chain = [];
+	let childEntity = rootEntity;
+
+	for (const ancestor of ancestorChain) {
+		const elem = ancestor.entity.elements[ancestor.compositionField];
+		const changelogAnnotation = ancestor.mergedAnnotations?.elementAnnotations?.[ancestor.compositionField] ?? elem['@changelog'];
+		if (changelogAnnotation === false) break;
+
+		chain.push({
+			entityName: ancestor.entity.name,
+			compositionFieldName: ancestor.compositionField,
+			keyBinding: utils.getCompositionParentBinding(childEntity, ancestor.entity),
+			objectIDs: utils.getObjectIDs(ancestor.entity, model, ancestor.mergedAnnotations?.entityAnnotation)
+		});
+
+		childEntity = ancestor.entity;
+	}
+
+	return chain;
+}
+
+module.exports = { getCompositionParentInfo, getGrandParentCompositionInfo, getAncestorCompositionChain };

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -346,20 +346,31 @@ function analyzeCompositions(csn) {
 		}
 	}
 
-	// Second pass: build hierarchy with grandparent info
+	// Second pass: build hierarchy with ancestor chain
 	const hierarchy = new Map();
 	const maxDepth = cds.env.requires?.['change-tracking']?.maxDisplayHierarchyDepth ?? 3;
 	for (const [childName, parentInfo] of childParentMap) {
 		const { parent: parentName, compositionField } = parentInfo;
 
-		// Only include grandparent info if maxDisplayHierarchyDepth allows it (depth > 2 needed for grandparent)
-		const grandParentInfo = maxDepth > 2 ? childParentMap.get(parentName) : null;
+		// Build ancestor chain by walking up the composition tree
+		const ancestors = [];
+		if (maxDepth > 2) {
+			let current = parentName;
+			for (let depth = 0; depth < maxDepth - 2 && current; depth++) {
+				const ancestorInfo = childParentMap.get(current);
+				if (!ancestorInfo) break;
+				ancestors.push({ entity: ancestorInfo.parent, compositionField: ancestorInfo.compositionField });
+				current = ancestorInfo.parent;
+			}
+		}
 
+		// Maintain backward-compatible fields for grandParent (ancestors[0])
 		hierarchy.set(childName, {
 			parent: parentName,
 			compositionField,
-			grandParent: grandParentInfo?.parent ?? null,
-			grandParentCompositionField: grandParentInfo?.compositionField ?? null
+			grandParent: ancestors[0]?.entity ?? null,
+			grandParentCompositionField: ancestors[0]?.compositionField ?? null,
+			ancestors
 		});
 	}
 

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -16,7 +16,7 @@ function buildExpressionSQL(xpr, entityName, refRow, model, CQN2SQL, toSQL, form
 		const assocElement = entity?.elements?.[assocName];
 		if (assocElement?.target) {
 			const where = _buildAssocWhere(assocElement, assocName, refRow, fmt);
-			const query = SELECT.one.from(assocElement.target).columns(fieldPath).where(where);
+			const query = SELECT.from(assocElement.target).columns(fieldPath).where(where);
 			return `(${toSQL(query, model)})`;
 		}
 		// Fallback: flattened field reference

--- a/lib/utils/trigger-utils.js
+++ b/lib/utils/trigger-utils.js
@@ -35,16 +35,23 @@ function generateTriggersForEntities(runtimeCSN, hierarchy, entities, generator)
 		const rootEntity = rootEntityName ? runtimeCSN.definitions[rootEntityName] : null;
 		const rootMergedAnnotations = rootEntityName ? entities.find((d) => d.dbEntityName === rootEntityName)?.mergedAnnotations : null;
 
-		// Get grandparent info for deep linking
-		const grandParentEntityName = hierarchyInfo?.grandParent ?? null;
-		const grandParentEntity = grandParentEntityName ? runtimeCSN.definitions[grandParentEntityName] : null;
-		const grandParentMergedAnnotations = grandParentEntityName ? entities.find((d) => d.dbEntityName === grandParentEntityName)?.mergedAnnotations : null;
-		const grandParentCompositionField = hierarchyInfo?.grandParentCompositionField ?? null;
+		// Resolve full ancestor chain for deep linking
+		const ancestorChain = (hierarchyInfo?.ancestors ?? []).map((a) => ({
+			entity: runtimeCSN.definitions[a.entity] ?? null,
+			mergedAnnotations: entities.find((d) => d.dbEntityName === a.entity)?.mergedAnnotations ?? null,
+			compositionField: a.compositionField
+		}));
+
+		// Backward-compatible grandParentContext derived from ancestorChain[0]
+		const grandParentEntity = ancestorChain[0]?.entity ?? null;
+		const grandParentMergedAnnotations = ancestorChain[0]?.mergedAnnotations ?? null;
+		const grandParentCompositionField = ancestorChain[0]?.compositionField ?? null;
 
 		const result = generator(runtimeCSN, entity, rootEntity, mergedAnnotations, rootMergedAnnotations, {
 			grandParentEntity,
 			grandParentMergedAnnotations,
-			grandParentCompositionField
+			grandParentCompositionField,
+			ancestorChain
 		});
 		if (result) triggers.push(...(Array.isArray(result) ? result : [result]));
 	}

--- a/tests/bookshop/db/change-logs.cds
+++ b/tests/bookshop/db/change-logs.cds
@@ -18,6 +18,14 @@ annotate change_tracking.DifferentFieldTypesChildren with {
   double @changelog;
 }
 
+annotate change_tracking.GrandRootSample with @(changelog: [
+  ID,
+  title
+]) {
+  title @changelog;
+  children @changelog;
+}
+
 annotate change_tracking.RootSample with @(changelog: [
   ID,
   title

--- a/tests/bookshop/db/incidents/schema.cds
+++ b/tests/bookshop/db/incidents/schema.cds
@@ -45,7 +45,7 @@ entity Incidents : cuid, managed {
   timezone : String default 'Asia/Riyadh' @Common.IsTimezone;
   time           : Time @title : 'time' @changelog;
   timestamp      : Timestamp @title : 'timestamp' @changelog;
-  decimalProp : Decimal(15,4) @title : 'Decimal prop' @changelog;
+  decimalProp : Decimal(15,4) @title : 'Decimal prop' @changelog: (decimalProp * 2);
   @changelog: false
   conversation   : Composition of many {
     key ID    : UUID;

--- a/tests/bookshop/db/incidents/schema.cds
+++ b/tests/bookshop/db/incidents/schema.cds
@@ -46,7 +46,6 @@ entity Incidents : cuid, managed {
   time           : Time @title : 'time' @changelog;
   timestamp      : Timestamp @title : 'timestamp' @changelog;
   decimalProp : Decimal(15,4) @title : 'Decimal prop' @changelog: (decimalProp * 2);
-  @changelog: false
   conversation   : Composition of many {
     key ID    : UUID;
     timestamp : type of managed:createdAt;

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -32,12 +32,21 @@ entity DifferentFieldTypesChildren {
       double : Double;
 }
 
+// Test for 4-level composition hierarchy: GrandRootSample -> RootSample -> Level1Sample -> Level2Sample
+entity GrandRootSample {
+  key ID       : String;
+      children : Composition of many RootSample
+                   on children.grandParent = $self;
+      title    : String @title: 'GrandRoot Sample Title';
+}
+
 // Test for key which include special character: '/' -- draft disabled
 entity RootSample {
-  key ID       : String;
-      children : Composition of many Level1Sample
-                   on children.parent = $self;
-      title    : String @title: 'Root Sample Title';
+  key ID          : String;
+      grandParent : Association to one GrandRootSample;
+      children    : Composition of many Level1Sample
+                      on children.parent = $self;
+      title       : String @title: 'Root Sample Title';
 }
 
 entity Level1Sample {

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -52,7 +52,8 @@
 				"scan": false
 			},
 			"change-tracking": {
-				"preserveDeletes": false
+				"preserveDeletes": false,
+				"maxDisplayHierarchyDepth": 4
 			}
 		},
 		"features": {

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -5,6 +5,7 @@ service VariantTesting {
   @cds.redirection.target
   entity DifferentFieldTypes as projection on my.DifferentFieldTypes;
 
+  entity GrandRootSample as projection on my.GrandRootSample;
   entity RootSample as projection on my.RootSample;
   entity Level1Sample as projection on my.Level1Sample;
   entity Level2Sample as projection on my.Level2Sample;

--- a/tests/build/hana-build.test.js
+++ b/tests/build/hana-build.test.js
@@ -53,12 +53,6 @@ const isHana = cds.env.requires?.db?.kind === 'hana';
 			csvEntries = result.definitions.filter((def) => def.suffix === '.csv');
 		});
 
-		test('Build adds CHANGE_TRACKING_DUMMY CSV', () => {
-			const dummy = csvEntries.find((def) => def.name === 'sap.changelog-CHANGE_TRACKING_DUMMY');
-			expect(dummy).toBeDefined();
-			expect(dummy.sql).toBe('X\n1');
-		});
-
 		test('Build adds i18nKeys CSV with translations for tracked entities', () => {
 			const i18n = csvEntries.find((def) => def.name === 'sap.changelog-i18nKeys');
 			expect(i18n).toBeDefined();

--- a/tests/integration/annotation-interpretation.test.js
+++ b/tests/integration/annotation-interpretation.test.js
@@ -239,7 +239,7 @@ describe('@changelog annotation interpretation', () => {
 			modification: 'delete',
 			entityKey: [newRoot.ID, lvl1ID, lvl2ID]
 		});
-		expect(deleteChanges.length).toEqual(2);
+		expect(deleteChanges.length).toEqual(3); // +1 for RootSample.children composition entry (RootSample is a composition child of GrandRootSample)
 		//expect(deleteChanges.find((c) => c.entity === 'sap.change_tracking.Level1Sample').objectID).toEqual(`${lvl1ID}, new Level1Sample title, ${newRoot.ID}`);
 		//expect(deleteChanges.find((c) => c.entity === 'sap.change_tracking.Level2Sample').objectID).toEqual(`${lvl2ID}, new Level2Sample title, ${newRoot.ID}`);
 	});

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -1,6 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
 const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
+const { regenerateTriggers } = require('../test-utils.js');
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('change log generation', () => {
@@ -1776,6 +1777,279 @@ describe('change log generation', () => {
 					modification: 'delete',
 					parent_ID: parentChange.ID,
 					valueChangedFrom: 'To Delete',
+					valueChangedTo: null
+				});
+			});
+		});
+
+		// Limitation: hierarchy linking only supports up to 3 levels (parent + grandparent).
+		// 4-level hierarchies (great-grandparent) are not linked correctly.
+		describe('4-level composition hierarchy (GrandRootSample -> RootSample -> Level1Sample -> Level2Sample)', () => {
+			const grandRootEntities = [
+				'sap.change_tracking.GrandRootSample',
+				'sap.change_tracking.RootSample',
+				'sap.change_tracking.Level1Sample',
+				'sap.change_tracking.Level2Sample'
+			];
+			let originalDepth;
+
+			beforeAll(async () => {
+				originalDepth = cds.env.requires['change-tracking'].maxDisplayHierarchyDepth;
+				cds.env.requires['change-tracking'].maxDisplayHierarchyDepth = 4;
+				await regenerateTriggers(grandRootEntities);
+			});
+
+			afterAll(async () => {
+				cds.env.requires['change-tracking'].maxDisplayHierarchyDepth = originalDepth;
+				await regenerateTriggers(grandRootEntities);
+			});
+
+			it.skip('links changes through all 4 levels when creating the deepest entity', async () => {
+				const adminService = await cds.connect.to('AdminService');
+				const { ChangeView } = adminService.entities;
+
+				const grandRootID = cds.utils.uuid();
+				const rootID = cds.utils.uuid();
+				const lvl1ID = cds.utils.uuid();
+
+				// Create 3-level hierarchy first
+				await POST(`/odata/v4/variant-testing/GrandRootSample`, {
+					ID: grandRootID,
+					title: 'GrandRoot title',
+					children: [
+						{
+							ID: rootID,
+							title: 'Root title',
+							children: [
+								{
+									ID: lvl1ID,
+									title: 'Level1 title'
+								}
+							]
+						}
+					]
+				});
+
+				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID]}`;
+				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+
+				// Now create a Level2Sample on the existing Level1Sample
+				const lvl2ID = cds.utils.uuid();
+				await POST(`/odata/v4/variant-testing/Level1Sample(ID='${lvl1ID}')/children`, {
+					ID: lvl2ID,
+					title: 'New Level2 title'
+				});
+
+				const changes = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]} and transactionID != ${transactionID}`;
+
+				// Expect 4 changelog entries forming a full chain
+				expect(changes.length).toEqual(4);
+
+				const grandRootChange = changes.find((c) => c.entityKey === grandRootID);
+				expect(grandRootChange).toMatchObject({
+					entity: 'sap.change_tracking.GrandRootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: null,
+					valueDataType: 'cds.Composition'
+				});
+
+				const rootChange = changes.find((c) => c.entityKey === rootID);
+				expect(rootChange).toMatchObject({
+					entity: 'sap.change_tracking.RootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: grandRootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				const lvl1Change = changes.find((c) => c.entityKey === lvl1ID);
+				expect(lvl1Change).toMatchObject({
+					entity: 'sap.change_tracking.Level1Sample',
+					attribute: 'children',
+					modification: 'create',
+					parent_ID: rootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				const lvl2Change = changes.find((c) => c.entityKey === lvl2ID);
+				expect(lvl2Change).toMatchObject({
+					entity: 'sap.change_tracking.Level2Sample',
+					attribute: 'title',
+					modification: 'create',
+					parent_ID: lvl1Change.ID,
+					valueChangedFrom: null,
+					valueChangedTo: 'New Level2 title'
+				});
+			});
+
+			it.skip('links changes through all 4 levels when updating the deepest entity', async () => {
+				const adminService = await cds.connect.to('AdminService');
+				const { ChangeView } = adminService.entities;
+
+				const grandRootID = cds.utils.uuid();
+				const rootID = cds.utils.uuid();
+				const lvl1ID = cds.utils.uuid();
+				const lvl2ID = cds.utils.uuid();
+
+				// Create full 4-level hierarchy
+				await POST(`/odata/v4/variant-testing/GrandRootSample`, {
+					ID: grandRootID,
+					title: 'GrandRoot title',
+					children: [
+						{
+							ID: rootID,
+							title: 'Root title',
+							children: [
+								{
+									ID: lvl1ID,
+									title: 'Level1 title',
+									children: [
+										{
+											ID: lvl2ID,
+											title: 'Level2 title'
+										}
+									]
+								}
+							]
+						}
+					]
+				});
+
+				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]}`;
+				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+
+				// Update the deepest entity (Level2Sample)
+				await PATCH(`/odata/v4/variant-testing/Level2Sample(ID='${lvl2ID}')`, {
+					title: 'Level2 title updated'
+				});
+
+				const changes = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]} and transactionID != ${transactionID}`;
+
+				// Expect 4 changelog entries forming a full chain:
+				// GrandRootSample.children (great-grandparent) -> RootSample.children (grandparent) -> Level1Sample.children (parent) -> Level2Sample.title (leaf)
+				expect(changes.length).toEqual(4);
+
+				// Level 1: GrandRootSample.children composition entry (great-grandparent, top of chain)
+				const grandRootChange = changes.find((c) => c.entityKey === grandRootID);
+				expect(grandRootChange).toMatchObject({
+					entity: 'sap.change_tracking.GrandRootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: null,
+					valueDataType: 'cds.Composition'
+				});
+
+				// Level 2: RootSample.children composition entry (grandparent, links to great-grandparent)
+				const rootChange = changes.find((c) => c.entityKey === rootID);
+				expect(rootChange).toMatchObject({
+					entity: 'sap.change_tracking.RootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: grandRootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				// Level 3: Level1Sample.children composition entry (parent, links to grandparent)
+				const lvl1Change = changes.find((c) => c.entityKey === lvl1ID);
+				expect(lvl1Change).toMatchObject({
+					entity: 'sap.change_tracking.Level1Sample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: rootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				// Level 4: Level2Sample.title field change (leaf, links to parent)
+				const lvl2Change = changes.find((c) => c.entityKey === lvl2ID);
+				expect(lvl2Change).toMatchObject({
+					entity: 'sap.change_tracking.Level2Sample',
+					attribute: 'title',
+					modification: 'update',
+					parent_ID: lvl1Change.ID,
+					valueChangedFrom: 'Level2 title',
+					valueChangedTo: 'Level2 title updated'
+				});
+			});
+
+			it.skip('links changes through all 4 levels when deleting the deepest entity', async () => {
+				const adminService = await cds.connect.to('AdminService');
+				const { ChangeView } = adminService.entities;
+
+				const grandRootID = cds.utils.uuid();
+				const rootID = cds.utils.uuid();
+				const lvl1ID = cds.utils.uuid();
+				const lvl2ID = cds.utils.uuid();
+
+				// Create full 4-level hierarchy
+				await POST(`/odata/v4/variant-testing/GrandRootSample`, {
+					ID: grandRootID,
+					title: 'GrandRoot title',
+					children: [
+						{
+							ID: rootID,
+							title: 'Root title',
+							children: [
+								{
+									ID: lvl1ID,
+									title: 'Level1 title',
+									children: [
+										{
+											ID: lvl2ID,
+											title: 'Level2 to delete'
+										}
+									]
+								}
+							]
+						}
+					]
+				});
+
+				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]}`;
+				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+
+				// Delete the deepest entity
+				await DELETE(`/odata/v4/variant-testing/Level2Sample(ID='${lvl2ID}')`);
+
+				const changes = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]} and transactionID != ${transactionID}`;
+
+				// Expect 4 changelog entries forming a full chain
+				expect(changes.length).toEqual(4);
+
+				const grandRootChange = changes.find((c) => c.entityKey === grandRootID);
+				expect(grandRootChange).toMatchObject({
+					entity: 'sap.change_tracking.GrandRootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: null,
+					valueDataType: 'cds.Composition'
+				});
+
+				const rootChange = changes.find((c) => c.entityKey === rootID);
+				expect(rootChange).toMatchObject({
+					entity: 'sap.change_tracking.RootSample',
+					attribute: 'children',
+					modification: 'update',
+					parent_ID: grandRootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				const lvl1Change = changes.find((c) => c.entityKey === lvl1ID);
+				expect(lvl1Change).toMatchObject({
+					entity: 'sap.change_tracking.Level1Sample',
+					attribute: 'children',
+					modification: 'delete',
+					parent_ID: rootChange.ID,
+					valueDataType: 'cds.Composition'
+				});
+
+				const lvl2Change = changes.find((c) => c.entityKey === lvl2ID);
+				expect(lvl2Change).toMatchObject({
+					entity: 'sap.change_tracking.Level2Sample',
+					attribute: 'title',
+					modification: 'delete',
+					parent_ID: lvl1Change.ID,
+					valueChangedFrom: 'Level2 to delete',
 					valueChangedTo: null
 				});
 			});

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -955,7 +955,7 @@ describe('change log generation', () => {
 		});
 
 		describe('Composition of many', () => {
-			it.only('logs each created child as a separate change on the root entity', async () => {
+			it('logs each created child as a separate change on the root entity', async () => {
 				const adminService = await cds.connect.to('AdminService');
 				const { ChangeView } = adminService.entities;
 
@@ -2015,7 +2015,7 @@ describe('Expression-based @changelog annotations', () => {
 	});
 
 	it('uses arithmetic expression as label for non-association elements (decimalProp * 2)', async () => {
-		// decimalProp uses @changelog: [(decimalProp * 2)]
+		// decimalProp uses @changelog: (decimalProp * 2)
 		const res = await POST(`/odata/v4/processor/Incidents`, {
 			customer_ID: '1004161',
 			title: 'Printer maintenance request',
@@ -2037,11 +2037,11 @@ describe('Expression-based @changelog annotations', () => {
 
 		const decimalChange = changes.find((c) => c.attribute === 'decimalProp' && c.modification === 'update');
 		expect(decimalChange).toBeTruthy();
-		expect(decimalChange.valueChangedFrom).toEqual('50');
-		expect(decimalChange.valueChangedTo).toEqual('250');
+		expect(decimalChange.valueChangedFrom).toEqual('50.0000');
+		expect(decimalChange.valueChangedTo).toEqual('250.0000');
 		// (decimalProp * 2): old=50 -> '100', new=250 -> '500'
-		expect(decimalChange.valueChangedFromLabel).toEqual('100');
-		expect(decimalChange.valueChangedToLabel).toEqual('500');
+		expect(decimalChange.valueChangedFromLabel).toEqual('100.0000');
+		expect(decimalChange.valueChangedToLabel).toEqual('500.0000');
 	});
 
 	it('classifies price values using ternary expression label on ExpressionScenarios', async () => {

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -1,7 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
 const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
-const { regenerateTriggers } = require('../test-utils.js');
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('change log generation', () => {
@@ -1785,26 +1784,7 @@ describe('change log generation', () => {
 		// Limitation: hierarchy linking only supports up to 3 levels (parent + grandparent).
 		// 4-level hierarchies (great-grandparent) are not linked correctly.
 		describe('4-level composition hierarchy (GrandRootSample -> RootSample -> Level1Sample -> Level2Sample)', () => {
-			const grandRootEntities = [
-				'sap.change_tracking.GrandRootSample',
-				'sap.change_tracking.RootSample',
-				'sap.change_tracking.Level1Sample',
-				'sap.change_tracking.Level2Sample'
-			];
-			let originalDepth;
-
-			beforeAll(async () => {
-				originalDepth = cds.env.requires['change-tracking'].maxDisplayHierarchyDepth;
-				cds.env.requires['change-tracking'].maxDisplayHierarchyDepth = 4;
-				await regenerateTriggers(grandRootEntities);
-			});
-
-			afterAll(async () => {
-				cds.env.requires['change-tracking'].maxDisplayHierarchyDepth = originalDepth;
-				await regenerateTriggers(grandRootEntities);
-			});
-
-			it.skip('links changes through all 4 levels when creating the deepest entity', async () => {
+			it('links changes through all 4 levels when creating the deepest entity', async () => {
 				const adminService = await cds.connect.to('AdminService');
 				const { ChangeView } = adminService.entities;
 
@@ -1883,7 +1863,7 @@ describe('change log generation', () => {
 				});
 			});
 
-			it.skip('links changes through all 4 levels when updating the deepest entity', async () => {
+			it('links changes through all 4 levels when updating the deepest entity', async () => {
 				const adminService = await cds.connect.to('AdminService');
 				const { ChangeView } = adminService.entities;
 
@@ -1937,7 +1917,8 @@ describe('change log generation', () => {
 					attribute: 'children',
 					modification: 'update',
 					parent_ID: null,
-					valueDataType: 'cds.Composition'
+					valueDataType: 'cds.Composition',
+					objectID: `${grandRootID}, GrandRoot title`
 				});
 
 				// Level 2: RootSample.children composition entry (grandparent, links to great-grandparent)
@@ -1947,7 +1928,8 @@ describe('change log generation', () => {
 					attribute: 'children',
 					modification: 'update',
 					parent_ID: grandRootChange.ID,
-					valueDataType: 'cds.Composition'
+					valueDataType: 'cds.Composition',
+					objectID: `${rootID}, Root title`
 				});
 
 				// Level 3: Level1Sample.children composition entry (parent, links to grandparent)
@@ -1972,7 +1954,7 @@ describe('change log generation', () => {
 				});
 			});
 
-			it.skip('links changes through all 4 levels when deleting the deepest entity', async () => {
+			it('links changes through all 4 levels when deleting the deepest entity', async () => {
 				const adminService = await cds.connect.to('AdminService');
 				const { ChangeView } = adminService.entities;
 

--- a/tests/performance/perf-bookshop/mta.yaml
+++ b/tests/performance/perf-bookshop/mta.yaml
@@ -30,6 +30,7 @@ modules:
     requires:
       - name: perf-bookshop-auth
       - name: perf-bookshop-db
+      - name: perf-bookshop-logging
 
   - name: perf-bookshop-db-deployer
     type: hdb
@@ -38,6 +39,7 @@ modules:
       buildpack: nodejs_buildpack
     requires:
       - name: perf-bookshop-db
+      - name: perf-bookshop-logging
 
 resources:
   - name: perf-bookshop-auth
@@ -58,3 +60,8 @@ resources:
     parameters:
       service: hana
       service-plan: hdi-shared
+  - name: perf-bookshop-logging
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: application-logs
+      service-plan: lite

--- a/tests/performance/perf-bookshop/package.json
+++ b/tests/performance/perf-bookshop/package.json
@@ -26,7 +26,8 @@
 						"max": 200
 					}
 				}
-			}
+			},
+			"application-logging": true
 		}
 	}
 }

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -17,12 +17,19 @@ function _resolveEntities(entityNames, allEntities, hierarchyMap) {
 		const rootEntity = rootEntityName ? model.definitions[rootEntityName] : null;
 		const rootMergedAnnotations = rootEntityName ? allEntities.find((d) => d.dbEntityName === rootEntityName)?.mergedAnnotations : null;
 
-		// Get grandparent info for deep linking
-		const grandParentEntityName = hierarchyInfo?.grandParent ?? null;
+		// Resolve full ancestor chain for deep linking
+		const ancestorChain = (hierarchyInfo?.ancestors ?? []).map((a) => ({
+			entity: model.definitions[a.entity] ?? null,
+			mergedAnnotations: allEntities.find((d) => d.dbEntityName === a.entity)?.mergedAnnotations ?? null,
+			compositionField: a.compositionField
+		}));
+
+		// Backward-compatible grandParentContext derived from ancestorChain[0]
 		const grandParentContext = {
-			grandParentEntity: grandParentEntityName ? model.definitions[grandParentEntityName] : null,
-			grandParentMergedAnnotations: grandParentEntityName ? allEntities.find((d) => d.dbEntityName === grandParentEntityName)?.mergedAnnotations : null,
-			grandParentCompositionField: hierarchyInfo?.grandParentCompositionField ?? null
+			grandParentEntity: ancestorChain[0]?.entity ?? null,
+			grandParentMergedAnnotations: ancestorChain[0]?.mergedAnnotations ?? null,
+			grandParentCompositionField: ancestorChain[0]?.compositionField ?? null,
+			ancestorChain
 		};
 
 		return [{ entity, rootEntity, mergedAnnotations, rootMergedAnnotations, grandParentContext }];
@@ -71,24 +78,10 @@ async function _regenerateH2Triggers(entityNames, allEntities, hierarchyMap) {
 	}
 }
 
-async function _regenerateHANATriggers(entityNames, allEntities, hierarchyMap) {
-	const model = cds.context?.model ?? cds.model;
-	const { generateHANATriggers } = require('../lib/hana/hdi.js');
-	require('../lib/utils/change-tracking.js');
-
-	for (const { entity, rootEntity, mergedAnnotations, rootMergedAnnotations, grandParentContext } of _resolveEntities(entityNames, allEntities, hierarchyMap)) {
-		const triggers = generateHANATriggers(model, entity, rootEntity, mergedAnnotations, rootMergedAnnotations, grandParentContext);
-		for (const trigger of triggers) {
-			await cds.db.run(`CREATE OR REPLACE ${trigger.sql}`);
-		}
-	}
-}
-
 const _generators = {
 	sqlite: _regenerateSQLiteTriggers,
 	postgres: _regeneratePostgresTriggers,
-	h2: _regenerateH2Triggers,
-	hana: _regenerateHANATriggers
+	h2: _regenerateH2Triggers
 };
 
 async function regenerateTriggers(entityNames) {


### PR DESCRIPTION
# Refactor: Convert HANA Triggers to Statement-Level

♻️ **Refactor**: Migrated HANA database triggers from row-level (`FOR EACH ROW`) to statement-level (`FOR EACH STATEMENT`) execution, replacing `:old`/`:new` row references with transition table aliases (`ot`/`nt` via `REFERENCING OLD TABLE old_tab` / `REFERENCING NEW TABLE new_tab`).

### Changes

This refactor eliminates the dependency on a dummy table (`CHANGE_TRACKING_DUMMY`) and rewrites all trigger SQL generation to use set-based `INSERT ... SELECT` patterns instead of per-row procedural logic.

* `index.cds`: Removed the `CHANGE_TRACKING_DUMMY` entity definition that was previously required as a workaround for HANA HDI triggers.
* `lib/TriggerCQN2SQL.js`: Updated trigger row reference regex to support `nt`/`ot` table aliases; removed the custom `from()` override that handled the now-deleted dummy table.
* `lib/hana/triggers.js`: Switched all three trigger types (INSERT, UPDATE, DELETE) from `REFERENCING NEW/OLD ROW` to `REFERENCING NEW/OLD TABLE ... FOR EACH STATEMENT`. Added `getFromClause()` helper to generate the appropriate `FROM` clause with transition table aliases. Updated all row references from `new`/`old` to `nt`/`ot`. Rewrote `buildInsertSQL` to embed all column expressions directly in the `UNION ALL` sub-selects, removing the outer wrapping SELECT.
* `lib/hana/composition.js`: Updated all composition parent context builders to use transition table aliases (`nt`/`ot`) instead of `:new`/`:old` row references. Replaced procedural `DECLARE`/`IF`/`END IF` SQL blocks with set-based `INSERT ... SELECT DISTINCT` patterns. Removed `buildParentLookupSQL` (row-level helper). Added `parentLookupExpr` as a correlated subquery for parent ID resolution.
* `lib/hana/sql-expressions.js`: Replaced all `:old.column` / `:new.column` references with `ot.column` / `nt.column`. Updated `nullSafeChanged`, `getValueExpr`, `getWhereCondition`, `buildAssocLookup`, `buildObjectIDExpr`, and `buildGrandParentObjectIDExpr` accordingly. Changed `SELECT.one.from(...)` to `SELECT.from(...)` throughout.
* `lib/hana/register.js`: Removed the HDI compiler hook logic that injected the dummy CSV data and patched the CSN definition for `CHANGE_TRACKING_DUMMY`.
* `tests/build/hana-build.test.js`: Removed test assertion for `CHANGE_TRACKING_DUMMY` CSV generation.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.3` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `a4f96c20-27a6-11f1-82b7-8bfcfe8a6519`
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
