### PR TITLE
Add missing guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.0-beta.10 - Upcoming
+
+### Fixed
+- Server crash when running raw inserts due to missing guards in service handler for setting session variables.
+
 ## Version 2.0.0-beta.9 - 15.04.26
 
 ### Added

--- a/lib/skipHandlers.js
+++ b/lib/skipHandlers.js
@@ -17,7 +17,7 @@ function registerSessionVariableHandlers() {
 	});
 
 	cds.db?.after(['INSERT', 'UPDATE', 'DELETE'], async (_, req) => {
-		if (!req.target || req.target.name.endsWith('.drafts')) return;
+		if (!req.target || req.target.name.endsWith('.drafts') || !req.target._service) return;
 
 		// Reset auto-skip variable if it was set
 		if (req._ctAutoSkipEntity) {

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -5,7 +5,7 @@ const DEBUG = cds.debug('change-tracking');
 function isChangeTracked(entity) {
 	if (entity['@changelog'] === false) return false;
 	if (entity['@changelog']) return true;
-	return Object.values(entity.elements).some((e) => e['@changelog']);
+	return entity.elements && Object.values(entity.elements).some((e) => e['@changelog']);
 }
 
 function _hasTrackedElements(entity) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cap-js/change-tracking",
-	"version": "2.0.0-beta.9",
+	"version": "2.0.0-beta.10",
 	"publishConfig": {
 		"access": "public",
 		"tag": "beta"

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -808,4 +808,12 @@ describe('CDS Features', () => {
 			expect(valueChangedToLabel.xpr.some((r) => r.val === 'status3')).toEqual(false);
 		});
 	});
+
+	describe('Draft', () => {
+		test('Insert into Draft_DraftAdministrativeData', async () => {
+			await INSERT.into("DRAFT_DraftAdministrativeData").entries({
+				DraftUUID: cds.utils.uuid(),
+			});
+		})
+	})
 });

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -811,9 +811,10 @@ describe('CDS Features', () => {
 
 	describe('Draft', () => {
 		test('Insert into Draft_DraftAdministrativeData', async () => {
-			await INSERT.into("DRAFT_DraftAdministrativeData").entries({
-				DraftUUID: cds.utils.uuid(),
+			const res = await INSERT.into('DRAFT_DraftAdministrativeData').entries({
+				DraftUUID: cds.utils.uuid()
 			});
-		})
-	})
+			expect(res).toBeTruthy();
+		});
+	});
 });


### PR DESCRIPTION
Add missing guards causing a crash in raw inserts.
Closes: https://github.com/cap-js/change-tracking/issues/292