### PR TITLE
fix: Add indexes and move back to row-level triggers for HANA

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -66,12 +66,14 @@ runs:
           # This prevents npm from resolving to v9 due to open-ended peer deps like ">=8"
           npm pkg set "devDependencies.@sap/cds=^8.9.8"
           npm pkg set "devDependencies.@cap-js/sqlite=^1"
+          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
           # Root overrides enforce versions across the entire workspace
           npm pkg set "overrides.@cap-js/sqlite=^1"
           npm pkg set "overrides.@cap-js/hana=^1"
           npm pkg set "overrides.@cap-js/db-service=^1"
           npm pkg set "overrides.@cap-js/postgres=^1"
           npm pkg set "overrides.@sap/cds-mtxs=^2"
+          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
           npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
           # Update workspace package dependencies to CDS 8 compatible versions
           cd tests/bookshop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,14 @@ jobs:
           # Add @sap/cds as direct devDependency to anchor the version
           npm pkg set "devDependencies.@sap/cds=^8.9.8"
           npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
           # Root overrides enforce versions across the entire workspace
           npm pkg set "overrides.@cap-js/sqlite=^1.0.0"
           npm pkg set "overrides.@cap-js/hana=^1.0.0"
           npm pkg set "overrides.@cap-js/db-service=^1.0.0"
           npm pkg set "overrides.@cap-js/postgres=^1.0.0"
           npm pkg set "overrides.@sap/cds-mtxs=^2.0.0"
+          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
           npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
           # Update workspace package dependencies
           cd tests/bookshop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 2.0.0-beta.10 - Upcoming
+## Version 2.0.0-beta.10 - 27.04.26
 
 ### Changed
 - HANA triggers reverted from statement-level back to row-level execution for improved compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 2.0.0-beta.10 - Upcoming
 
+### Changed
+- HANA triggers reverted from statement-level back to row-level execution for improved compatibility
+- Restored `CHANGE_TRACKING_DUMMY` entity required for row-level HANA triggers
+
+### Added
+- Database indexes on `sap.changelog.Changes` table for faster parent composition lookups and deduplication queries (SQLite, HANA, Postgres)
+
 ### Fixed
 - Server crash when running raw inserts due to missing guards in service handler for setting session variables.
 - Deployment crash during trigger and procedure generation for entities that use SQL reserved keywords as columns names (e.g. `order`) due to missing escaping

--- a/index.cds
+++ b/index.cds
@@ -170,6 +170,12 @@ entity i18nKeys {
       text   : String(5000);
 }
 
+// Dummy table necessary for HANA triggers because DUMMY cannot be used in HDI
+@cds.persistence.skip
+entity CHANGE_TRACKING_DUMMY {
+  key X : String(5);
+}
+
 entity Changes : cuid {
   parent                : Association to one Changes;
   children              : Composition of many Changes

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -5,7 +5,7 @@ const { toSQL, entityKeyExpr, quote } = require('./sql-expressions.js');
  * Builds rootObjectID select for composition of many.
  */
 function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
-	const keyValues = keyValueExprs ?? binding.map((k) => `${refRow}.${k}`);
+	const keyValues = keyValueExprs ?? binding.map((k) => `:${refRow}.${quote(k)}`);
 	const rootEntityKeyExpr = entityKeyExpr(keyValues);
 
 	if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
@@ -22,10 +22,10 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 	for (const oid of rootObjectIDs) {
 		if (oid.expression) {
 			const exprColumn = utils.buildExpressionColumn(oid.expression);
-			const query = SELECT.from(rootEntity.name).columns(exprColumn).where(where);
+			const query = SELECT.one.from(rootEntity.name).columns(exprColumn).where(where);
 			parts.push(`TO_NVARCHAR((${toSQL(query, model)}))`);
 		} else {
-			const query = SELECT.from(rootEntity.name).columns(oid.name).where(where);
+			const query = SELECT.one.from(rootEntity.name).columns(oid.name).where(where);
 			parts.push(`TO_NVARCHAR((${toSQL(query, model)}))`);
 		}
 	}
@@ -46,7 +46,7 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
  * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
  * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
  */
-function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr = null, outerRowRef = null) {
+function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr = null) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 	const { compositionName, childKeys } = parentKeyBinding;
 
@@ -57,7 +57,7 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	// Build WHERE clause to find the parent entity that has this child
 	const parentEntity = model.definitions[parentEntityName];
 	const parentKeys = utils.extractKeys(parentEntity.keys);
-	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${rowRef}.${quote(childKeys[i])}`).join(' AND ');
+	const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = :${rowRef}.${quote(childKeys[i])}`).join(' AND ');
 
 	// Build the parent key expression via subquery (reverse lookup)
 	const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${quote(pk)} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
@@ -67,71 +67,59 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 	// Falls back to parent's own objectID if child objectID is not available
 	const objectIDExpr = childObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
 
-	// Build the FROM clause referencing the transition table
-	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
-	const transitionAlias = modification === 'delete' ? 'oldTable' : 'newTable';
+	// Add parent_modification to declares for dynamic determination
+	const declares = 'DECLARE parent_id NVARCHAR(36); DECLARE parent_modification NVARCHAR(10);';
 
