### PR TITLE
fix: consider custom association-based types during model enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.0-beta.11 - tbd
+
+### Fixed
+- Deployment error when an entity key uses a custom type defined as an association (e.g., `type MyType : Association to SomeEntity`) due to incorrect entityKey expression in the changes association mapping
+- Runtime error when requesting `ChangeView` due to incorrect `where` clause for entities with association-typed keys in timezone column subselects
+
 ## Version 2.0.0-beta.10 - 27.04.26
 
 ### Changed

--- a/lib/csn-enhancements/index.js
+++ b/lib/csn-enhancements/index.js
@@ -15,7 +15,9 @@ function entityKey4(entity, model) {
 	for (const k in entity.elements) {
 		const e = entity.elements[k];
 		if (!e.key) continue;
-		if (e.type === 'cds.Association') {
+
+		// e.type === 'cds.Association' doesn't consider custom types based on associations
+		if (e.target) {
 			const foreignKeyName = e.keys?.[0]?.ref?.[0];
 			const targetEntity = e._target || model?.definitions?.[e.target];
 			const $type = targetEntity?.elements?.[foreignKeyName]?.type;

--- a/lib/csn-enhancements/timezoneProperties.js
+++ b/lib/csn-enhancements/timezoneProperties.js
@@ -61,7 +61,9 @@ function enhanceChangeViewWithTimeZones(changeView, m) {
 		if (timezoneProp.timezone.SELECT) {
 			const subSelect = structuredClone(timezoneProp.timezone);
 			const elements = m.definitions[timezoneProp.entity].elements;
-			const keys = Object.keys(elements).filter((e) => elements[e].key).map(k => elements[k].keys ? `${k}_${elements[k].keys[0].ref[0]}` : k);
+			const keys = Object.keys(elements)
+				.filter((e) => elements[e].key)
+				.map((k) => (elements[k].keys ? `${k}_${elements[k].keys[0].ref[0]}` : k));
 			subSelect.SELECT.where = [
 				{ ref: ['change', 'entityKey'] },
 				'=',

--- a/lib/csn-enhancements/timezoneProperties.js
+++ b/lib/csn-enhancements/timezoneProperties.js
@@ -63,7 +63,7 @@ function enhanceChangeViewWithTimeZones(changeView, m) {
 			const elements = m.definitions[timezoneProp.entity].elements;
 			const keys = Object.keys(elements)
 				.filter((e) => elements[e].key)
-				.map((k) => (elements[k].keys ? `${k}_${elements[k].keys[0].ref[0]}` : k));
+				.flatMap((k) => (elements[k].keys ? elements[k].keys.map((fk) => `${k}_${fk.ref[0]}`) : [k]));
 			subSelect.SELECT.where = [
 				{ ref: ['change', 'entityKey'] },
 				'=',

--- a/lib/csn-enhancements/timezoneProperties.js
+++ b/lib/csn-enhancements/timezoneProperties.js
@@ -60,7 +60,8 @@ function enhanceChangeViewWithTimeZones(changeView, m) {
 		timezoneColumn.xpr.push('when', { ref: ['attribute'] }, '=', { val: timezoneProp.property }, 'and', { ref: ['entity'] }, '=', { val: timezoneProp.entity }, 'then');
 		if (timezoneProp.timezone.SELECT) {
 			const subSelect = structuredClone(timezoneProp.timezone);
-			const keys = Object.keys(m.definitions[timezoneProp.entity].elements).filter((e) => m.definitions[timezoneProp.entity].elements[e].key);
+			const elements = m.definitions[timezoneProp.entity].elements;
+			const keys = Object.keys(elements).filter((e) => elements[e].key).map(k => elements[k].keys ? `${k}_${elements[k].keys[0].ref[0]}` : k);
 			subSelect.SELECT.where = [
 				{ ref: ['change', 'entityKey'] },
 				'=',

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -149,12 +149,12 @@ const { buildExpressionSQL } = require('../utils/expression-sql.js');
 /**
  * Returns SQL expression for a column's label (looked-up value for associations).
  */
-function getLabelExpr(col, refRow, model, entityName = null) {
+function getLabelExpr(col, refRow, model, entity) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
-	if (col.altExpression && entityName) {
+	if (col.altExpression) {
 		const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
 		// Cast to NVARCHAR to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`)})`;
+		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entity, refRow, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`)})`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -183,8 +183,8 @@ function getLabelExpr(col, refRow, model, entityName = null) {
 }
 
 /**
- * Builds SQL expression for objectID (entity display name).
- * Uses @changelog annotation fields, falling back to entity keys.
+ * Builds SQL expression for objectID based on @changelog annotation. Supports direct field references and expressions.
+ * Falls back to entity keys
  */
 function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 	const keys = utils.extractKeys(entity.keys);
@@ -204,7 +204,7 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 		} else if (oid.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-			const sql = buildExpressionSQL(oid.expression, entity.name, rowRef, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`);
+			const sql = buildExpressionSQL(oid.expression, entity, rowRef, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`);
 			parts.push(`TO_NVARCHAR(${sql})`);
 			nullChecks.push(`(${sql}) IS NULL`);
 		} else {

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -8,12 +8,12 @@ const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompos
 /**
  * Builds an objectID SQL expression from a parsed composition field @changelog.
  */
-function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntityName, parentEntity, parentKeyBinding, rowRef, model) {
+function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, parentKeyBinding, rowRef, model) {
 	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, `:${rowRef}`, quote);
 	if (!parsed) return null;
 
 	if (parsed.type === 'expression') {
-		const query = SELECT.one.from(parsed.parentEntityName).columns(parsed.exprColumn).where(parsed.where);
+		const query = SELECT.one.from(parentEntity.name).columns(parsed.exprColumn).where(parsed.where);
 		const { toSQL } = require('./sql-expressions.js');
 		return `TO_NVARCHAR((${toSQL(query, model)}))`;
 	}
@@ -54,8 +54,8 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 
 			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
 			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity.name);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity.name);
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity);
 
 			const dataType = col.altExpression ? 'cds.String' : col.type;
 
@@ -104,7 +104,7 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		buildObjectIDExpr(objectIDs, entity, 'new', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'new', model),
 		model
 	);
 	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
@@ -137,7 +137,7 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		buildObjectIDExpr(objectIDs, entity, 'new', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'new', model),
 		model
 	);
 	const ctx = buildTriggerContext(entity, objectIDs, 'new', model, compositionParentInfo);
@@ -179,7 +179,7 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		buildObjectIDExpr(objectIDs, entity, 'old', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'old', model),
 		model
 	);
 	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);
@@ -213,7 +213,7 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		buildObjectIDExpr(objectIDs, entity, 'old', model),
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'old', model),
 		model
 	);
 	const ctx = buildTriggerContext(entity, objectIDs, 'old', model, compositionParentInfo);

--- a/lib/postgres/sql-expressions.js
+++ b/lib/postgres/sql-expressions.js
@@ -135,13 +135,13 @@ const { buildExpressionSQL } = require('../utils/expression-sql.js');
 /**
  * Returns SQL expression for a column's label (looked-up value for associations).
  */
-function getLabelExpr(col, refRow, model, entityName = null) {
+function getLabelExpr(col, refRow, model, entity) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
-	if (col.altExpression && entityName) {
+	if (col.altExpression) {
 		const PostgresService = require('@cap-js/postgres');
 		const CQN2SQLClass = PostgresService?.CQN2SQL ?? require('@cap-js/db-service/lib/cqn2sql');
 		// Cast to TEXT to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `(${buildExpressionSQL(col.altExpression, entityName, refRow, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`)})::TEXT`;
+		return `(${buildExpressionSQL(col.altExpression, entity, refRow, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`)})::TEXT`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return 'NULL';
@@ -188,7 +188,7 @@ function buildObjectIDAssignment(objectIDs, entity, keys, recVar, targetVar, mod
 			// Leave NULL as-is so CONCAT_WS skips unresolved expressions
 			const PostgresService = require('@cap-js/postgres');
 			const CQN2SQLClass = PostgresService?.CQN2SQL ?? require('@cap-js/db-service/lib/cqn2sql');
-			const sql = buildExpressionSQL(oid.expression, entity.name, recVar, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`);
+			const sql = buildExpressionSQL(oid.expression, entity, recVar, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`);
 			parts.push(`(${sql})::TEXT`);
 			nullChecks.push(`(${sql}) IS NULL`);
 		} else {
@@ -246,8 +246,8 @@ function buildColumnSubquery(col, modification, entity, model) {
 
 	const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'OLD');
 	const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'NEW');
-	const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'OLD', model, entity.name);
-	const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'NEW', model, entity.name);
+	const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'OLD', model, entity);
+	const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'NEW', model, entity);
 
 	const dataType = col.altExpression ? 'cds.String' : col.type;
 
@@ -327,7 +327,6 @@ module.exports = {
 	entityKeyExpr,
 	getValueExpr,
 	getWhereCondition,
-	getLabelExpr,
 	buildObjectIDAssignment,
 	buildInsertBlock,
 	extractTrackedDbColumns

--- a/lib/postgres/triggers.js
+++ b/lib/postgres/triggers.js
@@ -8,13 +8,13 @@ const config = cds.env.requires['change-tracking'];
 /**
  * Builds an objectID SQL expression from a parsed composition field @changelog.
  */
-function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntityName, parentEntity, parentKeyBinding, model) {
+function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, parentKeyBinding, model) {
 	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, 'rec', quote);
 	if (!parsed) return null;
 
 	if (parsed.type === 'expression') {
 		const { toSQL } = require('./sql-expressions.js');
-		const query = SELECT.one.from(parsed.parentEntityName).columns(parsed.exprColumn).where(parsed.where);
+		const query = SELECT.one.from(parentEntity.name).columns(parsed.exprColumn).where(parsed.where);
 		return `(${toSQL(query, model)})::TEXT`;
 	}
 
@@ -41,7 +41,7 @@ function buildFunctionBody(entity, columns, objectIDs, rootEntity, rootObjectIDs
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		'object_id',
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, model),
 		model
 	);
 

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -153,11 +153,11 @@ const { buildExpressionSQL } = require('../utils/expression-sql.js');
 /**
  * Returns SQL expression for a column's label (looked-up value for associations)
  */
-function getLabelExpr(col, refRow, entityKey, model, entityName = null) {
+function getLabelExpr(col, refRow, entityKey, model, entity) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
-	if (col.altExpression && entityName) {
+	if (col.altExpression) {
 		const SQLiteService = require('@cap-js/sqlite');
-		const exprSQL = buildExpressionSQL(col.altExpression, entityName, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
+		const exprSQL = buildExpressionSQL(col.altExpression, entity, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
 		// Preserve decimal scale for arithmetic expressions on Decimal columns
 		// SQLite loses fractional digits when evaluating numeric expressions (e.g. 50 * 2 → 100).
 		if (col.type === 'cds.Decimal' && col.scale != null) {
@@ -198,7 +198,7 @@ function getLabelExpr(col, refRow, entityKey, model, entityName = null) {
  * When all @changelog fields are NULL, falls back to the entity key.
  * When some are NULL, shows '<empty>' for missing values.
  */
-function buildObjectIDSelect(objectIDs, entityName, entityKeys, refRow, model) {
+function buildObjectIDSelect(objectIDs, entity, entityKeys, refRow, model) {
 	if (objectIDs.length === 0) return null;
 
 	for (const objectID of objectIDs) {
@@ -206,10 +206,10 @@ function buildObjectIDSelect(objectIDs, entityName, entityKeys, refRow, model) {
 		if (objectID.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const SQLiteService = require('@cap-js/sqlite');
-			objectID.selectSQL = buildExpressionSQL(objectID.expression, entityName, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
+			objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
 		} else {
 			const where = buildKeyWhere(entityKeys, refRow);
-			const query = SELECT.one.from(entityName).columns(objectID.name).where(where);
+			const query = SELECT.one.from(entity).columns(objectID.name).where(where);
 			objectID.selectSQL = toSQL(query, model);
 		}
 	}
@@ -237,7 +237,7 @@ function buildObjectIDSelect(objectIDs, entityName, entityKeys, refRow, model) {
 function buildTriggerContext(entity, objectIDs, refRow, model, compositionParentInfo = null) {
 	const keys = utils.extractKeys(entity.keys);
 	const entityKey = entityKeyExpr(keys.map((k) => `${refRow}.${quote(k)}`));
-	const objectID = buildObjectIDSelect(objectIDs, entity.name, keys, refRow, model) ?? entityKey;
+	const objectID = buildObjectIDSelect(objectIDs, entity, keys, refRow, model) ?? entityKey;
 	const parentLookupExpr = compositionParentInfo ? 'PARENT_LOOKUP_PLACEHOLDER' : null;
 
 	return { keys, entityKey, objectID, parentLookupExpr };
@@ -266,8 +266,8 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 
 			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
 			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', ctx.entityKey, model, entity.name);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', ctx.entityKey, model, entity.name);
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', ctx.entityKey, model, entity);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', ctx.entityKey, model, entity);
 
 			// When an expression-based label is used, the label result type may differ from
 			// the element's declared type (e.g., a ternary returning strings on a Decimal column).
@@ -316,7 +316,6 @@ module.exports = {
 	entityKeyExpr,
 	getValueExpr,
 	getWhereCondition,
-	getLabelExpr,
 	buildObjectIDSelect,
 	buildTriggerContext,
 	buildInsertSQL

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -122,14 +122,14 @@ function getWhereCondition(col, modification) {
 function buildAssocLookup(column, assocPaths, refRow, entityKey, model) {
 	const where = column.foreignKeys
 		? column.foreignKeys.reduce((acc, k) => {
-			acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
-			return acc;
-		}, {})
+				acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
+				return acc;
+			}, {})
 		: column.on?.reduce((acc, k) => {
-			// Composition of aspect has a targetKey object
-			acc[k.targetKey ?? k] = { val: entityKey, literal: 'sql' };
-			return acc;
-		}, {});
+				// Composition of aspect has a targetKey object
+				acc[k.targetKey ?? k] = { val: entityKey, literal: 'sql' };
+				return acc;
+			}, {});
 
 	// Drop the first part of each path (association name)
 	const alt = assocPaths.map((s) => s.split('.').slice(1).join('.'));
@@ -215,7 +215,7 @@ function buildObjectIDSelect(objectIDs, entity, refRow, model) {
 			objectID.selectSQL = toSQL(query, model);
 		}
 	}
-	
+
 	const entityKey = entityKeyExpr(keys.map((k) => `${refRow}.${quote(k)}`));
 
 	// Single objectID field: simple COALESCE, no GROUP_CONCAT needed

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -122,14 +122,14 @@ function getWhereCondition(col, modification) {
 function buildAssocLookup(column, assocPaths, refRow, entityKey, model) {
 	const where = column.foreignKeys
 		? column.foreignKeys.reduce((acc, k) => {
-				acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
-				return acc;
-			}, {})
+			acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
+			return acc;
+		}, {})
 		: column.on?.reduce((acc, k) => {
-				// Composition of aspect has a targetKey object
-				acc[k.targetKey ?? k] = { val: entityKey, literal: 'sql' };
-				return acc;
-			}, {});
+			// Composition of aspect has a targetKey object
+			acc[k.targetKey ?? k] = { val: entityKey, literal: 'sql' };
+			return acc;
+		}, {});
 
 	// Drop the first part of each path (association name)
 	const alt = assocPaths.map((s) => s.split('.').slice(1).join('.'));
@@ -198,8 +198,9 @@ function getLabelExpr(col, refRow, entityKey, model, entity) {
  * When all @changelog fields are NULL, falls back to the entity key.
  * When some are NULL, shows '<empty>' for missing values.
  */
-function buildObjectIDSelect(objectIDs, entity, entityKeys, refRow, model) {
+function buildObjectIDSelect(objectIDs, entity, refRow, model) {
 	if (objectIDs.length === 0) return null;
+	const keys = utils.extractKeys(entity.keys);
 
 	for (const objectID of objectIDs) {
 		if (objectID.included) continue;
@@ -208,13 +209,14 @@ function buildObjectIDSelect(objectIDs, entity, entityKeys, refRow, model) {
 			const SQLiteService = require('@cap-js/sqlite');
 			objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
 		} else {
-			const where = buildKeyWhere(entityKeys, refRow);
-			const query = SELECT.one.from(entity).columns(objectID.name).where(where);
+			// Path-based ObjectID
+			const where = buildKeyWhere(keys, refRow);
+			const query = SELECT.one.from(entity.name).columns(objectID.name).where(where);
 			objectID.selectSQL = toSQL(query, model);
 		}
 	}
-
-	const entityKey = entityKeyExpr(entityKeys.map((k) => `${refRow}.${quote(k)}`));
+	
+	const entityKey = entityKeyExpr(keys.map((k) => `${refRow}.${quote(k)}`));
 
 	// Single objectID field: simple COALESCE, no GROUP_CONCAT needed
 	if (objectIDs.length === 1) {
@@ -237,7 +239,7 @@ function buildObjectIDSelect(objectIDs, entity, entityKeys, refRow, model) {
 function buildTriggerContext(entity, objectIDs, refRow, model, compositionParentInfo = null) {
 	const keys = utils.extractKeys(entity.keys);
 	const entityKey = entityKeyExpr(keys.map((k) => `${refRow}.${quote(k)}`));
-	const objectID = buildObjectIDSelect(objectIDs, entity, keys, refRow, model) ?? entityKey;
+	const objectID = buildObjectIDSelect(objectIDs, entity, refRow, model) ?? entityKey;
 	const parentLookupExpr = compositionParentInfo ? 'PARENT_LOOKUP_PLACEHOLDER' : null;
 
 	return { keys, entityKey, objectID, parentLookupExpr };

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -1,7 +1,7 @@
 const utils = require('../utils/change-tracking.js');
 const config = require('@sap/cds').env.requires['change-tracking'];
 const { getCompositionParentInfo, getAncestorCompositionChain, resolveCompositionObjectIDs, parseCompositionFieldChangelog } = require('../utils/composition-helpers.js');
-const { getSkipCheckCondition, buildObjectIDSelect: buildObjectIdSqlExpr, buildTriggerContext, buildInsertSQL, entityKeyExpr, toSQL, quote } = require('./sql-expressions.js');
+const { getSkipCheckCondition, buildObjectIDSelect: buildObjectIdSqlExpr, buildTriggerContext, buildInsertSQL, toSQL, quote } = require('./sql-expressions.js');
 const { buildCompositionParentContext } = require('./composition.js');
 
 /**

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -7,17 +7,17 @@ const { buildCompositionParentContext } = require('./composition.js');
 /**
  * Builds an objectID SQL expression from a parsed composition field @changelog.
  */
-function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntityName, parentEntity, parentKeyBinding, refRow, model) {
+function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, model) {
 	const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, quote);
 	if (!parsed) return null;
 
 	if (parsed.type === 'expression') {
-		const query = SELECT.one.from(parsed.parentEntityName).columns(parsed.exprColumn).where(parsed.where);
+		const query = SELECT.one.from(parentEntity.name).columns(parsed.exprColumn).where(parsed.where);
 		return `(${toSQL(query, model)})`;
 	}
 
 	const parentKeys = utils.extractKeys(parentEntity.keys);
-	return buildObjectIDSelect(parsed.objectIDs, parentEntityName, parentKeys, refRow, model);
+	return buildObjectIDSelect(parsed.objectIDs, parentEntity, parentKeys, refRow, model);
 }
 
 function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
@@ -26,7 +26,7 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'new', model),
 		model
 	);
 
@@ -63,7 +63,7 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'new', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'new', model),
 		model
 	);
 
@@ -109,7 +109,7 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'old', model),
 		model
 	);
 
@@ -146,7 +146,7 @@ function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
-		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentName, parentEntity, keyBinding, 'old', model),
+		(changelog, parentName, parentEntity, keyBinding) => buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, 'old', model),
 		model
 	);
 

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -1,7 +1,7 @@
 const utils = require('../utils/change-tracking.js');
 const config = require('@sap/cds').env.requires['change-tracking'];
 const { getCompositionParentInfo, getAncestorCompositionChain, resolveCompositionObjectIDs, parseCompositionFieldChangelog } = require('../utils/composition-helpers.js');
-const { getSkipCheckCondition, buildObjectIDSelect, buildTriggerContext, buildInsertSQL, entityKeyExpr, toSQL, quote } = require('./sql-expressions.js');
+const { getSkipCheckCondition, buildObjectIDSelect: buildObjectIdSqlExpr, buildTriggerContext, buildInsertSQL, entityKeyExpr, toSQL, quote } = require('./sql-expressions.js');
 const { buildCompositionParentContext } = require('./composition.js');
 
 /**
@@ -17,12 +17,11 @@ function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, 
 	}
 
 	const parentKeys = utils.extractKeys(parentEntity.keys);
-	return buildObjectIDSelect(parsed.objectIDs, parentEntity, parentKeys, refRow, model);
+	return buildObjectIdSqlExpr(parsed.objectIDs, parentEntity, parentKeys, refRow, model);
 }
 
 function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const childKeys = utils.extractKeys(entity.keys);
-	const defaultChildObjectIDExpr = buildObjectIDSelect(objectIDs, entity.name, childKeys, 'new', model) ?? entityKeyExpr(childKeys.map((k) => `new.${k}`));
+	const defaultChildObjectIDExpr = buildObjectIdSqlExpr(objectIDs, entity, 'new', model);
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
@@ -58,8 +57,7 @@ function generateCreateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 }
 
 function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const childKeys = utils.extractKeys(entity.keys);
-	const defaultChildObjectIDExpr = buildObjectIDSelect(objectIDs, entity.name, childKeys, 'new', model) ?? entityKeyExpr(childKeys.map((k) => `new.${k}`));
+	const defaultChildObjectIDExpr = buildObjectIdSqlExpr(objectIDs, entity, 'new', model);
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
@@ -104,8 +102,7 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 }
 
 function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const childKeys = utils.extractKeys(entity.keys);
-	const defaultChildObjectIDExpr = buildObjectIDSelect(objectIDs, entity.name, childKeys, 'old', model) ?? entityKeyExpr(childKeys.map((k) => `old.${k}`));
+	const defaultChildObjectIDExpr = buildObjectIdSqlExpr(objectIDs, entity, 'old', model);
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,
@@ -141,8 +138,7 @@ function generateDeleteTriggerPreserve(entity, columns, objectIDs, rootObjectIDs
 }
 
 function generateDeleteTrigger(entity, columns, objectIDs, rootObjectIDs, model, compositionParentInfo = null, ancestorCompositionChain = []) {
-	const childKeys = utils.extractKeys(entity.keys);
-	const defaultChildObjectIDExpr = buildObjectIDSelect(objectIDs, entity.name, childKeys, 'old', model) ?? entityKeyExpr(childKeys.map((k) => `old.${k}`));
+	const defaultChildObjectIDExpr = buildObjectIdSqlExpr(objectIDs, entity, 'old', model);
 	const { childObjectIDExpr, compositionFieldObjectIDExpr } = resolveCompositionObjectIDs(
 		compositionParentInfo,
 		defaultChildObjectIDExpr,

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -97,20 +97,9 @@ function extractFKFieldsFromOnCondition(on, assocName) {
 	return fkFields;
 }
 
-// Extract entity key fields (flatten association keys to <name>_<fk>)
+// Extract entity key fields without association keys
 function extractKeys(keys) {
-	if (!keys) return [];
-	const result = [];
-	for (const k of keys) {
-		if (k.type === 'cds.Association' && !k._foreignKey4) continue;
-		if (k.type === 'cds.Association') {
-			const fks = extractForeignKeys(k.foreignKeys).map((fk) => `${k.name}_${fk}`);
-			result.push(...fks);
-		} else {
-			result.push(k.name);
-		}
-	}
-	return result;
+	return Object.keys(keys).filter(k => keys[k].type !== 'cds.Association');
 }
 /**
  * Retrieves changetracking columns from entity definition

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -99,7 +99,7 @@ function extractFKFieldsFromOnCondition(on, assocName) {
 
 // Extract entity key fields without association keys
 function extractKeys(keys) {
-	return Object.keys(keys).filter(k => keys[k].type !== 'cds.Association');
+	return Object.keys(keys).filter((k) => keys[k].type !== 'cds.Association');
 }
 /**
  * Retrieves changetracking columns from entity definition

--- a/lib/utils/composition-helpers.js
+++ b/lib/utils/composition-helpers.js
@@ -141,7 +141,7 @@ function getAncestorCompositionChain(rootEntity, ancestorChain, model) {
  * @param {object} parentEntity - CSN definition of the parent entity
  * @param {Array} parentKeyBinding - FK field names on the child entity pointing to the parent
  * @param {string} refRow - Trigger row reference
- * @returns {null | { type: 'expression', exprColumn: object, where: object, parentEntityName: string } | { type: 'paths', objectIDs: Array }}
+ * @returns {null | { type: 'expression', exprColumn: object, where: object } | { type: 'paths', objectIDs: Array }}
  */
 function parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, quoteFn) {
 	if (!compositionFieldChangelog || compositionFieldChangelog.length === 0) return null;
@@ -158,7 +158,7 @@ function parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity,
 			where[parentKeys[i]] = { val: `${refRow}.${q(parentKeyBinding[i])}`, literal: 'sql' };
 		}
 		const exprColumn = utils.buildExpressionColumn(expressionEntry.xpr);
-		return { type: 'expression', exprColumn, where, parentEntityName: parentEntity.name };
+		return { type: 'expression', exprColumn, where };
 	}
 
 	// Path-based annotation (e.g., @changelog: [orderNumber])

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -3,8 +3,7 @@
  * in trigger context. Used by all DB backends (SQLite, HANA, Postgres).
  *
  */
-function buildExpressionSQL(xpr, entityName, refRow, model, CQN2SQL, toSQL, colRef) {
-	const entity = model.definitions[entityName];
+function buildExpressionSQL(xpr, entity, refRow, model, CQN2SQL, toSQL, colRef) {
 	const fmt = colRef ?? ((r, c) => `${r}.${c}`);
 
 	const renderer = new CQN2SQL({ model });

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -147,3 +147,11 @@ entity NonExistentTable {
   key ID : UUID;
       name : String;
 }
+
+entity CustomTypeKeyTable {
+  key abc : CustomType;
+      name : String;
+      timezone : String default 'Asia/Riyadh' @Common.IsTimezone @changelog;
+}
+
+type CustomType : Association to one TrackingComposition;

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -32,6 +32,8 @@ service VariantTesting {
   entity ExtendedEvents as select from my.ExtendedEvents;
   entity DataExtractionSummaryView as select from my.DataExtractionSummaryView;
 
+  entity CustomTypeKeyTable as projection on my.CustomTypeKeyTable;
+
 }
 
 // Test: changes facet nested in CollectionFacet targeting changes/@UI.LineItem — plugin must not add a duplicate

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -97,7 +97,7 @@ describe('CDS Features', () => {
 				timezone: 'Europe/Amsterdam'
 			};
 			await INSERT.into(CustomTypeKeyTable).entries(customTypeData);
-			
+
 			let changes = await SELECT.from({ ref: [{ id: srvCustomTypeKeyTable.name, where: [{ ref: ['abc_ID'] }, '=', { val: customTypeData.abc_ID }] }, 'changes'] }).where({
 				entity: 'sap.change_tracking.CustomTypeKeyTable',
 				entityKey: customTypeData.abc_ID,

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -87,6 +87,24 @@ describe('CDS Features', () => {
 			let change = changes[0];
 			expect(change.valueTimeZone).toEqual('Europe/Amsterdam');
 		});
+
+		it('timezone field has timezone for dynamic annotation value and entity has custom association type as key', async () => {
+			const { CustomTypeKeyTable } = cds.entities('sap.change_tracking');
+			const { CustomTypeKeyTable: srvCustomTypeKeyTable } = cds.entities('VariantTesting');
+			const customTypeData = {
+				abc_ID: cds.utils.uuid(),
+				name: 'Test Name',
+				timezone: 'Europe/Amsterdam'
+			};
+			await INSERT.into(CustomTypeKeyTable).entries(customTypeData);
+			
+			let changes = await SELECT.from({ ref: [{ id: srvCustomTypeKeyTable.name, where: [{ ref: ['abc_ID'] }, '=', { val: customTypeData.abc_ID }] }, 'changes'] }).where({
+				entity: 'sap.change_tracking.CustomTypeKeyTable',
+				entityKey: customTypeData.abc_ID,
+				attribute: 'timezone'
+			});
+			expect(changes.length).toEqual(1);
+		});
 	});
 
 	describe('tracking dates', () => {


### PR DESCRIPTION
This PR closes gaps that would occur when using custom types like:
```cds
namespace test;

entity CustomTypeKeyTable {
  key abc : CustomType;
      name : String;
      timezone : String default 'Asia/Riyadh' @Common.IsTimezone @changelog;
}

type CustomType : Association to one TrackingComposition;
```
During the the `loaded` lifecycle event, the CSN model does include those abstract types unresolved which lead to the following errors:
- **CDS Deploy Error** because the `entityKey4()` function checked `e.type === 'cds.Association'` to detect association keys, but the custom type `CustomType` resolves to `test.CustomType`. This produced an incorrect entityKey expression in the `changes` association mapping.
- **Runtime Error on ChangeView**:  the timezone enhancement for `ChangeView` built a WHERE clause using raw element names for keys, but association keys are stored as flattened foreign key columns (`<assoc>_<fk>`). This caused a wrong where clause in the subselect for timezone columns.