### PR TITLE
Fix bug with detecting UI changes sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Fixed
+- Existing Facets for displaying the Changes UI are correctly detected avoiding redundant Changes sections.
 
 ### Changed
 

--- a/lib/csn-enhancements/annotations.js
+++ b/lib/csn-enhancements/annotations.js
@@ -39,8 +39,7 @@ function addSideEffects(actions, entityName, hierarchyMap, model) {
 function addUIFacet(entity, m) {
 	const { 'sap.changelog.aspect': aspect } = m.definitions;
 	const {
-		'@UI.Facets': [facet],
-		elements: { changes }
+		'@UI.Facets': [facet]
 	} = aspect;
 	if (entity['@changelog.disable_facet'] !== undefined) {
 		LOG.warn(

--- a/lib/csn-enhancements/annotations.js
+++ b/lib/csn-enhancements/annotations.js
@@ -57,7 +57,7 @@ function addUIFacet(entity, m) {
 	if (
 		facets &&
 		!entity['@changelog.disable_facet'] &&
-		!hasFacetForComp(changes, entity['@UI.Facets']) &&
+		!hasFacetForComp('changes', entity['@UI.Facets']) &&
 		!entity['@Capabilities.NavigationRestrictions.RestrictedProperties']?.some((restriction) => restriction.NavigationProperty?.['='] === 'changes' && restriction.ReadRestrictions?.Readable === false)
 	) {
 		facets.push(facet);
@@ -67,8 +67,8 @@ function addUIFacet(entity, m) {
 /**
  * Check if a facet already exists for the changes composition.
  */
-function hasFacetForComp(comp, facets) {
-	return facets.some((f) => f.Target === `${comp.name}/@UI.LineItem` || (f.Facets && hasFacetForComp(comp, f.Facets)));
+function hasFacetForComp(compName, facets) {
+	return facets.some((f) => (f.Target && f.Target.startsWith(`${compName}/`)) || (f.Facets && hasFacetForComp(compName, f.Facets)));
 }
 
 module.exports = {

--- a/tests/bookshop/srv/admin-service.cds
+++ b/tests/bookshop/srv/admin-service.cds
@@ -87,3 +87,19 @@ annotate AdminService.Customers with {
   country @changelog;
   age     @changelog;
 }
+
+// Test: top-level facet already targeting changes/@UI.LineItem — plugin must not add a duplicate
+annotate AdminService.BookStores with @(UI.Facets: [{
+  $Type  : 'UI.ReferenceFacet',
+  ID     : 'CustomChangesFacet',
+  Label  : 'Custom Changes',
+  Target : 'changes/@UI.LineItem',
+}]);
+
+// Test: top-level facet already targeting changes/@UI.PresentationVariant — plugin must not add a duplicate
+annotate AdminService.Order with @(UI.Facets: [{
+  $Type  : 'UI.ReferenceFacet',
+  ID     : 'CustomChangesFacet',
+  Label  : 'Custom Changes',
+  Target : 'changes/@UI.PresentationVariant',
+}]);

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -30,3 +30,52 @@ service VariantTesting {
   entity DataExtractionSummaryView as select from my.DataExtractionSummaryView;
 
 }
+
+// Test: changes facet nested in CollectionFacet targeting changes/@UI.LineItem — plugin must not add a duplicate
+annotate VariantTesting.RootSample with @(UI.Facets: [{
+  $Type  : 'UI.CollectionFacet',
+  ID     : 'TestCollection',
+  Label  : 'Test Collection',
+  Facets : [{
+    $Type  : 'UI.ReferenceFacet',
+    ID     : 'CustomChangesFacet',
+    Label  : 'Custom Changes',
+    Target : 'changes/@UI.LineItem',
+  }]
+}]);
+
+// Test: changes facet nested in CollectionFacet targeting changes/@UI.PresentationVariant — plugin must not add a duplicate
+annotate VariantTesting.DifferentFieldTypes with @(UI.Facets: [{
+  $Type  : 'UI.CollectionFacet',
+  ID     : 'TestCollection',
+  Label  : 'Test Collection',
+  Facets : [{
+    $Type  : 'UI.ReferenceFacet',
+    ID     : 'CustomChangesFacet',
+    Label  : 'Custom Changes',
+    Target : 'changes/@UI.PresentationVariant',
+  }]
+}]);
+
+// Test: changes facet nested three levels deep in CollectionFacets — plugin must not add a duplicate
+annotate VariantTesting.CompositeKeyParent with @(UI.Facets: [{
+  $Type  : 'UI.CollectionFacet',
+  ID     : 'Level1',
+  Label  : 'Level 1',
+  Facets : [{
+    $Type  : 'UI.CollectionFacet',
+    ID     : 'Level2',
+    Label  : 'Level 2',
+    Facets : [{
+      $Type  : 'UI.CollectionFacet',
+      ID     : 'Level3',
+      Label  : 'Level 3',
+      Facets : [{
+        $Type  : 'UI.ReferenceFacet',
+        ID     : 'CustomChangesFacet',
+        Label  : 'Custom Changes',
+        Target : 'changes/@UI.PresentationVariant',
+      }]
+    }]
+  }]
+}]);

--- a/tests/integration/annotation-interpretation.test.js
+++ b/tests/integration/annotation-interpretation.test.js
@@ -533,6 +533,64 @@ describe('@changelog annotation interpretation', () => {
 		});
 	});
 
+	describe('does not add duplicate changes facet when @UI.Facets already has one', () => {
+		function countChangesFacets(facets) {
+			let count = 0;
+			for (const f of facets) {
+				if (f.Target?.startsWith('changes/')) count++;
+				if (f.Facets) count += countChangesFacets(f.Facets);
+			}
+			return count;
+		}
+
+		it('when a top-level facet targets changes/@UI.LineItem', () => {
+			const entity = cds.model.definitions['AdminService.BookStores'];
+			const facets = entity['@UI.Facets'];
+			expect(facets).toBeDefined();
+			expect(countChangesFacets(facets)).toBe(1);
+			expect(facets.find((f) => f.Target?.startsWith('changes/')).ID).toBe('CustomChangesFacet');
+		});
+
+		it('when a top-level facet targets changes/@UI.PresentationVariant', () => {
+			const entity = cds.model.definitions['AdminService.Order'];
+			const facets = entity['@UI.Facets'];
+			expect(facets).toBeDefined();
+			expect(countChangesFacets(facets)).toBe(1);
+			expect(facets.find((f) => f.Target?.startsWith('changes/')).ID).toBe('CustomChangesFacet');
+		});
+
+		it('when a nested facet targets changes/@UI.LineItem inside a CollectionFacet', () => {
+			const entity = cds.model.definitions['VariantTesting.RootSample'];
+			const facets = entity['@UI.Facets'];
+			expect(facets).toBeDefined();
+			expect(countChangesFacets(facets)).toBe(1);
+			const collection = facets.find((f) => f.Facets);
+			expect(collection).toBeDefined();
+			expect(collection.Facets.find((f) => f.Target?.startsWith('changes/')).ID).toBe('CustomChangesFacet');
+		});
+
+		it('when a nested facet targets changes/@UI.PresentationVariant inside a CollectionFacet', () => {
+			const entity = cds.model.definitions['VariantTesting.DifferentFieldTypes'];
+			const facets = entity['@UI.Facets'];
+			expect(facets).toBeDefined();
+			expect(countChangesFacets(facets)).toBe(1);
+			const collection = facets.find((f) => f.Facets);
+			expect(collection).toBeDefined();
+			expect(collection.Facets.find((f) => f.Target?.startsWith('changes/')).ID).toBe('CustomChangesFacet');
+		});
+
+		it('when a facet is nested three levels deep in CollectionFacets', () => {
+			const entity = cds.model.definitions['VariantTesting.CompositeKeyParent'];
+			const facets = entity['@UI.Facets'];
+			expect(facets).toBeDefined();
+			expect(countChangesFacets(facets)).toBe(1);
+			const level1 = facets.find((f) => f.ID === 'Level1');
+			const level2 = level1.Facets.find((f) => f.ID === 'Level2');
+			const level3 = level2.Facets.find((f) => f.ID === 'Level3');
+			expect(level3.Facets.find((f) => f.Target?.startsWith('changes/')).ID).toBe('CustomChangesFacet');
+		});
+	});
+
 	describe('service projections with element renames', () => {
 		it('does not conflict when a service renames an element but @changelog annotations are inherited unchanged', async () => {
 			const {


### PR DESCRIPTION
Fix bug with detecting UI changes sections.

comp.name did not exist as the csn is not yet compiled for node at that point