-	// Bulk-insert parent entries for all affected rows
-	// Use ROW_NUMBER to pick one child's objectID per parent key since objectID now reflects the child entity
-	// Cannot use GROUP BY + MIN because objectID may contain subquery expressions
+	// Determine modification dynamically: 'create' if parent was just created, 'update' otherwise
 	const insertSQL = `
+		SELECT CASE WHEN COUNT(*) > 0 THEN 'create' ELSE 'update' END INTO parent_modification
+			FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${parentEntityName}'
+			AND entityKey = ${parentKeyExpr}
+			AND modification = 'create'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();
 		INSERT INTO SAP_CHANGELOG_CHANGES
 			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT SYSUUID, sub.* FROM (
-				SELECT parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID FROM (
-					SELECT
-						NULL AS parent_ID,
-						'${compositionFieldName}' AS attribute,
-						'${parentEntityName}' AS entity,
-						${parentKeyExpr} AS entityKey,
-						${objectIDExpr} AS objectID,
-						CURRENT_TIMESTAMP AS createdAt,
-						SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-						'cds.Composition' AS valueDataType,
-						CASE WHEN EXISTS (
-							SELECT 1 FROM SAP_CHANGELOG_CHANGES
-							WHERE entity = '${parentEntityName}'
-							AND entityKey = ${parentKeyExpr}
-							AND modification = 'create'
-							AND transactionID = CURRENT_UPDATE_TRANSACTION()
-						) THEN 'create' ELSE 'update' END AS modification,
-						CURRENT_UPDATE_TRANSACTION() AS transactionID,
-						ROW_NUMBER() OVER (PARTITION BY ${parentKeyExpr} ORDER BY ${parentKeyExpr}) AS rn
-					FROM ${transitionTable} ${transitionAlias}
-					WHERE EXISTS (
-						SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
-					)
-					AND NOT EXISTS (
-						SELECT 1 FROM SAP_CHANGELOG_CHANGES
-						WHERE entity = '${parentEntityName}'
-						AND entityKey = ${parentKeyExpr}
-						AND attribute = '${compositionFieldName}'
-						AND valueDataType = 'cds.Composition'
-						AND transactionID = CURRENT_UPDATE_TRANSACTION()
-					)
-				) WHERE rn = 1
-			) sub;`;
+			SELECT
+				parent_id,
+				NULL,
+				'${compositionFieldName}',
+				'${parentEntityName}',
+				${parentKeyExpr},
+				${objectIDExpr},
+				CURRENT_TIMESTAMP,
+				SESSION_CONTEXT('APPLICATIONUSER'),
+				'cds.Composition',
+				parent_modification,
+				CURRENT_UPDATE_TRANSACTION()
+			FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY
+			WHERE EXISTS (
+				SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM SAP_CHANGELOG_CHANGES
+				WHERE entity = '${parentEntityName}'
+				AND entityKey = ${parentKeyExpr}
+				AND attribute = '${compositionFieldName}'
+				AND valueDataType = 'cds.Composition'
+				AND transactionID = CURRENT_UPDATE_TRANSACTION()
+			);`;
 
-	// Parent lookup expression: correlated subquery to find the parent changelog entry ID
-	// Uses outerRowRef (falls back to rowRef) because this expression is evaluated in the outer SELECT context (alias 'x')
-	const lookupRowRef = outerRowRef ?? rowRef;
-	const lookupWhereClause = parentFKFields.map((fk, i) => `${fk} = ${lookupRowRef}.${quote(childKeys[i])}`).join(' AND ');
-	const lookupKeySubqueries = parentKeys.map((pk) => `(SELECT ${quote(pk)} FROM ${utils.transformName(parentEntityName)} WHERE ${lookupWhereClause})`);
-	const lookupKeyExpr = entityKeyExpr(lookupKeySubqueries);
-	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${lookupKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
-
-	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
+	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr };
 }
 
-function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = [], childObjectIDExpr = null, compositionFieldObjectIDExpr = null, outerRowRef = null) {
+function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = [], childObjectIDExpr = null, compositionFieldObjectIDExpr = null) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 
 	// Handle composition of one (parent has FK to child - need reverse lookup)
 	if (parentKeyBinding.type === 'compositionOfOne') {
-		return buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr, outerRowRef);
+		return buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr);
 	}
 
-	const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `${rowRef}.${quote(k)}`));
+	const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `:${rowRef}.${quote(k)}`));
+
+	// Null check for parent FK columns — prevents creating composition entries when FK is null
+	const parentFKNullCheck = parentKeyBinding.map((k) => `:${rowRef}.${quote(k)} IS NOT NULL`).join(' AND ');
 
 	// Resolve objectID for the composition entry:
 	// 1. childObjectIDExpr: child's own @changelog objectID (only for composition-of-one)
@@ -140,11 +128,7 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 	const rootEntity = model.definitions[parentEntityName];
 	const immediateParentObjectIDExpr = childObjectIDExpr ?? compositionFieldObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, parentKeyBinding, rowRef, model);
 
-	// Build the FROM clause referencing the transition table
-	const transitionTable = modification === 'delete' ? ':old_tab' : ':new_tab';
-	const transitionAlias = modification === 'delete' ? 'oldTable' : 'newTable';
-
-	let insertSQL;
+	let declares, insertSQL;
 
 	if (ancestorCompositionChain.length > 0) {
 		// Build the full chain of ancestor levels.
@@ -155,13 +139,13 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 
 		// Build key expressions for each level.
 		const keyExprs = [parentKeyExpr]; // level 0
-		const ancestorKeyValues = [parentKeyBinding.map((k) => `${rowRef}.${quote(k)}`)]; // level 0
+		const ancestorKeyValues = [parentKeyBinding.map((k) => `:${rowRef}.${quote(k)}`)]; // level 0
 
 		// childWhereClauses[i] = WHERE clause on level[i]'s table to find the record for this trigger row
 		const childWhereClauses = [];
 		const childEntity0 = model.definitions[levels[0].entityName];
 		const childKeys0 = utils.extractKeys(childEntity0.keys);
-		childWhereClauses.push(childKeys0.map((pk, j) => `${quote(pk)} = ${rowRef}.${quote(levels[0].keyBinding[j])}`).join(' AND '));
+		childWhereClauses.push(childKeys0.map((pk, j) => `${quote(pk)} = :${rowRef}.${quote(levels[0].keyBinding[j])}`).join(' AND '));
 
 		for (let i = 1; i < levels.length; i++) {
 			const childLevel = levels[i - 1];
@@ -179,8 +163,21 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 			keyExprs.push(entityKeyExpr(whereForAncestor));
 		}
 
+		// Declare variables for each level's parent_id
+		const declareStatements = ['DECLARE parent_id NVARCHAR(36);'];
+		for (let i = 1; i < levels.length; i++) {
+			declareStatements.push(`DECLARE ancestor_${i}_id NVARCHAR(36);`);
+		}
+		declares = declareStatements.join('\n\t');
+
 		// Generate INSERT statements from outermost ancestor down to the immediate parent
+		// Row-level triggers: use procedural INSERT ... VALUES with IF NULL checks
+		// For ancestor levels, add a null check on the immediate parent FK to ensure the chain exists.
+		// If the immediate parent FK is null, skip all ancestor levels too.
 		const insertStatements = [];
+
+		// Build a null check on the immediate parent FK columns (these are on the trigger's entity)
+		const immediateParentFKNullCheck = parentKeyBinding.map((k) => `:${rowRef}.${quote(k)} IS NOT NULL`).join(' AND ');
 
 		for (let i = levels.length - 1; i >= 0; i--) {
 			const level = levels[i];
@@ -188,19 +185,13 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 			const isOutermost = i === levels.length - 1;
 			const isImmediateParent = i === 0;
 
-			// parent_ID: NULL for outermost, lookup for inner levels
-			let parentIDExpr;
-			if (isOutermost) {
-				parentIDExpr = 'NULL';
-			} else {
-				const parentLevel = levels[i + 1];
-				const parentLevelKeyExpr = keyExprs[i + 1];
-				parentIDExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES
-					WHERE entity = '${parentLevel.entityName}'
-					AND entityKey = ${parentLevelKeyExpr}
-					AND attribute = '${parentLevel.compositionFieldName}'
-					AND valueDataType = 'cds.Composition'
-					AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+			// Variable name for this level's changelog entry ID
+			const varName = isImmediateParent ? 'parent_id' : `ancestor_${i}_id`;
+
+			// parent_ID: NULL for outermost, variable for inner levels
+			let parentIDValue = 'NULL';
+			if (!isOutermost) {
+				parentIDValue = `ancestor_${i + 1}_id`;
 			}
 
 			const modExpr = isImmediateParent ? `'${modification}'` : "'update'";
@@ -220,90 +211,109 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 				}
 			}
 
-			insertStatements.push(`INSERT INTO SAP_CHANGELOG_CHANGES
+			// For non-immediate parent levels (ancestors), wrap in a null check on the immediate parent FK
+			// This prevents creating ancestor composition entries when the child has no parent
+			// (e.g., RootSample inserted without grandParent)
+			const needsFKCheck = !isImmediateParent;
+			const fkCheckOpen = needsFKCheck ? `IF ${immediateParentFKNullCheck} THEN\n\t\t\t` : '';
+			const fkCheckClose = needsFKCheck ? `\n\t\tEND IF;` : '';
+
+			// Look up existing entry for this level, or create one
+			insertStatements.push(`${fkCheckOpen}SELECT MAX(ID) INTO ${varName} FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${level.entityName}'
+			AND entityKey = ${levelKeyExpr}
+			AND attribute = '${level.compositionFieldName}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();
+		IF ${varName} IS NULL THEN
+			${varName} := SYSUUID;
+			INSERT INTO SAP_CHANGELOG_CHANGES
 				(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-				SELECT SYSUUID, sub.* FROM (
-					SELECT parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID FROM (
-						SELECT
-							${parentIDExpr} AS parent_ID,
-							'${level.compositionFieldName}' AS attribute,
-							'${level.entityName}' AS entity,
-							${levelKeyExpr} AS entityKey,
-							${objectIDExpr} AS objectID,
-							CURRENT_TIMESTAMP AS createdAt,
-							SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-							'cds.Composition' AS valueDataType,
-							${modExpr} AS modification,
-							CURRENT_UPDATE_TRANSACTION() AS transactionID,
-							ROW_NUMBER() OVER (PARTITION BY ${levelKeyExpr} ORDER BY ${levelKeyExpr}) AS rn
-						FROM ${transitionTable} ${transitionAlias}
-						WHERE NOT EXISTS (
-							SELECT 1 FROM SAP_CHANGELOG_CHANGES
-							WHERE entity = '${level.entityName}'
-							AND entityKey = ${levelKeyExpr}
-							AND attribute = '${level.compositionFieldName}'
-							AND valueDataType = 'cds.Composition'
-							AND transactionID = CURRENT_UPDATE_TRANSACTION()
-						)
-					) WHERE rn = 1
-				) sub;`);
+				VALUES (
+					${varName},
+					${parentIDValue},
+					'${level.compositionFieldName}',
+					'${level.entityName}',
+					${levelKeyExpr},
+					${objectIDExpr},
+					CURRENT_TIMESTAMP,
+					SESSION_CONTEXT('APPLICATIONUSER'),
+					'cds.Composition',
+					${modExpr},
+					CURRENT_UPDATE_TRANSACTION()
+				);
+		END IF;${fkCheckClose}`);
 		}
 
 		insertSQL = insertStatements.join('\n\t\t');
 	} else {
 		// Simple composition-of-many: single-level parent.
-    // Use SELECT DISTINCT on FK columns to deduplicate parent keys.
-    const distinctColumns = parentKeyBinding.join(', ');
-		insertSQL = `INSERT INTO SAP_CHANGELOG_CHANGES (ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT 
-				SYSUUID,
-        NULL AS parent_ID,
-        '${compositionFieldName}' AS attribute,
-        '${parentEntityName}' AS entity,
-        ${parentKeyExpr} AS entityKey,
-        ${immediateParentObjectIDExpr} AS objectID,
-        CURRENT_TIMESTAMP AS createdAt,
-        SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-        'cds.Composition' AS valueDataType,
-        'update' AS modification,
-        CURRENT_UPDATE_TRANSACTION() AS transactionID
-			FROM ( SELECT DISTINCT ${distinctColumns} FROM ${transitionTable} ) ${transitionAlias}
-			WHERE NOT EXISTS (
-				SELECT 1 FROM SAP_CHANGELOG_CHANGES
-				WHERE entity = '${parentEntityName}'
-					AND entityKey = ${parentKeyExpr}
-					AND attribute = '${compositionFieldName}'
-					AND valueDataType = 'cds.Composition'
-					AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		// Add parent_modification to declares for dynamic determination
+		declares = 'DECLARE parent_id NVARCHAR(36);\n\tDECLARE parent_modification NVARCHAR(10);';
+
+		// Determine modification dynamically: 'create' if parent was just created, 'update' otherwise
+		insertSQL = `
+		SELECT CASE WHEN COUNT(*) > 0 THEN 'create' ELSE 'update' END INTO parent_modification
+			FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${parentEntityName}'
+			AND entityKey = ${parentKeyExpr}
+			AND modification = 'create'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();
+		INSERT INTO SAP_CHANGELOG_CHANGES
+			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+			VALUES (
+				parent_id,
+				NULL,
+				'${compositionFieldName}',
+				'${parentEntityName}',
+				${parentKeyExpr},
+				${immediateParentObjectIDExpr},
+				CURRENT_TIMESTAMP,
+				SESSION_CONTEXT('APPLICATIONUSER'),
+				'cds.Composition',
+				parent_modification,
+				CURRENT_UPDATE_TRANSACTION()
 			);`;
 	}
 
-	// Parent lookup expression: correlated subquery to find the parent changelog entry ID per row
-	// parentLookupExpr uses outerRowRef (or falls back to rowRef) — used in the child's outer SELECT
-    const lookupRowRef = outerRowRef ?? rowRef;
-    const lookupKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `${lookupRowRef}.${k}`));
-
-	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${lookupKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
-
-	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
+	return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck };
 }
 
-/**
- * Builds parent lookup/create SQL.
- * The insertSQL contains set-based INSERT ... SELECT statements
- * that handle bulk creation of parent entries.
- */
+function buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName) {
+	return `SELECT MAX(ID) INTO parent_id FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${parentEntityName}'
+			AND entityKey = ${parentKeyExpr}
+			AND attribute = '${compositionFieldName}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();`;
+}
+
 function buildParentLookupOrCreateSQL(compositionParentContext) {
-	const { insertSQL: compInsertSQL } = compositionParentContext;
-	return compInsertSQL;
+	const { insertSQL: compInsertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck } = compositionParentContext;
+	const lookupSQL = buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName);
+	// Wrap in FK null check to skip composition entry creation when parent FK is null
+	if (parentFKNullCheck) {
+		return `IF ${parentFKNullCheck} THEN
+			${lookupSQL}
+		IF parent_id IS NULL THEN
+			parent_id := SYSUUID;
+			${compInsertSQL}
+		END IF;
+		END IF;`;
+	}
+	return `${lookupSQL}
+		IF parent_id IS NULL THEN
+			parent_id := SYSUUID;
+			${compInsertSQL}
+		END IF;`;
 }
 
 function buildCompositionOnlyBody(entityName, compositionParentContext, prefixSQL = '') {
 	const { getSkipCheckCondition } = require('./sql-expressions.js');
 	const { declares } = compositionParentContext;
-	const declareBlock = declares ? `${declares}\n\t` : '';
 	const prefix = prefixSQL ? `\n\t\t${prefixSQL}` : '';
-	return `${declareBlock}IF ${getSkipCheckCondition(entityName)} THEN${prefix}
+	return `${declares}
+	IF ${getSkipCheckCondition(entityName)} THEN${prefix}
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 	END IF;`;
 }
@@ -312,6 +322,7 @@ module.exports = {
 	buildCompOfManyRootObjectIDSelect,
 	buildCompositionOfOneParentContext,
 	buildCompositionParentContext,
+	buildParentLookupSQL,
 	buildParentLookupOrCreateSQL,
 	buildCompositionOnlyBody
 };

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -46,7 +46,7 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
  * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
  * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
  */
-function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr = null) {
+function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr = null, outerRowRef = null) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 	const { compositionName, childKeys } = parentKeyBinding;
 
@@ -113,17 +113,22 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
 			) sub;`;
 
 	// Parent lookup expression: correlated subquery to find the parent changelog entry ID
-	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+	// Uses outerRowRef (falls back to rowRef) because this expression is evaluated in the outer SELECT context (alias 'x')
+	const lookupRowRef = outerRowRef ?? rowRef;
+	const lookupWhereClause = parentFKFields.map((fk, i) => `${fk} = ${lookupRowRef}.${quote(childKeys[i])}`).join(' AND ');
+	const lookupKeySubqueries = parentKeys.map((pk) => `(SELECT ${quote(pk)} FROM ${utils.transformName(parentEntityName)} WHERE ${lookupWhereClause})`);
+	const lookupKeyExpr = entityKeyExpr(lookupKeySubqueries);
+	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${lookupKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
 
 	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }
 
-function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = [], childObjectIDExpr = null, compositionFieldObjectIDExpr = null) {
+function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, ancestorCompositionChain = [], childObjectIDExpr = null, compositionFieldObjectIDExpr = null, outerRowRef = null) {
 	const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
 
 	// Handle composition of one (parent has FK to child - need reverse lookup)
 	if (parentKeyBinding.type === 'compositionOfOne') {
-		return buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr);
+		return buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, modification, rowRef, model, childObjectIDExpr, outerRowRef);
 	}
 
 	const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `${rowRef}.${quote(k)}`));
