### PR TITLE
Reduce scope of skipped PersonalData fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.0-beta.9 - upcoming
+
+### Changed
+- Only skip change tracking for `@PersonalData.IsPotentiallySensitive` and `@PersonalData.IsPotentiallyPersonal` and not `@PersonalData.FieldSemantics`
+
 ## Version 2.0.0-beta.8 - 09.04.26
 
 ### Fixed

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -118,8 +118,8 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 		const isComposition = col.type === 'cds.Composition';
 		if ((!changelogAnnotation && !isComposition) || changelogAnnotation === false) continue;
 
-		// skip any PersonalData* annotation
-		const hasPersonalData = Object.keys(col).some((k) => k.startsWith('@PersonalData'));
+		// skip fields which might contain personal data
+		const hasPersonalData = col['@PersonalData.IsPotentiallyPersonal'] || col['@PersonalData.IsPotentiallySensitive'];
 		if (hasPersonalData) {
 			LOG.warn(`Skipped @changelog for ${name} on entity ${entity.name}: Personal data tracking not supported!`);
 			continue;

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -121,7 +121,7 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 		// skip fields which might contain personal data
 		const hasPersonalData = col['@PersonalData.IsPotentiallyPersonal'] || col['@PersonalData.IsPotentiallySensitive'];
 		if (hasPersonalData) {
-			LOG.warn(`Skipped @changelog for ${name} on entity ${entity.name}: Personal data tracking not supported!`);
+			LOG.warn(`Skipped @changelog for '${name}' on entity '${entity.name}': Elements annotated with @PersonalData.IsPotentiallyPersonal or @PersonalData.IsPotentiallySensitive are not supported for change tracking.`);
 			continue;
 		}
 

--- a/tests/bookshop/db/change-logs.cds
+++ b/tests/bookshop/db/change-logs.cds
@@ -9,6 +9,7 @@ annotate change_tracking.DifferentFieldTypes with @(changelog: [title]) {
   bool      @changelog;
   dppField1 @changelog;
   dppField2 @changelog;
+  dppField3 @changelog;
   // Ignored changelog annotations due to data type
   image @changelog;
   icon @changelog;

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -20,6 +20,7 @@ entity DifferentFieldTypes {
       icon      : Binary      @changelog; // Unsupported - should trigger warning
       dppField1 : String      @PersonalData.IsPotentiallyPersonal;
       dppField2 : String      @PersonalData.IsPotentiallySensitive;
+      dppField3 : String      @PersonalData.FieldSemantics: 'DataControllerID';
       @changelog: false
       children  : Composition of many DifferentFieldTypesChildren
                     on children.parent = $self;

--- a/tests/integration/annotation-interpretation.test.js
+++ b/tests/integration/annotation-interpretation.test.js
@@ -354,16 +354,25 @@ describe('@changelog annotation interpretation', () => {
 		await INSERT.into(DifferentFieldTypes).entries({
 			ID,
 			dppField1: 'John Doe',
-			dppField2: 'John Doe'
+			dppField2: 'John Doe',
+			dppField3: 'Controller-123'
 		});
 
-		const changes = await SELECT.from(ChangeView).where({
+		// @PersonalData.IsPotentiallyPersonal and @PersonalData.IsPotentiallySensitive must be ignored
+		const ignoredChanges = await SELECT.from(ChangeView).where({
 			entity: 'sap.change_tracking.DifferentFieldTypes',
 			entityKey: ID,
 			attribute: { in: ['dppField1', 'dppField2'] }
 		});
+		expect(ignoredChanges.length).toEqual(0);
 
-		expect(changes.length).toEqual(0);
+		// @PersonalData.FieldSemantics must still be tracked (e.g. DataSubjectID, PurposeID, EndOfBusinessDate)
+		const trackedChanges = await SELECT.from(ChangeView).where({
+			entity: 'sap.change_tracking.DifferentFieldTypes',
+			entityKey: ID,
+			attribute: 'dppField3'
+		});
+		expect(trackedChanges.length).toEqual(1);
 	});
 
 	describe('Code lists resolution', () => {


### PR DESCRIPTION
Avoid skipping fields which do not contain personal data but are still annotated with @PersonalData.*