@@ -246,48 +251,39 @@ function buildCompositionParentContext(compositionParentInfo, rootObjectIDs, mod
 
 		insertSQL = insertStatements.join('\n\t\t');
 	} else {
-		// Bulk-insert parent entries for all affected rows.
-		// Use ROW_NUMBER to pick one child's objectID per parent key,
-		// since objectID now reflects the child entity (differs per child row).
-		// Cannot use GROUP BY + MIN because objectID may contain subquery expressions.
-		insertSQL = `
-		INSERT INTO SAP_CHANGELOG_CHANGES
-			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT SYSUUID, sub.* FROM (
-				SELECT parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID FROM (
-					SELECT
-						NULL AS parent_ID,
-						'${compositionFieldName}' AS attribute,
-						'${parentEntityName}' AS entity,
-						${parentKeyExpr} AS entityKey,
-						${immediateParentObjectIDExpr} AS objectID,
-						CURRENT_TIMESTAMP AS createdAt,
-						SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-						'cds.Composition' AS valueDataType,
-						CASE WHEN EXISTS (
-							SELECT 1 FROM SAP_CHANGELOG_CHANGES
-							WHERE entity = '${parentEntityName}'
-							AND entityKey = ${parentKeyExpr}
-							AND modification = 'create'
-							AND transactionID = CURRENT_UPDATE_TRANSACTION()
-						) THEN 'create' ELSE 'update' END AS modification,
-						CURRENT_UPDATE_TRANSACTION() AS transactionID,
-						ROW_NUMBER() OVER (PARTITION BY ${parentKeyExpr} ORDER BY ${parentKeyExpr}) AS rn
-					FROM ${transitionTable} ${transitionAlias}
-					WHERE NOT EXISTS (
-						SELECT 1 FROM SAP_CHANGELOG_CHANGES
-						WHERE entity = '${parentEntityName}'
-						AND entityKey = ${parentKeyExpr}
-						AND attribute = '${compositionFieldName}'
-						AND valueDataType = 'cds.Composition'
-						AND transactionID = CURRENT_UPDATE_TRANSACTION()
-					)
-				) WHERE rn = 1
-			) sub;`;
+		// Simple composition-of-many: single-level parent.
+    // Use SELECT DISTINCT on FK columns to deduplicate parent keys.
+    const distinctColumns = parentKeyBinding.join(', ');
+		insertSQL = `INSERT INTO SAP_CHANGELOG_CHANGES (ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+			SELECT 
+				SYSUUID,
+        NULL AS parent_ID,
+        '${compositionFieldName}' AS attribute,
+        '${parentEntityName}' AS entity,
+        ${parentKeyExpr} AS entityKey,
+        ${immediateParentObjectIDExpr} AS objectID,
+        CURRENT_TIMESTAMP AS createdAt,
+        SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+        'cds.Composition' AS valueDataType,
+        'update' AS modification,
+        CURRENT_UPDATE_TRANSACTION() AS transactionID
+			FROM ( SELECT DISTINCT ${distinctColumns} FROM ${transitionTable} ) ${transitionAlias}
+			WHERE NOT EXISTS (
+				SELECT 1 FROM SAP_CHANGELOG_CHANGES
+				WHERE entity = '${parentEntityName}'
+					AND entityKey = ${parentKeyExpr}
+					AND attribute = '${compositionFieldName}'
+					AND valueDataType = 'cds.Composition'
+					AND transactionID = CURRENT_UPDATE_TRANSACTION()
+			);`;
 	}
 
 	// Parent lookup expression: correlated subquery to find the parent changelog entry ID per row
-	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+	// parentLookupExpr uses outerRowRef (or falls back to rowRef) — used in the child's outer SELECT
+    const lookupRowRef = outerRowRef ?? rowRef;
+    const lookupKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `${lookupRowRef}.${k}`));
+
+	const parentLookupExpr = `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${lookupKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
 
 	return { declares: '', insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentLookupExpr };
 }

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -61,7 +61,7 @@ function registerHDICompilerHook() {
 		// Add index for trigger deduplication and parent lookup queries
 		data.push({
 			name: 'sap.changelog.Changes_CT_INDEX',
-			sql: 'INDEX "sap.changelog.Changes_CT_INDEX" ON sap_changelog_Changes (entity, entityKey, attribute, valueDataType, parent_ID)',
+			sql: 'INDEX "sap.changelog.Changes_CT_INDEX" ON sap_changelog_Changes (entity, entityKey, attribute, valueDataType, transactionID)',
 			suffix: '.hdbindex'
 		});
 

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -18,6 +18,7 @@ function registerHDICompilerHook() {
 		const triggers = generateTriggersForEntities(runtimeCSN, hierarchy, entities, generateHANATriggers);
 		const data = [];
 		if (triggers.length > 0) {
+			delete csn.definitions['sap.changelog.CHANGE_TRACKING_DUMMY']['@cds.persistence.skip'];
 			ensureUndeployJsonHasTriggerPattern();
 
 			const labels = getLabelTranslations(entities, runtimeCSN);
@@ -29,11 +30,18 @@ function registerHDICompilerHook() {
 			const rows = labels.map((row) => `${escape(row.ID)};${escape(row.locale)};${escape(row.text)}`);
 			const i18nContent = [header, ...rows].join('\n') + '\n';
 
-			data.push({
-				name: 'sap.changelog-i18nKeys',
-				sql: i18nContent,
-				suffix: '.csv'
-			});
+			data.push(
+				{
+					name: 'sap.changelog-CHANGE_TRACKING_DUMMY',
+					sql: 'X\n1',
+					suffix: '.csv'
+				},
+				{
+					name: 'sap.changelog-i18nKeys',
+					sql: i18nContent,
+					suffix: '.csv'
+				}
+			);
 		}
 
 		const config = cds.env.requires?.['change-tracking'];

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -50,6 +50,13 @@ function registerHDICompilerHook() {
 			csn.definitions['sap.changelog.Changes']['@cds.persistence.journal'] = true;
 		}
 
+		// Add index for trigger deduplication and parent lookup queries
+		data.push({
+			name: 'sap.changelog.Changes_CT_INDEX',
+			sql: 'INDEX "sap.changelog.Changes_CT_INDEX" ON sap_changelog_Changes (entity, entityKey, attribute, valueDataType, parent_ID)',
+			suffix: '.hdbindex'
+		});
+
 		const ret = _hdi_migration(csn, options, beforeImage);
 		ret.definitions = ret.definitions.concat(triggers).concat(data);
 		return ret;

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -51,19 +51,20 @@ function wrapLargeString(val, isLob = false) {
 
 /**
  * Returns SQL expression for a column's raw value.
+ * Uses HANA row-level trigger syntax: :refRow.column
  */
 function getValueExpr(col, refRow) {
 	if (col.type === 'cds.Boolean') {
-		return `${refRow}.${quote(col.name)}`;
+		return `:${refRow}.${quote(col.name)}`;
 	}
 	if (col.target && col.foreignKeys) {
-		return col.foreignKeys.map((fk) => `TO_NVARCHAR(${refRow}.${quote(`${col.name}_${fk}`)})`).join(" || ' ' || ");
+		return col.foreignKeys.map((fk) => `TO_NVARCHAR(:${refRow}.${quote(`${col.name}_${fk}`)})`).join(" || ' ' || ");
 	}
 	if (col.target && col.on) {
-		return col.on.map((m) => `TO_NVARCHAR(${refRow}.${quote(m.foreignKeyField)})`).join(" || ' ' || ");
+		return col.on.map((m) => `TO_NVARCHAR(:${refRow}.${quote(m.foreignKeyField)})`).join(" || ' ' || ");
 	}
 	// Scalar value
-	let raw = `${refRow}.${quote(col.name)}`;
+	let raw = `:${refRow}.${quote(col.name)}`;
 	if (col.type === 'cds.LargeString') {
 		return wrapLargeString(raw, true);
 	}
@@ -75,17 +76,19 @@ function getValueExpr(col, refRow) {
 
 /**
  * Null-safe change detection: (old <> new OR old IS NULL OR new IS NULL) AND NOT (old IS NULL AND new IS NULL)
+ * Uses HANA row-level trigger syntax: :old.column, :new.column
  */
 function nullSafeChanged(column, isLob = false) {
 	// For LOB types, convert to NVARCHAR before comparison
 	const qCol = quote(column);
-	const o = isLob ? `TO_NVARCHAR(oldTable.${qCol})` : `oldTable.${qCol}`;
-	const n = isLob ? `TO_NVARCHAR(newTable.${qCol})` : `newTable.${qCol}`;
+	const o = isLob ? `TO_NVARCHAR(:old.${qCol})` : `:old.${qCol}`;
+	const n = isLob ? `TO_NVARCHAR(:new.${qCol})` : `:new.${qCol}`;
 	return `(${o} <> ${n} OR ${o} IS NULL OR ${n} IS NULL) AND NOT (${o} IS NULL AND ${n} IS NULL)`;
 }
 
 /**
  * Returns SQL WHERE condition for detecting column changes (null-safe comparison).
+ * Uses HANA row-level trigger syntax.
  */
 function getWhereCondition(col, modification) {
 	const isLob = col.type === 'cds.LargeString';
@@ -94,18 +97,18 @@ function getWhereCondition(col, modification) {
 		return checkCols.map((k) => nullSafeChanged(k, isLob)).join(' OR ');
 	}
 	// CREATE or DELETE: check value is not null
-	const rowRef = modification === 'create' ? 'newTable' : 'oldTable';
+	const rowRef = modification === 'create' ? 'new' : 'old';
 	if (col.target && col.foreignKeys) {
-		return col.foreignKeys.map((fk) => `${rowRef}.${quote(`${col.name}_${fk}`)} IS NOT NULL`).join(' OR ');
+		return col.foreignKeys.map((fk) => `:${rowRef}.${quote(`${col.name}_${fk}`)} IS NOT NULL`).join(' OR ');
 	}
 	if (col.target && col.on) {
-		return col.on.map((m) => `${rowRef}.${quote(m.foreignKeyField)} IS NOT NULL`).join(' OR ');
+		return col.on.map((m) => `:${rowRef}.${quote(m.foreignKeyField)} IS NOT NULL`).join(' OR ');
 	}
 	// For LOB types, convert to NVARCHAR before null check
 	if (isLob) {
-		return `TO_NVARCHAR(${rowRef}.${quote(col.name)}) IS NOT NULL`;
+		return `TO_NVARCHAR(:${rowRef}.${quote(col.name)}) IS NOT NULL`;
 	}
-	return `${rowRef}.${quote(col.name)} IS NOT NULL`;
+	return `:${rowRef}.${quote(col.name)} IS NOT NULL`;
 }
 
 /**
@@ -115,12 +118,12 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
 	let where = {};
 	if (col.foreignKeys) {
 		where = col.foreignKeys.reduce((acc, k) => {
-			acc[k] = { val: `${refRow}.${quote(`${col.name}_${k}`)}`, literal: 'sql' };
+			acc[k] = { val: `:${refRow}.${quote(`${col.name}_${k}`)}`, literal: 'sql' };
 			return acc;
 		}, {});
 	} else if (col.on) {
 		where = col.on.reduce((acc, mapping) => {
-			acc[mapping.targetKey] = { val: `${refRow}.${quote(mapping.foreignKeyField)}`, literal: 'sql' };
+			acc[mapping.targetKey] = { val: `:${refRow}.${quote(mapping.foreignKeyField)}`, literal: 'sql' };
 			return acc;
 		}, {});
 	}
@@ -132,12 +135,12 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
 	const localizedInfo = utils.getLocalizedLookupInfo(col.target, assocPaths, model);
 	if (localizedInfo) {
 		const textsWhere = { ...where, locale: { func: 'SESSION_CONTEXT', args: [{ val: 'LOCALE' }] } };
-		const textsQuery = SELECT.from(localizedInfo.textsEntity).columns(columns).where(textsWhere);
-		const baseQuery = SELECT.from(col.target).columns(columns).where(where);
+		const textsQuery = SELECT.one.from(localizedInfo.textsEntity).columns(columns).where(textsWhere);
+		const baseQuery = SELECT.one.from(col.target).columns(columns).where(where);
 		return `COALESCE((${toSQL(textsQuery, model)}), (${toSQL(baseQuery, model)}))`;
 	}
 
-	const query = SELECT.from(col.target).columns(columns).where(where);
+	const query = SELECT.one.from(col.target).columns(columns).where(where);
 	return `(${toSQL(query, model)})`;
 }
 
@@ -151,7 +154,7 @@ function getLabelExpr(col, refRow, model, entityName = null) {
 	if (col.altExpression && entityName) {
 		const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
 		// Cast to NVARCHAR to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`)})`;
+		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`)})`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -171,7 +174,7 @@ function getLabelExpr(col, refRow, model, entityName = null) {
 			assocBatch.push(entry.path);
 		} else {
 			flushAssocBatch();
-			parts.push(`TO_NVARCHAR(${refRow}.${quote(entry.path)})`);
+			parts.push(`TO_NVARCHAR(:${refRow}.${quote(entry.path)})`);
 		}
 	}
 	flushAssocBatch();
@@ -185,7 +188,7 @@ function getLabelExpr(col, refRow, model, entityName = null) {
  */
 function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
-	const entityKey = entityKeyExpr(keys.map((k) => `${rowRef}.${quote(k)}`));
+	const entityKey = entityKeyExpr(keys.map((k) => `:${rowRef}.${quote(k)}`));
 
 	if (!objectIDs || objectIDs.length === 0) {
 		return entityKey;
@@ -196,20 +199,20 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	for (const oid of objectIDs) {
 		if (oid.included) {
 			// Included fields are directly available from the trigger row
-			parts.push(`COALESCE(TO_NVARCHAR(${rowRef}.${quote(oid.name)}), '<empty>')`);
-			nullChecks.push(`${rowRef}.${quote(oid.name)} IS NULL`);
+			parts.push(`COALESCE(TO_NVARCHAR(:${rowRef}.${quote(oid.name)}), '<empty>')`);
+			nullChecks.push(`:${rowRef}.${quote(oid.name)} IS NULL`);
 		} else if (oid.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-			const sql = buildExpressionSQL(oid.expression, entity.name, rowRef, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`);
+			const sql = buildExpressionSQL(oid.expression, entity.name, rowRef, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`);
 			parts.push(`TO_NVARCHAR(${sql})`);
 			nullChecks.push(`(${sql}) IS NULL`);
 		} else {
 			const where = keys.reduce((acc, k) => {
-				acc[k] = { val: `${rowRef}.${quote(k)}`, literal: 'sql' };
+				acc[k] = { val: `:${rowRef}.${quote(k)}`, literal: 'sql' };
 				return acc;
 			}, {});
-			const query = SELECT.from(entity.name).columns(oid.name).where(where);
+			const query = SELECT.one.from(entity.name).columns(oid.name).where(where);
 			const sql = toSQL(query, model);
 			parts.push(`TO_NVARCHAR((${sql}))`);
 			nullChecks.push(`(${sql}) IS NULL`);

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -2,183 +2,96 @@ const cds = require('@sap/cds');
 const utils = require('../utils/change-tracking.js');
 const config = cds.env.requires['change-tracking'];
 const { getCompositionParentInfo, getAncestorCompositionChain, resolveCompositionObjectIDs, parseCompositionFieldChangelog } = require('../utils/composition-helpers.js');
-const { getSkipCheckCondition, getElementSkipCondition, entityKeyExpr, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr, toSQL, quote } = require('./sql-expressions.js');
-const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody, buildCompOfManyRootObjectIDSelect } = require('./composition.js');
+const { getSkipCheckCondition, getElementSkipCondition, entityKeyExpr, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr, quote } = require('./sql-expressions.js');
+const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody } = require('./composition.js');
 
 /**
  * Builds an objectID SQL expression from a parsed composition field @changelog.
  */
 function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntityName, parentEntity, parentKeyBinding, rowRef, model) {
-	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, rowRef, quote);
+	const hanaRowRef = `:${rowRef}`;
+	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, hanaRowRef, quote);
 	if (!parsed) return null;
 
 	if (parsed.type === 'expression') {
-		// HANA: use SELECT.from (not SELECT.one) to avoid TOP 1 in correlated subqueries
-		const query = SELECT.from(parsed.parentEntityName).columns(parsed.exprColumn).where(parsed.where);
+		const query = SELECT.one.from(parsed.parentEntityName).columns(parsed.exprColumn).where(parsed.where);
+		const { toSQL } = require('./sql-expressions.js');
 		return `TO_NVARCHAR((${toSQL(query, model)}))`;
 	}
 
+	const { buildCompOfManyRootObjectIDSelect } = require('./composition.js');
 	return buildCompOfManyRootObjectIDSelect(parentEntity, parsed.objectIDs, parentKeyBinding, rowRef, model);
 }
 
-/**
- * Returns the FROM clause for statement-level trigger sub-SELECTs.
- * - For 'create': FROM :new_tab newTable
- * - For 'delete': FROM :old_tab oldTable
- * - For 'update': FROM :new_tab newTable INNER JOIN :old_tab oldTable ON newTable.key1 = oldTable.key1 [AND ...]
- */
-function getFromClause(entity, modification) {
-	const keys = utils.extractKeys(entity.keys);
-	if (modification === 'create') {
-		return 'FROM :new_tab newTable';
-	}
-	if (modification === 'delete') {
-		return 'FROM :old_tab oldTable';
-	}
-	// update: join new and old tables on keys
-	const joinCondition = keys.map((k) => `newTable.${k} = oldTable.${k}`).join(' AND ');
-	return `FROM :new_tab newTable INNER JOIN :old_tab oldTable ON ${joinCondition}`;
-}
-
-function buildTriggerContext(entity, objectIDs, rowRef, model) {
+function buildTriggerContext(entity, objectIDs, rowRef, model, compositionParentInfo = null) {
 	const keys = utils.extractKeys(entity.keys);
 	return {
-		entityKeyExpr: entityKeyExpr(keys.map((k) => `x.${k}`)),
-		objectIDExpr: buildObjectIDExpr(objectIDs, entity, 'x', model),
-		parentLookupExpr: null
+		entityKeyExpr: entityKeyExpr(keys.map((k) => `:${rowRef}.${quote(k)}`)),
+		objectIDExpr: buildObjectIDExpr(objectIDs, entity, rowRef, model),
+		parentLookupExpr: compositionParentInfo !== null ? 'parent_id' : null
 	};
 }
 
-/**
- * Collects the set of column names that the outer SELECT needs from the inner
- * UNION ALL subquery (aliased as 'x'). These columns must be projected through
- * every inner SELECT branch so the outer SELECT can reference them as x.<col>.
- *
- * Includes: entity keys, parent FK columns (for composition children),
- * included objectID fields, and column refs from expression-based objectIDs.
- */
-function collectOuterSelectColumns(entity, objectIDs, parentFKColumns) {
-	const cols = new Set();
-	// 1. Entity keys — always needed for entityKeyExpr and objectIDExpr fallback
-	const keys = utils.extractKeys(entity.keys);
-	for (const k of keys) cols.add(k);
-	// 2. Parent FK columns — needed for parentLookupExpr (composition children only)
-	if (parentFKColumns) {
-		for (const fk of parentFKColumns) cols.add(fk);
-	}
-	// 3. objectID field references
-	if (objectIDs) {
-		for (const oid of objectIDs) {
-			if (oid.included) {
-				// Directly referenced as x.<field> in the outer SELECT
-				cols.add(oid.name);
-			} else if (oid.expression) {
-				// Extract column refs from expression xpr tree
-				const exprRefs = extractExpressionColumnRefs(oid.expression, entity);
-				for (const r of exprRefs) cols.add(r);
-			}
-			// Non-included, non-expression: uses subquery with entity keys (already added above)
-		}
-	}
-	return [...cols];
-}
-/**
- * Extracts direct column references from a CDS expression (xpr array).
- * For single-segment refs like { ref: ['name'] }, returns 'name'.
- * For multi-segment refs like { ref: ['customer', 'name'] } (association paths),
- * returns the FK column names on the entity (e.g., 'customer_ID').
- */
-function extractExpressionColumnRefs(xpr, entity) {
-	const refs = new Set();
-	if (!xpr) return refs;
-	for (const token of xpr) {
-		if (token && token.ref) {
-			if (token.ref.length === 1) {
-				refs.add(token.ref[0]);
-			} else {
-				// Association path — need FK columns for the association
-				const assocName = token.ref[0];
-				const assocElement = entity?.elements?.[assocName];
-				if (assocElement?.keys) {
-					for (const k of assocElement.keys) {
-						refs.add(`${assocName}_${k.ref.join('_')}`);
-					}
-				} else if (assocElement?.on) {
-					for (let i = 0; i < assocElement.on.length; i += 4) {
-						const fkRef = assocElement.on[i + 2];
-						if (fkRef?.ref) {
-							refs.add(fkRef.ref[fkRef.ref.length - 1]);
-						}
-					}
-				}
-			}
-		}
-	}
-	return refs;
-}
-
-function buildInsertSQL(entity, columns, modification, ctx, model, outerColumns) {
-	const fromClause = getFromClause(entity, modification);
-	const rowRef = modification === 'delete' ? 'oldTable' : 'newTable';
-
-	// Build the passthrough column expressions for the inner SELECTs
-	// These are projected unchanged so the outer SELECT can reference them as x.<col>
-	const passthroughSelect = outerColumns.map((c) => `${rowRef}.${quote(c)}`).join(', ');
-
-	// Generate inner UNION ALL query for all changed columns
-	const unionQuery = columns.filter(c => c.type !== 'cds.Composition')
+function buildInsertSQL(entity, columns, modification, ctx, model) {
+	// Generate single UNION ALL query for all changed columns
+	const unionQuery = columns
 		.map((col) => {
 			const whereCondition = getWhereCondition(col, modification);
 			const elementSkipCondition = getElementSkipCondition(entity.name, col.name);
 			let fullWhere = `(${whereCondition}) AND ${elementSkipCondition}`;
 
-			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'oldTable');
-			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'newTable');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'oldTable', model, entity.name);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'newTable', model, entity.name);
+			// For composition-of-one columns, add deduplication check to prevent duplicate entries
+			// when child trigger has already created a composition entry for this transaction
+			if (col.type === 'cds.Composition' && ctx.entityKeyExpr) {
+				fullWhere += ` AND NOT EXISTS (
+			SELECT 1 FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${entity.name}'
+			AND entityKey = ${ctx.entityKeyExpr}
+			AND attribute = '${col.name}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		)`;
+			}
+
+			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
+			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity.name);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity.name);
 
 			const dataType = col.altExpression ? 'cds.String' : col.type;
 
-			return `SELECT
-				${passthroughSelect},
-				'${col.name}' AS attribute,
-				${oldVal} AS valueChangedFrom,
-				${newVal} AS valueChangedTo,
-				${oldLabel} AS valueChangedFromLabel,
-				${newLabel} AS valueChangedToLabel,
-				'${dataType}' AS valueDataType
-			${fromClause} WHERE ${fullWhere}`;
+			return `SELECT '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${dataType}' AS valueDataType FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY WHERE ${fullWhere}`;
 		})
 		.join('\nUNION ALL\n');
 
 	return `INSERT INTO SAP_CHANGELOG_CHANGES
 		(ID, parent_ID, attribute, valueChangedFrom, valueChangedTo, valueChangedFromLabel, valueChangedToLabel, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT
-				SYSUUID AS ID,
-				${ctx.parentLookupExpr ?? 'NULL'} AS parent_ID,
-				x.attribute,
-				x.valueChangedFrom,
-				x.valueChangedTo,
-				x.valueChangedFromLabel,
-				x.valueChangedToLabel,
-				'${entity.name}' AS entity,
-				${ctx.entityKeyExpr} AS entityKey,
-				${ctx.objectIDExpr} AS objectID,
-				CURRENT_TIMESTAMP AS createdAt,
-				SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
-				x.valueDataType,
-				'${modification}' AS modification,
-				CURRENT_UPDATE_TRANSACTION() AS transactionID
-			FROM (
-				${unionQuery}
-			) x;`;
+		SELECT
+			SYSUUID,
+			${ctx.parentLookupExpr},
+			attribute,
+			valueChangedFrom,
+			valueChangedTo,
+			valueChangedFromLabel,
+			valueChangedToLabel,
+			'${entity.name}',
+			${ctx.entityKeyExpr},
+			${ctx.objectIDExpr},
+			CURRENT_TIMESTAMP,
+			SESSION_CONTEXT('APPLICATIONUSER'),
+			valueDataType,
+			'${modification}',
+			CURRENT_UPDATE_TRANSACTION()
+		FROM (
+			${unionQuery}
+		);`;
 }
 
 function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null) {
 	if (compositionParentContext) {
 		const { declares } = compositionParentContext;
-		const declareBlock = declares ? `${declares}\n\t` : '';
-		return `${declareBlock}IF ${getSkipCheckCondition(entityName)} THEN
+		return `${declares}
+	IF ${getSkipCheckCondition(entityName)} THEN
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 		${insertSQL}
 	END IF;`;
@@ -191,26 +104,21 @@ function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null)
 function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
-		buildObjectIDExpr(objectIDs, entity, 'newTable', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'newTable', model),
+		buildObjectIDExpr(objectIDs, entity, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
 		model
 	);
-	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
-	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
-
-	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
-	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
-	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'new', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'create', ctx, model, outerColumns);
+		const insertSQL = buildInsertSQL(entity, columns, 'create', ctx, model);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -218,8 +126,7 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_CREATE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_CREATE AFTER INSERT
 ON ${utils.transformName(entity.name)}
-REFERENCING NEW TABLE new_tab
-FOR EACH STATEMENT
+REFERENCING NEW ROW new
 BEGIN
 	${body}
 END;`,
@@ -230,26 +137,21 @@ END;`,
 function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
-		buildObjectIDExpr(objectIDs, entity, 'newTable', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'newTable', model),
+		buildObjectIDExpr(objectIDs, entity, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
 		model
 	);
-	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
-	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
-
-	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
-	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
-	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'new', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'update', ctx, model, outerColumns);
+		const insertSQL = buildInsertSQL(entity, columns, 'update', ctx, model);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -266,8 +168,7 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_UPDATE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_UPDATE AFTER UPDATE ${ofClause}
 ON ${utils.transformName(entity.name)}
-REFERENCING NEW TABLE new_tab, OLD TABLE old_tab
-FOR EACH STATEMENT
+REFERENCING NEW ROW new, OLD ROW old
 BEGIN
 	${body}
 END;`,
@@ -278,26 +179,21 @@ END;`,
 function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
-		buildObjectIDExpr(objectIDs, entity, 'oldTable', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'oldTable', model),
+		buildObjectIDExpr(objectIDs, entity, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
 		model
 	);
-	const ctx = buildTriggerContext(entity, objectIDs, 'oldTable', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
-	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
-
-	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
-	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
-	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -305,8 +201,7 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 		name: entity.name + '_CT_DELETE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_DELETE AFTER DELETE
 ON ${utils.transformName(entity.name)}
-REFERENCING OLD TABLE old_tab
-FOR EACH STATEMENT
+REFERENCING OLD ROW old
 BEGIN
 	${body}
 END;`,
@@ -318,21 +213,16 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const keys = utils.extractKeys(entity.keys);
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
-		buildObjectIDExpr(objectIDs, entity, 'oldTable', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'oldTable', model),
+		buildObjectIDExpr(objectIDs, entity, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
 		model
 	);
-	const ctx = buildTriggerContext(entity, objectIDs, 'oldTable', model);
+	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
 
-	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${entityKeyExpr(keys.map((k) => `oldTable.${k}`))} FROM :old_tab oldTable);`;
+	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey = ${entityKeyExpr(keys.map((k) => `:old.${quote(k)}`))};`;
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
-	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
-
-	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
-	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
-	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'old', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
 
 	// Special wrapping for delete - need variable declared if using composition
 	let body;
@@ -341,17 +231,17 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext, deleteSQL);
 	} else if (compositionParentContext) {
 		// Mixed case: both composition parent entry and child column inserts
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
 		const { declares } = compositionParentContext;
-		const declareBlock = declares ? `${declares}\n\t` : '';
-		body = `${declareBlock}IF ${getSkipCheckCondition(entity.name)} THEN
+		body = `${declares}
+	IF ${getSkipCheckCondition(entity.name)} THEN
 		${deleteSQL}
 		${buildParentLookupOrCreateSQL(compositionParentContext)}
 		${insertSQL}
 	END IF;`;
 	} else {
 		// No composition: standard delete with column inserts
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
 		body = wrapInSkipCheck(entity.name, `${deleteSQL}\n\t\t${insertSQL}`);
 	}
 
@@ -359,8 +249,7 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		name: entity.name + '_CT_DELETE',
 		sql: `TRIGGER ${utils.transformName(entity.name)}_CT_DELETE AFTER DELETE
 ON ${utils.transformName(entity.name)}
-REFERENCING OLD TABLE old_tab
-FOR EACH STATEMENT
+REFERENCING OLD ROW old
 BEGIN
 	${body}
 END;`,

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -43,35 +43,94 @@ function getFromClause(entity, modification) {
 function buildTriggerContext(entity, objectIDs, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
 	return {
-		entityKeyExpr: entityKeyExpr(keys.map((k) => `${rowRef}.${k}`)),
-		objectIDExpr: buildObjectIDExpr(objectIDs, entity, rowRef, model),
+		entityKeyExpr: entityKeyExpr(keys.map((k) => `x.${k}`)),
+		objectIDExpr: buildObjectIDExpr(objectIDs, entity, 'x', model),
 		parentLookupExpr: null
 	};
 }
 
-function buildInsertSQL(entity, columns, modification, ctx, model) {
-	const fromClause = getFromClause(entity, modification);
+/**
+ * Collects the set of column names that the outer SELECT needs from the inner
+ * UNION ALL subquery (aliased as 'x'). These columns must be projected through
+ * every inner SELECT branch so the outer SELECT can reference them as x.<col>.
+ *
+ * Includes: entity keys, parent FK columns (for composition children),
+ * included objectID fields, and column refs from expression-based objectIDs.
+ */
+function collectOuterSelectColumns(entity, objectIDs, parentFKColumns) {
+	const cols = new Set();
+	// 1. Entity keys — always needed for entityKeyExpr and objectIDExpr fallback
+	const keys = utils.extractKeys(entity.keys);
+	for (const k of keys) cols.add(k);
+	// 2. Parent FK columns — needed for parentLookupExpr (composition children only)
+	if (parentFKColumns) {
+		for (const fk of parentFKColumns) cols.add(fk);
+	}
+	// 3. objectID field references
+	if (objectIDs) {
+		for (const oid of objectIDs) {
+			if (oid.included) {
+				// Directly referenced as x.<field> in the outer SELECT
+				cols.add(oid.name);
+			} else if (oid.expression) {
+				// Extract column refs from expression xpr tree
+				const exprRefs = extractExpressionColumnRefs(oid.expression, entity);
+				for (const r of exprRefs) cols.add(r);
+			}
+			// Non-included, non-expression: uses subquery with entity keys (already added above)
+		}
+	}
+	return [...cols];
+}
+/**
+ * Extracts direct column references from a CDS expression (xpr array).
+ * For single-segment refs like { ref: ['name'] }, returns 'name'.
+ * For multi-segment refs like { ref: ['customer', 'name'] } (association paths),
+ * returns the FK column names on the entity (e.g., 'customer_ID').
+ */
+function extractExpressionColumnRefs(xpr, entity) {
+	const refs = new Set();
+	if (!xpr) return refs;
+	for (const token of xpr) {
+		if (token && token.ref) {
+			if (token.ref.length === 1) {
+				refs.add(token.ref[0]);
+			} else {
+				// Association path — need FK columns for the association
+				const assocName = token.ref[0];
+				const assocElement = entity?.elements?.[assocName];
+				if (assocElement?.keys) {
+					for (const k of assocElement.keys) {
+						refs.add(`${assocName}_${k.ref.join('_')}`);
+					}
+				} else if (assocElement?.on) {
+					for (let i = 0; i < assocElement.on.length; i += 4) {
+						const fkRef = assocElement.on[i + 2];
+						if (fkRef?.ref) {
+							refs.add(fkRef.ref[fkRef.ref.length - 1]);
+						}
+					}
+				}
+			}
+		}
+	}
+	return refs;
+}
 
-	// Generate single UNION ALL query for all changed columns
-	// Each sub-SELECT produces all columns needed for the INSERT, including per-row entity key and objectID
-	const unionQuery = columns
+function buildInsertSQL(entity, columns, modification, ctx, model, outerColumns) {
+	const fromClause = getFromClause(entity, modification);
+	const rowRef = modification === 'delete' ? 'oldTable' : 'newTable';
+
+	// Build the passthrough column expressions for the inner SELECTs
+	// These are projected unchanged so the outer SELECT can reference them as x.<col>
+	const passthroughSelect = outerColumns.map((c) => `${rowRef}.${quote(c)}`).join(', ');
+
+	// Generate inner UNION ALL query for all changed columns
+	const unionQuery = columns.filter(c => c.type !== 'cds.Composition')
 		.map((col) => {
 			const whereCondition = getWhereCondition(col, modification);
 			const elementSkipCondition = getElementSkipCondition(entity.name, col.name);
 			let fullWhere = `(${whereCondition}) AND ${elementSkipCondition}`;
-
-			// For composition-of-one columns, add deduplication check to prevent duplicate entries
-			// when child trigger has already created a composition entry for this transaction
-			if (col.type === 'cds.Composition' && ctx.entityKeyExpr) {
-				fullWhere += ` AND NOT EXISTS (
-			SELECT 1 FROM SAP_CHANGELOG_CHANGES
-			WHERE entity = '${entity.name}'
-			AND entityKey = ${ctx.entityKeyExpr}
-			AND attribute = '${col.name}'
-			AND valueDataType = 'cds.Composition'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION()
-		)`;
-			}
 
 			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'oldTable');
 			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'newTable');
@@ -80,13 +139,39 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 
 			const dataType = col.altExpression ? 'cds.String' : col.type;
 
-			return `SELECT SYSUUID AS ID, ${ctx.parentLookupExpr} AS parent_ID, '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${entity.name}' AS entity, ${ctx.entityKeyExpr} AS entityKey, ${ctx.objectIDExpr} AS objectID, CURRENT_TIMESTAMP AS createdAt, SESSION_CONTEXT('APPLICATIONUSER') AS createdBy, '${dataType}' AS valueDataType, '${modification}' AS modification, CURRENT_UPDATE_TRANSACTION() AS transactionID ${fromClause} WHERE ${fullWhere}`;
+			return `SELECT
+				${passthroughSelect},
+				'${col.name}' AS attribute,
+				${oldVal} AS valueChangedFrom,
+				${newVal} AS valueChangedTo,
+				${oldLabel} AS valueChangedFromLabel,
+				${newLabel} AS valueChangedToLabel,
+				'${dataType}' AS valueDataType
+			${fromClause} WHERE ${fullWhere}`;
 		})
 		.join('\nUNION ALL\n');
 
 	return `INSERT INTO SAP_CHANGELOG_CHANGES
 		(ID, parent_ID, attribute, valueChangedFrom, valueChangedTo, valueChangedFromLabel, valueChangedToLabel, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-		${unionQuery};`;
+			SELECT
+				SYSUUID AS ID,
+				${ctx.parentLookupExpr ?? 'NULL'} AS parent_ID,
+				x.attribute,
+				x.valueChangedFrom,
+				x.valueChangedTo,
+				x.valueChangedFromLabel,
+				x.valueChangedToLabel,
+				'${entity.name}' AS entity,
+				${ctx.entityKeyExpr} AS entityKey,
+				${ctx.objectIDExpr} AS objectID,
+				CURRENT_TIMESTAMP AS createdAt,
+				SESSION_CONTEXT('APPLICATIONUSER') AS createdBy,
+				x.valueDataType,
+				'${modification}' AS modification,
+				CURRENT_UPDATE_TRANSACTION() AS transactionID
+			FROM (
+				${unionQuery}
+			) x;`;
 }
 
 function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null) {
@@ -113,15 +198,19 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'create', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
+
+	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
+	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
+	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'create', ctx, model);
+		const insertSQL = buildInsertSQL(entity, columns, 'create', ctx, model, outerColumns);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -148,15 +237,19 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const ctx = buildTriggerContext(entity, objectIDs, 'newTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'update', 'newTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
+
+	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
+	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
+	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'update', ctx, model);
+		const insertSQL = buildInsertSQL(entity, columns, 'update', ctx, model, outerColumns);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -192,15 +285,19 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 	const ctx = buildTriggerContext(entity, objectIDs, 'oldTable', model);
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
+
+	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
+	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
+	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
 
 	// Handle composition-only triggers (no tracked columns, only composition parent entry)
 	let body;
 	if (columns.length === 0 && compositionParentContext) {
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext);
 	} else {
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
 		body = wrapInSkipCheck(entity.name, insertSQL, compositionParentContext);
 	}
 
@@ -230,8 +327,12 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const deleteSQL = `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${entityKeyExpr(keys.map((k) => `oldTable.${k}`))} FROM :old_tab oldTable);`;
 
 	// Build context for composition parent entry if this is a tracked composition target
-	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr) : null;
+	const compositionParentContext = compositionParentInfo ? buildCompositionParentContext(compositionParentInfo, rootObjectIDs, 'delete', 'oldTable', model, ancestorCompositionChain, childObjectIDExpr, compositionFieldObjectIDExpr, 'x') : null;
 	if (compositionParentContext) ctx.parentLookupExpr = compositionParentContext.parentLookupExpr;
+
+	// Compute columns needed in inner SELECTs for the outer SELECT to reference via x.*
+	const parentFKColumns = compositionParentInfo?.parentKeyBinding;
+	const outerColumns = collectOuterSelectColumns(entity, objectIDs, Array.isArray(parentFKColumns) ? parentFKColumns : null);
 
 	// Special wrapping for delete - need variable declared if using composition
 	let body;
@@ -240,7 +341,7 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 		body = buildCompositionOnlyBody(entity.name, compositionParentContext, deleteSQL);
 	} else if (compositionParentContext) {
 		// Mixed case: both composition parent entry and child column inserts
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
 		const { declares } = compositionParentContext;
 		const declareBlock = declares ? `${declares}\n\t` : '';
 		body = `${declareBlock}IF ${getSkipCheckCondition(entity.name)} THEN
@@ -250,7 +351,7 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	END IF;`;
 	} else {
 		// No composition: standard delete with column inserts
-		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model);
+		const insertSQL = buildInsertSQL(entity, columns, 'delete', ctx, model, outerColumns);
 		body = wrapInSkipCheck(entity.name, `${deleteSQL}\n\t\t${insertSQL}`);
 	}
 

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -9,8 +9,7 @@ const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompos
  * Builds an objectID SQL expression from a parsed composition field @changelog.
  */
 function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntityName, parentEntity, parentKeyBinding, rowRef, model) {
-	const hanaRowRef = `:${rowRef}`;
-	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, hanaRowRef, quote);
+	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, `:${rowRef}`, quote);
 	if (!parsed) return null;
 
 	if (parsed.type === 'expression') {

--- a/lib/postgres/register.js
+++ b/lib/postgres/register.js
@@ -16,6 +16,8 @@ function registerPostgresCompilerHook() {
 
 		if (triggers.length === 0) return ddl;
 
+		triggers.push(`CREATE INDEX IF NOT EXISTS sap_changelog_changes_ct_idx ON sap_changelog_changes (entity, entitykey, attribute, valuedatatype, parent_id)`);
+
 		// Handle standard compilation (array) or delta compilation (object with createsAndAlters/drops)
 		if (Array.isArray(ddl)) {
 			return [...ddl, ...triggers];

--- a/lib/postgres/register.js
+++ b/lib/postgres/register.js
@@ -16,7 +16,7 @@ function registerPostgresCompilerHook() {
 
 		if (triggers.length === 0) return ddl;
 
-		triggers.push(`CREATE INDEX IF NOT EXISTS sap_changelog_changes_ct_idx ON sap_changelog_changes (entity, entitykey, attribute, valuedatatype, parent_id)`);
+		triggers.push(`CREATE INDEX IF NOT EXISTS sap_changelog_changes_ct_idx ON sap_changelog_changes (entity, entitykey, attribute, valuedatatype, transactionid)`);
 
 		// Handle standard compilation (array) or delta compilation (object with createsAndAlters/drops)
 		if (Array.isArray(ddl)) {

--- a/lib/sqlite/register.js
+++ b/lib/sqlite/register.js
@@ -22,7 +22,12 @@ async function deploySQLiteTriggers() {
 	// Delete existing triggers
 	await Promise.all(deleteTriggers.map((t) => cds.db.run(t)));
 
-	await Promise.all([...triggers.map((t) => cds.db.run(t)), cds.delete(i18nKeys), cds.insert(labels).into(i18nKeys)]);
+	await Promise.all([
+		...triggers.map((t) => cds.db.run(t)),
+		cds.db.run(`CREATE INDEX IF NOT EXISTS sap_changelog_Changes_ct_index ON sap_changelog_Changes (entity, entityKey, attribute, valueDataType, parent_ID)`),
+		cds.delete(i18nKeys),
+		cds.insert(labels).into(i18nKeys)
+	]);
 }
 
 module.exports = { deploySQLiteTriggers };

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -274,7 +274,15 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 			// Use 'cds.String' so the ChangeView doesn't cast the label to the wrong type.
 			const dataType = col.altExpression ? 'cds.String' : col.type;
 
-			return `SELECT '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${dataType}' AS valueDataType WHERE ${fullWhere}`;
+			return `
+			SELECT 
+				'${col.name}' AS attribute, 
+				${oldVal} AS valueChangedFrom, 
+				${newVal} AS valueChangedTo, 
+				${oldLabel} AS valueChangedFromLabel, 
+				${newLabel} AS valueChangedToLabel, 
+				'${dataType}' AS valueDataType 
+			WHERE ${fullWhere}`;
 		})
 		.join('\nUNION ALL\n');
 

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -235,7 +235,7 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 					}
 					// If alt is the same as foreign keys, no need to generate lookup
 					const paths = alt.map((a) => a.path);
-					const foreignKeys = col.keys.map(k => k.$generatedFieldName.replace('_', '.'));
+					const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replace('_', '.'));
 					if (paths.join(',') === foreignKeys.join(',')) {
 						alt = [];
 					}

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -235,7 +235,8 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 					}
 					// If alt is the same as foreign keys, no need to generate lookup
 					const paths = alt.map((a) => a.path);
-					const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replace('_', '.'));
+				const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replaceAll('_', '.'));
+
 					if (paths.join(',') === foreignKeys.join(',')) {
 						alt = [];
 					}

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -225,13 +225,19 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 					entry.altExpression = expressionEntry.xpr;
 				} else {
 					// Path expression
-					const alt = [];
+					let alt = [];
 					const changelogPaths = changelogAnnotation.map((c) => c['=']);
 					for (const path of changelogPaths) {
 						const p = validateChangelogPath(entity, path, model);
 						if (!p) continue;
 						if (p.includes('.')) alt.push({ path: p, source: 'assoc' });
 						else alt.push({ path: p, source: 'local' });
+					}
+					// If alt is the same as foreign keys, no need to generate lookup
+					const paths = alt.map((a) => a.path);
+					const foreignKeys = col.keys.map(k => k.$generatedFieldName.replace('_', '.'));
+					if (paths.join(',') === foreignKeys.join(',')) {
+						alt = [];
 					}
 					if (alt.length > 0) entry.alt = alt;
 				}

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -235,7 +235,7 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 					}
 					// If alt is the same as foreign keys, no need to generate lookup
 					const paths = alt.map((a) => a.path);
-				const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replaceAll('_', '.'));
+					const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replaceAll('_', '.'));
 
 					if (paths.join(',') === foreignKeys.join(',')) {
 						alt = [];

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -1,10 +1,11 @@
 /**
  * Shared utility for translating CDS expression annotations (xpr) to SQL
  * in trigger context. Used by all DB backends (SQLite, HANA, Postgres).
+ *
  */
-function buildExpressionSQL(xpr, entityName, refRow, model, CQN2SQL, toSQL, formatRef) {
+function buildExpressionSQL(xpr, entityName, refRow, model, CQN2SQL, toSQL, colRef) {
 	const entity = model.definitions[entityName];
-	const fmt = formatRef ?? ((r, c) => `${r}.${c}`);
+	const fmt = colRef ?? ((r, c) => `${r}.${c}`);
 
 	const renderer = new CQN2SQL({ model });
 	renderer.ref = function ({ ref }) {

--- a/tests/bookshop/db/batch-inserts.cds
+++ b/tests/bookshop/db/batch-inserts.cds
@@ -1,0 +1,56 @@
+using {
+  cuid,
+  managed,
+} from '@sap/cds/common';
+
+namespace sap.dh;
+
+entity UseCases : cuid, managed {
+  name             : String(100)  @mandatory;
+  description      : String(500)  @mandatory;
+  type             : String(100);
+  closed           : Boolean default false;
+  owner_ID         : String(100)  @readonly;
+  dataRequests     : Composition of many DataRequests
+                       on dataRequests.useCase = $self;
+}
+
+entity DataRequests : cuid, managed {
+  useCase_ID       : UUID         @mandatory;
+  type_ID          : String       @mandatory;
+  govStatus_ID     : String(100) default 'IN_PROCESS';
+  useCase          : Association to one UseCases
+                       on useCase.ID = useCase_ID;
+  dataSets         : Composition of many DataSets
+                       on dataSets.dataRequest.ID = $self.ID;
+}
+
+@assert.unique: {DataSets: [
+  tenant_ID,
+  definitions_ID
+]}
+entity DataSets : cuid, managed {
+  dataRequest                 : Association to one DataRequests       @changelog: [dataRequest.ID];
+  tenant_ID                   : UUID                                 @mandatory  @changelog;
+  definitions_ID              : UUID                                 @changelog;
+  extractions                 : Composition of many DataSetExtractions
+                                  on extractions.dataSet = $self     @changelog: [extractions.ID];
+  lastExtraction              : Composition of one DataSetExtractions @changelog: [lastExtraction.ID];
+  lastSuccessfulExtraction    : Composition of one DataSetExtractions @changelog: [lastSuccessfulExtraction.ID];
+  prefix                      : String default ''                    @changelog;
+  status_ID                   : String(100) default 'NEW'            @changelog;
+  autoRetryTotalCount         : Integer default 0;
+  autoRetryCurrentPolicyCount : Integer default 0;
+  lastAutoRetryPolicy_ID      : UUID;
+  isAutoRetryActive           : Boolean default false;
+}
+
+entity DataSetExtractions : cuid, managed {
+  dataSet_ID          : UUID                                         @mandatory  @changelog;
+  extractionTime      : Timestamp                                    @changelog;
+  folderName          : String                                       @changelog;
+  dataSet             : Association to DataSets
+                          on dataSet.ID = dataSet_ID;
+  status_ID           : String(100)                                  @changelog;
+  extractionReference : String                                       @changelog;
+}

--- a/tests/bookshop/db/batch-inserts.cds
+++ b/tests/bookshop/db/batch-inserts.cds
@@ -3,54 +3,54 @@ using {
   managed,
 } from '@sap/cds/common';
 
-namespace sap.dh;
+namespace sap.change_tracking.batch;
 
-entity UseCases : cuid, managed {
+entity Projects : cuid, managed {
   name             : String(100)  @mandatory;
   description      : String(500)  @mandatory;
   type             : String(100);
   closed           : Boolean default false;
   owner_ID         : String(100)  @readonly;
-  dataRequests     : Composition of many DataRequests
-                       on dataRequests.useCase = $self;
+  tasks            : Composition of many Tasks
+                       on tasks.project = $self;
 }
 
-entity DataRequests : cuid, managed {
-  useCase_ID       : UUID         @mandatory;
+entity Tasks : cuid, managed {
+  project_ID       : UUID         @mandatory;
   type_ID          : String       @mandatory;
-  govStatus_ID     : String(100) default 'IN_PROCESS';
-  useCase          : Association to one UseCases
-                       on useCase.ID = useCase_ID;
-  dataSets         : Composition of many DataSets
-                       on dataSets.dataRequest.ID = $self.ID;
+  approvalStatus_ID : String(100) default 'IN_PROCESS';
+  project          : Association to one Projects
+                       on project.ID = project_ID;
+  workItems        : Composition of many WorkItems
+                       on workItems.task.ID = $self.ID;
 }
 
-@assert.unique: {DataSets: [
-  tenant_ID,
-  definitions_ID
+@assert.unique: {WorkItems: [
+  assignee_ID,
+  category_ID
 ]}
-entity DataSets : cuid, managed {
-  dataRequest                 : Association to one DataRequests       @changelog: [dataRequest.ID];
-  tenant_ID                   : UUID                                 @mandatory  @changelog;
-  definitions_ID              : UUID                                 @changelog;
-  extractions                 : Composition of many DataSetExtractions
-                                  on extractions.dataSet = $self     @changelog: [extractions.ID];
-  lastExtraction              : Composition of one DataSetExtractions @changelog: [lastExtraction.ID];
-  lastSuccessfulExtraction    : Composition of one DataSetExtractions @changelog: [lastSuccessfulExtraction.ID];
-  prefix                      : String default ''                    @changelog;
-  status_ID                   : String(100) default 'NEW'            @changelog;
-  autoRetryTotalCount         : Integer default 0;
-  autoRetryCurrentPolicyCount : Integer default 0;
-  lastAutoRetryPolicy_ID      : UUID;
-  isAutoRetryActive           : Boolean default false;
+entity WorkItems : cuid, managed {
+  task                        : Association to one Tasks               @changelog: [task.ID];
+  assignee_ID                 : UUID                                   @mandatory  @changelog;
+  category_ID                 : UUID                                   @changelog;
+  logs                        : Composition of many WorkItemLogs
+                                  on logs.workItem = $self             @changelog: [logs.ID];
+  lastLog                     : Composition of one WorkItemLogs        @changelog: [lastLog.ID];
+  lastSuccessfulLog           : Composition of one WorkItemLogs        @changelog: [lastSuccessfulLog.ID];
+  prefix                      : String default ''                      @changelog;
+  status_ID                   : String(100) default 'NEW'              @changelog;
+  retryTotalCount             : Integer default 0;
+  retryCurrentPolicyCount     : Integer default 0;
+  lastRetryPolicy_ID          : UUID;
+  isRetryActive               : Boolean default false;
 }
 
-entity DataSetExtractions : cuid, managed {
-  dataSet_ID          : UUID                                         @mandatory  @changelog;
-  extractionTime      : Timestamp                                    @changelog;
-  folderName          : String                                       @changelog;
-  dataSet             : Association to DataSets
-                          on dataSet.ID = dataSet_ID;
-  status_ID           : String(100)                                  @changelog;
-  extractionReference : String                                       @changelog;
+entity WorkItemLogs : cuid, managed {
+  workItem_ID         : UUID                                           @mandatory  @changelog;
+  executionTime       : Timestamp                                      @changelog;
+  folderName          : String                                         @changelog;
+  workItem            : Association to WorkItems
+                          on workItem.ID = workItem_ID;
+  status_ID           : String(100)                                    @changelog;
+  logReference        : String                                         @changelog;
 }

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -1,5 +1,7 @@
 using from './change-logs';
 using from './joins-and-unions';
+using from './batch-inserts';
+
 
 namespace sap.change_tracking;
 

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -821,14 +821,14 @@ describe('CDS Features', () => {
 	it.skip('tracks changes correctly for bulk insert with JSON_TABLE inserts', async () => {
 		const { DataSets } = cds.entities('sap.dh');
 		// Arrange
-		const timeAtStart = Date.now()
-		const largeDataSetCount = 16000
-		const dataSets = []
-		const dataSetIds = []
-		const dataRequestID = cds.utils.uuid()
+		const timeAtStart = Date.now();
+		const largeDataSetCount = 16000;
+		const dataSets = [];
+		const dataSetIds = [];
+		const dataRequestID = cds.utils.uuid();
 
 		for (let i = 0; i < largeDataSetCount; i++) {
-			const id = cds.utils.uuid()
+			const id = cds.utils.uuid();
 			dataSets.push({
 				ID: id,
 				dataRequest_ID: dataRequestID,
@@ -837,26 +837,26 @@ describe('CDS Features', () => {
 				modifiedAt: '2024-01-01T00:00:00.000Z',
 				modifiedBy: 'test',
 				tenant_ID: 'TestTenant',
-				status_ID: 'WAITING',
-			})
-			dataSetIds.push(id)
+				status_ID: 'WAITING'
+			});
+			dataSetIds.push(id);
 		}
 
 		// Single unbatched INSERT — same as original ng test
-		await INSERT.into(DataSets).entries(dataSets)
+		await INSERT.into(DataSets).entries(dataSets);
 
 		// Act — batched UPDATE simulating updateStatusesGrouped
-		const newStatus = 'DELIVERED'
-		await UPDATE(DataSets).set({ status_ID: newStatus }).where({ ID: dataSetIds })
+		const newStatus = 'DELIVERED';
+		await UPDATE(DataSets).set({ status_ID: newStatus }).where({ ID: dataSetIds });
 
 		// Assert
-		const updatedDataSets = await SELECT.from(DataSets).where({ ID: dataSetIds })
+		const updatedDataSets = await SELECT.from(DataSets).where({ ID: dataSetIds });
 
-		expect(updatedDataSets).toHaveLength(largeDataSetCount)
-		expect(updatedDataSets.every(ds => ds.status_ID === 'DELIVERED')).toBeTruthy()
+		expect(updatedDataSets).toHaveLength(largeDataSetCount);
+		expect(updatedDataSets.every((ds) => ds.status_ID === 'DELIVERED')).toBeTruthy();
 
-		const timeAtEnd = Date.now()
-		const durationInSeconds = (timeAtEnd - timeAtStart) / 1000
-		console.log(`Updated ${largeDataSetCount} datasets in ${durationInSeconds} seconds`)
-	})
+		const timeAtEnd = Date.now();
+		const durationInSeconds = (timeAtEnd - timeAtStart) / 1000;
+		// console.log(`Updated ${largeDataSetCount} datasets in ${durationInSeconds} seconds`);
+	});
 });

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -818,45 +818,45 @@ describe('CDS Features', () => {
 		});
 	});
 
-	it.skip('tracks changes correctly for bulk insert with JSON_TABLE inserts', async () => {
-		const { DataSets } = cds.entities('sap.dh');
+	it.skip('change tracking scales for large batch INSERT and UPDATE operations', async () => {
+		const { WorkItems } = cds.entities('sap.change_tracking.batch');
 		// Arrange
 		const timeAtStart = Date.now();
-		const largeDataSetCount = 16000;
-		const dataSets = [];
-		const dataSetIds = [];
-		const dataRequestID = cds.utils.uuid();
+		const largeWorkItemCount = 16000;
+		const workItems = [];
+		const workItemIds = [];
+		const taskID = cds.utils.uuid();
 
-		for (let i = 0; i < largeDataSetCount; i++) {
+		for (let i = 0; i < largeWorkItemCount; i++) {
 			const id = cds.utils.uuid();
-			dataSets.push({
+			workItems.push({
 				ID: id,
-				dataRequest_ID: dataRequestID,
+				task_ID: taskID,
 				createdAt: '2024-01-01T00:00:00.000Z',
 				createdBy: 'test',
 				modifiedAt: '2024-01-01T00:00:00.000Z',
 				modifiedBy: 'test',
-				tenant_ID: 'TestTenant',
+				assignee_ID: 'TestAssignee',
 				status_ID: 'WAITING'
 			});
-			dataSetIds.push(id);
+			workItemIds.push(id);
 		}
 
-		// Single unbatched INSERT — same as original ng test
-		await INSERT.into(DataSets).entries(dataSets);
+		// Single unbatched INSERT
+		await INSERT.into(WorkItems).entries(workItems);
 
-		// Act — batched UPDATE simulating updateStatusesGrouped
+		// Act — batched UPDATE
 		const newStatus = 'DELIVERED';
-		await UPDATE(DataSets).set({ status_ID: newStatus }).where({ ID: dataSetIds });
+		await UPDATE(WorkItems).set({ status_ID: newStatus }).where({ ID: workItemIds });
 
 		// Assert
-		const updatedDataSets = await SELECT.from(DataSets).where({ ID: dataSetIds });
+		const updatedWorkItems = await SELECT.from(WorkItems).where({ ID: workItemIds });
 
-		expect(updatedDataSets).toHaveLength(largeDataSetCount);
-		expect(updatedDataSets.every((ds) => ds.status_ID === 'DELIVERED')).toBeTruthy();
+		expect(updatedWorkItems).toHaveLength(largeWorkItemCount);
+		expect(updatedWorkItems.every((wi) => wi.status_ID === 'DELIVERED')).toBeTruthy();
 
 		const timeAtEnd = Date.now();
 		const durationInSeconds = (timeAtEnd - timeAtStart) / 1000;
-		// console.log(`Updated ${largeDataSetCount} datasets in ${durationInSeconds} seconds`);
+		// console.log(`Updated ${largeWorkItemCount} work items in ${durationInSeconds} seconds`);
 	});
 });

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -818,7 +818,7 @@ describe('CDS Features', () => {
 		});
 	});
 
-	it.skip('statement-level trigger on SAP_BAI_CDH_DATASETS fails for CAP-generated JSON_TABLE inserts, but works for normal relational inserts.', async () => {
+	it.skip('tracks changes correctly for bulk insert with JSON_TABLE inserts', async () => {
 		const { DataSets } = cds.entities('sap.dh');
 		// Arrange
 		const timeAtStart = Date.now()

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -817,4 +817,46 @@ describe('CDS Features', () => {
 			expect(res).toBeTruthy();
 		});
 	});
+
+	it('statement-level trigger on SAP_BAI_CDH_DATASETS fails for CAP-generated JSON_TABLE inserts, but works for normal relational inserts.', async () => {
+		const { DataSets } = cds.entities('sap.dh');
+		// Arrange
+		const timeAtStart = Date.now()
+		const largeDataSetCount = 16000
+		const dataSets = []
+		const dataSetIds = []
+		const dataRequestID = cds.utils.uuid()
+
+		for (let i = 0; i < largeDataSetCount; i++) {
+			const id = cds.utils.uuid()
+			dataSets.push({
+				ID: id,
+				dataRequest_ID: dataRequestID,
+				createdAt: '2024-01-01T00:00:00.000Z',
+				createdBy: 'test',
+				modifiedAt: '2024-01-01T00:00:00.000Z',
+				modifiedBy: 'test',
+				tenant_ID: 'TestTenant',
+				status_ID: 'WAITING',
+			})
+			dataSetIds.push(id)
+		}
+
+		// Single unbatched INSERT — same as original ng test
+		await INSERT.into(DataSets).entries(dataSets)
+
+		// Act — batched UPDATE simulating updateStatusesGrouped
+		const newStatus = 'DELIVERED'
+		await UPDATE(DataSets).set({ status_ID: newStatus }).where({ ID: dataSetIds })
+
+		// Assert
+		const updatedDataSets = await SELECT.from(DataSets).where({ ID: dataSetIds })
+
+		expect(updatedDataSets).toHaveLength(largeDataSetCount)
+		expect(updatedDataSets.every(ds => ds.status_ID === 'DELIVERED')).toBeTruthy()
+
+		const timeAtEnd = Date.now()
+		const durationInSeconds = (timeAtEnd - timeAtStart) / 1000
+		console.log(`Updated ${largeDataSetCount} datasets in ${durationInSeconds} seconds`)
+	})
 });

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -818,7 +818,7 @@ describe('CDS Features', () => {
 		});
 	});
 
-	it('statement-level trigger on SAP_BAI_CDH_DATASETS fails for CAP-generated JSON_TABLE inserts, but works for normal relational inserts.', async () => {
+	it.skip('statement-level trigger on SAP_BAI_CDH_DATASETS fails for CAP-generated JSON_TABLE inserts, but works for normal relational inserts.', async () => {
 		const { DataSets } = cds.entities('sap.dh');
 		// Arrange
 		const timeAtStart = Date.now()

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -820,8 +820,7 @@ describe('CDS Features', () => {
 
 	it.skip('change tracking scales for large batch INSERT and UPDATE operations', async () => {
 		const { WorkItems } = cds.entities('sap.change_tracking.batch');
-		// Arrange
-		const timeAtStart = Date.now();
+
 		const largeWorkItemCount = 16000;
 		const workItems = [];
 		const workItemIds = [];
@@ -854,9 +853,5 @@ describe('CDS Features', () => {
 
 		expect(updatedWorkItems).toHaveLength(largeWorkItemCount);
 		expect(updatedWorkItems.every((wi) => wi.status_ID === 'DELIVERED')).toBeTruthy();
-
-		const timeAtEnd = Date.now();
-		const durationInSeconds = (timeAtEnd - timeAtStart) / 1000;
-		// console.log(`Updated ${largeWorkItemCount} work items in ${durationInSeconds} seconds`);
 	});
 });

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -374,7 +374,9 @@ describe('change log generation', () => {
 			});
 
 			const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
-			const transactionID = changesBefore.find((c) => c.transactionID).transactionID;
+			expect(changesBefore.length).toBeGreaterThan(0);
+			const transactionID = changesBefore[0].transactionID;
+
 			await PATCH(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`, {
 				content: 'new content'
 			});
@@ -423,7 +425,8 @@ describe('change log generation', () => {
 			});
 
 			const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
-			const transactionID = changesBefore.find((c) => c.transactionID).transactionID;
+			expect(changesBefore.length).toBeGreaterThan(0);
+			const transactionID = changesBefore[0].transactionID;
 
 			await DELETE(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`);
 
@@ -525,7 +528,8 @@ describe('change log generation', () => {
 			});
 
 			const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, bookID]}`;
-			const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+			expect(changesBefore.length).toBeGreaterThan(0);
+			const transactionID = changesBefore[0].transactionID;
 
 			// Update the book title through deep update on existing data
 			await UPDATE(BookStores)
@@ -581,7 +585,8 @@ describe('change log generation', () => {
 			});
 
 			const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, compositeKey]}`;
-			const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+			expect(changesBefore.length).toBeGreaterThan(0);
+			const transactionID = changesBefore[0].transactionID;
 
 			await PATCH(`/odata/v4/admin/Order(ID=${orderID})/Items(ID=${orderItemID})`, {
 				quantity: 12
@@ -632,7 +637,8 @@ describe('change log generation', () => {
 			);
 
 			const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]}`;
-			const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+			expect(changesBefore.length).toBeGreaterThan(0);
+			const transactionID = changesBefore[0].transactionID;
 
 			await UPDATE(BookStores).where({ ID: bookStoreID }).with({
 				registry: null,
@@ -723,7 +729,8 @@ describe('change log generation', () => {
 				const headerID = order.header_ID;
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, headerID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				await DELETE(`/odata/v4/admin/Order(ID=${orderID})/header`);
 
@@ -822,7 +829,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/AdminService.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=true)/AdminService.draftEdit`, {});
 				await PATCH(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)`, {
@@ -886,7 +894,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/AdminService.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=true)/AdminService.draftEdit`, {});
 				await PATCH(`/odata/v4/admin/BookStoreRegistry(ID=${registryID},IsActiveEntity=false)`, {
@@ -1133,7 +1142,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and update aspect child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1185,7 +1195,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and delete the aspect child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1285,7 +1296,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and update the aspect child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1331,7 +1343,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and delete the aspect child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1432,7 +1445,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and update explicit FK child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1481,7 +1495,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and delete the explicit FK child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1578,7 +1593,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and update explicit FK child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1626,7 +1642,8 @@ describe('change log generation', () => {
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=false)/VariantTesting.draftActivate`, {});
 
 				const changesBefore = await SELECT.from(ChangeView).where({ entityKey: parentID });
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Edit draft and delete explicit FK child
 				await POST(`/odata/v4/variant-testing/TrackingComposition(ID=${parentID},IsActiveEntity=true)/VariantTesting.draftEdit`, {});
@@ -1827,7 +1844,8 @@ describe('change log generation', () => {
 				});
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Now create a Level2Sample on the existing Level1Sample
 				const lvl2ID = cds.utils.uuid();
@@ -1913,7 +1931,8 @@ describe('change log generation', () => {
 				});
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Update the deepest entity (Level2Sample)
 				await PATCH(`/odata/v4/variant-testing/Level2Sample(ID='${lvl2ID}')`, {
@@ -2006,7 +2025,8 @@ describe('change log generation', () => {
 				});
 
 				const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[grandRootID, rootID, lvl1ID, lvl2ID]}`;
-				const transactionID = changesBefore.find((c) => c.transactionID)?.transactionID;
+				expect(changesBefore.length).toBeGreaterThan(0);
+				const transactionID = changesBefore[0].transactionID;
 
 				// Delete the deepest entity
 				await DELETE(`/odata/v4/variant-testing/Level2Sample(ID='${lvl2ID}')`);


### PR DESCRIPTION
- Add database indexes for the columns `entity, entityKey, attribute, valueDataType, parent_ID` on `sap_changelog_Changes`
- Rollback to row-level triggers for HANA to fix issues with transition table variable and JSON_TABLE-based INSERTs  