### PR TITLE
fix: @changelog annotations on unmanaged associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.0-beta.12 - 29.04.26
+
+### Fixed
+- Build crash when using `@changelog` path annotations on unmanaged associations due to missing guard on `col.keys`
+- SQLite update trigger `OF` clause generates correct column names for unmanaged associations (e.g., `assocName_fkField` instead of `fkField`)
+- SQLite association label lookup using the entity's primary key instead of the foreign key field in the `where` clause for unmanaged associations
+- Deduplication of column names in update trigger `OF` clauses when a field is referenced by both a tracked element and an unmanaged association
+
+### Added
+- Optimization to skip unnecessary subselect lookups for unmanaged associations when the `@changelog` path references a target key that is already available as a local foreign key field
+
 ## Version 2.0.0-beta.11 - 28.04.26
 
 ### Added

--- a/lib/hana/restoreProcedure.js
+++ b/lib/hana/restoreProcedure.js
@@ -295,7 +295,7 @@ function _generateCompositionBlock(comp, model) {
 					}
 				}
 			],
-			groupBy: [parentKeyFromChildCQN, { ref: ['c', 'transactionID'] }, { ref: ['c', 'createdBy'] }]
+			groupBy: [parentKeyFromChildCQN, { ref: ['c', 'transactionID'] }]
 		}
 	};
 
@@ -499,7 +499,7 @@ function _generateCompositionBlock(comp, model) {
 						}
 					}
 				],
-				groupBy: [gpKeyFromParentCQN, { ref: ['comp2', 'transactionID'] }, { ref: ['comp2', 'createdBy'] }]
+				groupBy: [gpKeyFromParentCQN, { ref: ['comp2', 'transactionID'] }]
 			}
 		};
 

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -154,7 +154,7 @@ function getLabelExpr(col, refRow, model, entity) {
 	if (col.altExpression) {
 		const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
 		// Cast to NVARCHAR to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entity, refRow, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`)})`;
+		return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entity, refRow, model, toSQL, (r, c) => `:${r}.${quote(c)}`, CQN2SQLClass)})`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -204,7 +204,7 @@ function buildObjectIDExpr(objectIDs, entity, rowRef, model) {
 		} else if (oid.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-			const sql = buildExpressionSQL(oid.expression, entity, rowRef, model, CQN2SQLClass, toSQL, (r, c) => `:${r}.${quote(c)}`);
+			const sql = buildExpressionSQL(oid.expression, entity, rowRef, model, toSQL, (r, c) => `:${r}.${quote(c)}`, CQN2SQLClass);
 			parts.push(`TO_NVARCHAR(${sql})`);
 			nullChecks.push(`(${sql}) IS NULL`);
 		} else {

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -155,12 +155,12 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	}
 
 	// Build OF clause for targeted update trigger
-	const ofColumns = columns.flatMap((c) => {
+	const ofColumns = [...new Set(columns.flatMap((c) => {
 		if (!c.target) return [quote(c.name)];
 		if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k.replaceAll(/\./g, '_')}`));
 		if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
 		return [];
-	});
+	}))];
 	const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
 
 	return {

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -155,12 +155,16 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	}
 
 	// Build OF clause for targeted update trigger
-	const ofColumns = [...new Set(columns.flatMap((c) => {
-		if (!c.target) return [quote(c.name)];
-		if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k.replaceAll(/\./g, '_')}`));
-		if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
-		return [];
-	}))];
+	const ofColumns = [
+		...new Set(
+			columns.flatMap((c) => {
+				if (!c.target) return [quote(c.name)];
+				if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k.replaceAll(/\./g, '_')}`));
+				if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
+				return [];
+			})
+		)
+	];
 	const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
 
 	return {

--- a/lib/postgres/sql-expressions.js
+++ b/lib/postgres/sql-expressions.js
@@ -141,7 +141,7 @@ function getLabelExpr(col, refRow, model, entity) {
 		const PostgresService = require('@cap-js/postgres');
 		const CQN2SQLClass = PostgresService?.CQN2SQL ?? require('@cap-js/db-service/lib/cqn2sql');
 		// Cast to TEXT to ensure UNION compatibility — expression results may be numeric/date/etc.
-		return `(${buildExpressionSQL(col.altExpression, entity, refRow, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`)})::TEXT`;
+		return `(${buildExpressionSQL(col.altExpression, entity, refRow, model, toSQL, (r, c) => `${r}.${quote(c)}`, CQN2SQLClass)})::TEXT`;
 	}
 
 	if (!col.alt || col.alt.length === 0) return 'NULL';
@@ -188,7 +188,7 @@ function buildObjectIDAssignment(objectIDs, entity, keys, recVar, targetVar, mod
 			// Leave NULL as-is so CONCAT_WS skips unresolved expressions
 			const PostgresService = require('@cap-js/postgres');
 			const CQN2SQLClass = PostgresService?.CQN2SQL ?? require('@cap-js/db-service/lib/cqn2sql');
-			const sql = buildExpressionSQL(oid.expression, entity, recVar, model, CQN2SQLClass, toSQL, (r, c) => `${r}.${quote(c)}`);
+			const sql = buildExpressionSQL(oid.expression, entity, recVar, model, toSQL, (r, c) => `${r}.${quote(c)}`, CQN2SQLClass);
 			parts.push(`(${sql})::TEXT`);
 			nullChecks.push(`(${sql}) IS NULL`);
 		} else {

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -159,11 +159,11 @@ function getLabelExpr(col, refRow, model, entity) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
 	if (col.altExpression) {
 		const SQLiteService = require('@cap-js/sqlite');
-		const exprSQL = buildExpressionSQL(col.altExpression, entity, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
+		const exprSQL = `(${buildExpressionSQL(col.altExpression, entity, refRow, model, toSQL, (r, c) => `${r}.${quote(c)}`, SQLiteService.CQN2SQL)})`;
 		// Preserve decimal scale for arithmetic expressions on Decimal columns
 		// SQLite loses fractional digits when evaluating numeric expressions (e.g. 50 * 2 → 100).
 		if (col.type === 'cds.Decimal' && col.scale != null) {
-			return `CASE WHEN (${exprSQL}) IS NOT NULL THEN PRINTF('%.${col.scale}f', ${exprSQL}) ELSE NULL END`;
+			return `CASE WHEN ${exprSQL} IS NOT NULL THEN PRINTF('%.${col.scale}f', ${exprSQL}) ELSE NULL END`;
 		}
 		return exprSQL;
 	}
@@ -209,7 +209,7 @@ function buildObjectIDSelect(objectIDs, entity, refRow, model) {
 		if (objectID.expression) {
 			// Expression-based ObjectID: inline expression using trigger row refs
 			const SQLiteService = require('@cap-js/sqlite');
-			objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, SQLiteService.CQN2SQL, toSQL, (r, c) => `${r}.${quote(c)}`);
+			objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, toSQL, (r, c) => `${r}.${quote(c)}`, SQLiteService.CQN2SQL);
 		} else {
 			// Path-based ObjectID
 			const where = buildKeyWhere(keys, refRow);

--- a/lib/sqlite/sql-expressions.js
+++ b/lib/sqlite/sql-expressions.js
@@ -119,17 +119,19 @@ function getWhereCondition(col, modification) {
 /**
  * Builds scalar subselect for association label lookup with locale awareness
  */
-function buildAssocLookup(column, assocPaths, refRow, entityKey, model) {
-	const where = column.foreignKeys
-		? column.foreignKeys.reduce((acc, k) => {
-				acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
-				return acc;
-			}, {})
-		: column.on?.reduce((acc, k) => {
-				// Composition of aspect has a targetKey object
-				acc[k.targetKey ?? k] = { val: entityKey, literal: 'sql' };
-				return acc;
-			}, {});
+function buildAssocLookup(column, assocPaths, refRow, model) {
+	let where = {};
+	if (column.foreignKeys) {
+		where = column.foreignKeys.reduce((acc, k) => {
+			acc[k] = { val: `${refRow}.${quote(`${column.name}_${k}`)}`, literal: 'sql' };
+			return acc;
+		}, {});
+	} else if (column.on) {
+		where = column.on.reduce((acc, mapping) => {
+			acc[mapping.targetKey] = { val: `${refRow}.${quote(mapping.foreignKeyField)}`, literal: 'sql' };
+			return acc;
+		}, {});
+	}
 
 	// Drop the first part of each path (association name)
 	const alt = assocPaths.map((s) => s.split('.').slice(1).join('.'));
@@ -153,7 +155,7 @@ const { buildExpressionSQL } = require('../utils/expression-sql.js');
 /**
  * Returns SQL expression for a column's label (looked-up value for associations)
  */
-function getLabelExpr(col, refRow, entityKey, model, entity) {
+function getLabelExpr(col, refRow, model, entity) {
 	// Expression-based labels: translate CDS expression to SQL with trigger row refs
 	if (col.altExpression) {
 		const SQLiteService = require('@cap-js/sqlite');
@@ -173,7 +175,7 @@ function getLabelExpr(col, refRow, entityKey, model, entity) {
 
 	const flushAssocBatch = () => {
 		if (assocBatch.length > 0) {
-			parts.push(buildAssocLookup(col, assocBatch, refRow, entityKey, model));
+			parts.push(buildAssocLookup(col, assocBatch, refRow, model));
 			assocBatch = [];
 		}
 	};
@@ -267,8 +269,8 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 
 			const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
 			const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
-			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', ctx.entityKey, model, entity);
-			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', ctx.entityKey, model, entity);
+			const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity);
+			const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity);
 
 			// When an expression-based label is used, the label result type may differ from
 			// the element's declared type (e.g., a ternary returning strings on a Decimal column).

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -85,12 +85,16 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	}
 
 	// Build OF clause for targeted update trigger
-	const ofColumns = [...new Set(columns.flatMap((c) => {
-		if (!c.target) return [quote(c.name)];
-		if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k}`));
-		if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
-		return [];
-	}))];
+	const ofColumns = [
+		...new Set(
+			columns.flatMap((c) => {
+				if (!c.target) return [quote(c.name)];
+				if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k}`));
+				if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
+				return [];
+			})
+		)
+	];
 	const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
 
 	return `CREATE TRIGGER IF NOT EXISTS ${utils.transformName(entity.name)}_ct_update AFTER UPDATE ${ofClause}

--- a/lib/sqlite/triggers.js
+++ b/lib/sqlite/triggers.js
@@ -85,12 +85,12 @@ function generateUpdateTrigger(entity, columns, objectIDs, rootObjectIDs, model,
 	}
 
 	// Build OF clause for targeted update trigger
-	const ofColumns = columns.flatMap((c) => {
+	const ofColumns = [...new Set(columns.flatMap((c) => {
 		if (!c.target) return [quote(c.name)];
 		if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k}`));
-		if (c.on) return c.on.map((m) => quote(`${c.name}_${m.foreignKeyField}`));
+		if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
 		return [];
-	});
+	}))];
 	const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
 
 	return `CREATE TRIGGER IF NOT EXISTS ${utils.transformName(entity.name)}_ct_update AFTER UPDATE ${ofClause}

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -265,6 +265,7 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 				// for managed associations with generated foreign keys
 				entry.foreignKeys = col.keys.flatMap((k) => k.ref);
 			} else if (onMapping) {
+				// for unmanaged associations, use the parsed on-condition mapping
 				entry.on = onMapping;
 			}
 		} else if (Array.isArray(changelogAnnotation) && changelogAnnotation.length > 0) {

--- a/lib/utils/change-tracking.js
+++ b/lib/utils/change-tracking.js
@@ -206,6 +206,27 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 				continue;
 			}
 			entry.target = col.target;
+
+			// Parse on-condition mapping once for unmanaged associations
+			let onMapping = null;
+			if (!col.keys && col.on) {
+				onMapping = [];
+				for (let i = 0; i < col.on.length; i++) {
+					const cond = col.on[i];
+					if (cond.ref && cond.ref.length === 2 && cond.ref[0] === name) {
+						const targetKey = cond.ref[1];
+						if (i + 1 < col.on.length && col.on[i + 1] === '=') {
+							const fkRef = col.on[i + 2];
+							if (fkRef?.ref) {
+								const fkField = fkRef.ref[fkRef.ref.length - 1];
+								onMapping.push({ targetKey, foreignKeyField: fkField });
+							}
+						}
+					}
+				}
+				if (onMapping.length === 0) onMapping = null;
+			}
+
 			// Use the resolved changelog annotation (which could be from override)
 			if (Array.isArray(changelogAnnotation) && changelogAnnotation.length > 0) {
 				// Check if the entry is an expression
@@ -224,10 +245,17 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 					}
 					// If alt is the same as foreign keys, no need to generate lookup
 					const paths = alt.map((a) => a.path);
-					const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replaceAll('_', '.'));
-
-					if (paths.join(',') === foreignKeys.join(',')) {
-						alt = [];
+					if (col.keys) {
+						const foreignKeys = col.keys.map((k) => k.$generatedFieldName.replaceAll('_', '.'));
+						if (paths.join(',') === foreignKeys.join(',')) {
+							alt = [];
+						}
+					} else if (onMapping) {
+						// For unmanaged associations, check if all alt paths reference target keys
+						const onTargetPaths = onMapping.map((m) => `${name}.${m.targetKey}`);
+						if (paths.join(',') === onTargetPaths.join(',')) {
+							alt = [];
+						}
 					}
 					if (alt.length > 0) entry.alt = alt;
 				}
@@ -236,25 +264,8 @@ function extractTrackedColumns(entity, model = cds.context?.model ?? cds.model, 
 			if (col.keys) {
 				// for managed associations with generated foreign keys
 				entry.foreignKeys = col.keys.flatMap((k) => k.ref);
-			} else if (col.on) {
-				// for unmanaged associations (multiple conditions possible)
-				const mapping = [];
-				for (let i = 0; i < col.on.length; i++) {
-					const cond = col.on[i];
-					if (cond.ref && cond.ref.length === 2 && cond.ref[0] === name) {
-						const targetKey = cond.ref[1];
-						// next should be '='
-						if (i + 1 < col.on.length && col.on[i + 1] === '=') {
-							const fkRef = col.on[i + 2];
-							if (fkRef?.ref) {
-								// get last segement as foreign key field
-								const fkField = fkRef.ref[fkRef.ref.length - 1];
-								mapping.push({ targetKey, foreignKeyField: fkField });
-							}
-						}
-					}
-				}
-				if (mapping.length > 0) entry.on = mapping;
+			} else if (onMapping) {
+				entry.on = onMapping;
 			}
 		} else if (Array.isArray(changelogAnnotation) && changelogAnnotation.length > 0) {
 			// Non-association elements with expression-based @changelog labels

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -133,6 +133,20 @@ function _normalizeEntry(entry, srvEntity, model) {
 					entryChanged = true;
 					return { ...token, ref: [dbRef[0], ...token.ref.slice(1)] };
 				}
+				// Handle flattened FK refs from renamed associations (e.g., renamedStatus_code -> status_code)
+				if (token.ref.length === 1) {
+					const refName = token.ref[0];
+					for (const el of srvEntity.elements) {
+						if (el.target && refName.startsWith(el.name + '_')) {
+							const canonical = _getDbRef(srvEntity, el.name, model);
+							if (canonical[0] !== el.name) {
+								const suffix = refName.slice(el.name.length);
+								entryChanged = true;
+								return { ...token, ref: [canonical[0] + suffix] };
+							}
+						}
+					}
+				}
 			}
 			return token;
 		});

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -14,12 +14,11 @@ function buildExpressionSQL(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL) 
 	// Build a subselect from the association target entity
 	let result;
 	if (!hasLocal && assocNames.length === 1) {
-		result = _buildSingleAssocExpression(xpr, entity, assocNames[0], refRow, model, toSQL, colRef);
+		return _buildSingleAssocExpression(xpr, entity, assocNames[0], refRow, model, toSQL, colRef);
 	}
 
 	// Case A (local-only) and Case C (mixed): Use inline CQN2SQL rendering
-	result = _buildInlineExpression(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL);
-	return result;
+	return _buildInlineExpression(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL);
 }
 
 /**

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -1,5 +1,3 @@
-const utils = require('../utils/change-tracking.js');
-
 /**
  * Shared utility for translating CDS expression annotations (xpr) to SQL
  * in trigger context. Used by all DB backends (SQLite, HANA, Postgres).

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -1,52 +1,146 @@
+const utils = require('../utils/change-tracking.js');
+
 /**
  * Shared utility for translating CDS expression annotations (xpr) to SQL
  * in trigger context. Used by all DB backends (SQLite, HANA, Postgres).
  *
+ * Classifies the expression and dispatches to the appropriate strategy:
+ * - Case A (local-only): Inline rendering using trigger row refs
+ * - Case B (single association, no local fields): Subselect from target entity
+ * - Case C (mixed local + association, or multiple associations): Inline with scalar subselects per association ref
  */
-function buildExpressionSQL(xpr, entity, refRow, model, CQN2SQL, toSQL, colRef) {
-	const fmt = colRef ?? ((r, c) => `${r}.${c}`);
+function buildExpressionSQL(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL) {
+	const { hasLocal, assocNames } = _classifyExpression(xpr);
 
+	// Case B: Single association, no local fields
+	// Build a subselect from the association target entity
+	let result;
+	if (!hasLocal && assocNames.length === 1) {
+		result = _buildSingleAssocExpression(xpr, entity, assocNames[0], refRow, model, toSQL, colRef);
+	}
+
+	// Case A (local-only) and Case C (mixed): Use inline CQN2SQL rendering
+	result = _buildInlineExpression(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL);
+	return result;
+}
+
+/**
+ * Classifies an xpr by analyzing its ref tokens.
+ * @returns {{ hasLocal: boolean, assocNames: string[] }}
+ */
+function _classifyExpression(xpr) {
+	let hasLocal = false;
+	const assocSet = new Set();
+
+	for (const token of xpr) {
+		if (token?.ref) {
+			if (token.ref.length === 1) {
+				hasLocal = true;
+			} else {
+				assocSet.add(token.ref[0]);
+			}
+		}
+		// Recurse into nested xpr (e.g., ternary/CASE expressions)
+		if (token?.xpr) {
+			const nested = _classifyExpression(token.xpr);
+			if (nested.hasLocal) hasLocal = true;
+			for (const a of nested.assocNames) assocSet.add(a);
+		}
+	}
+
+	return { hasLocal, assocNames: [...assocSet] };
+}
+
+/**
+ * Case B: Expression references only fields from a single association target.
+ * Builds a SELECT from the target entity with the expression (refs stripped of assoc prefix)
+ * and WHERE clause using FK fields from the trigger row.
+ */
+function _buildSingleAssocExpression(xpr, entity, assocName, refRow, model, toSQL, colRef) {
+	const assocElement = entity.elements[assocName];
+	const target = assocElement.target;
+
+	// Strip the association prefix from all refs in the xpr
+	const strippedXpr = _stripAssocPrefix(xpr, assocName);
+
+	// Build WHERE clause using FK fields from trigger row
+	const where = _buildAssocWhere(assocElement, assocName, refRow, colRef);
+
+	const query = SELECT.one.from(target).columns({ xpr: strippedXpr, as: 'value' }).where(where);
+	return toSQL(query, model);
+}
+
+/**
+ * Cases A & C: Use CQN2SQL with a custom ref handler to render the expression inline.
+ * - Single-segment refs (local fields) -> trigger row references
+ * - Multi-segment refs (association paths) -> scalar subselects from the target entity
+ */
+function _buildInlineExpression(xpr, entity, refRow, model, toSQL, colRef, CQN2SQL) {
 	const renderer = new CQN2SQL({ model });
 	renderer.ref = function ({ ref }) {
-		if (ref.length === 1) return fmt(refRow, ref[0]);
+		if (ref.length === 1) {
+			// Local field: inline trigger row reference
+			return colRef(refRow, ref[0]);
+		}
 
-		// Multi-segment ref: association path -> scalar subquery against target
+		// Multi-segment ref: association path -> scalar subquery against the target
 		const assocName = ref[0];
-		const fieldPath = ref.slice(1).join('_');
 		const assocElement = entity?.elements?.[assocName];
 		if (assocElement?.target) {
-			const where = _buildAssocWhere(assocElement, assocName, refRow, fmt);
-			const query = SELECT.from(assocElement.target).columns(fieldPath).where(where);
+			// Build subselect from the target entity using remaining ref segments as column
+			// cqn4sql will resolve nested association paths (e.g., customer.address.city)
+			const remainingRef = ref.slice(1);
+			const where = _buildAssocWhere(assocElement, assocName, refRow, colRef);
+			const query = SELECT.one.from(assocElement.target).columns({ ref: remainingRef, as: 'value' }).where(where);
 			return `(${toSQL(query, model)})`;
 		}
+
 		// Fallback: flattened field reference
-		return fmt(refRow, ref.join('_'));
+		return colRef(refRow, ref.join('_'));
 	};
 
 	return renderer.xpr({ xpr });
 }
 
 /**
- * Builds a CQN WHERE object for looking up an association target
- * using trigger-row FK values.
+ * Strips the association prefix from all refs in an xpr array.
+ * e.g., { ref: ['status', 'code'] } -> { ref: ['code'] }
  */
-function _buildAssocWhere(assocElement, assocName, refRow, fmt) {
-	const where = {};
-	if (assocElement.keys) {
-		for (const k of assocElement.keys) {
-			const fkName = k.ref.join('_');
-			where[fkName] = { val: fmt(refRow, `${assocName}_${fkName}`), literal: 'sql' };
+function _stripAssocPrefix(xpr, assocName) {
+	return xpr.map((token) => {
+		if (token?.ref && token.ref.length > 1 && token.ref[0] === assocName) {
+			return { ...token, ref: token.ref.slice(1) };
 		}
-	} else if (assocElement.on) {
-		for (let i = 0; i < assocElement.on.length; i++) {
-			const cond = assocElement.on[i];
+		if (token?.xpr) {
+			return { ...token, xpr: _stripAssocPrefix(token.xpr, assocName) };
+		}
+		return token;
+	});
+}
+
+/**
+ * Builds a CQN WHERE object for looking up an association target
+ * using trigger-row FK values. Handles both managed and unmanaged associations.
+ */
+function _buildAssocWhere(column, assocName, refRow, colRef) {
+	const where = {};
+	if (column.keys) {
+		// Managed association: FK fields are named assocName_keyRef
+		for (const k of column.keys) {
+			const fkName = k.ref.join('_');
+			where[fkName] = { val: colRef(refRow, `${assocName}_${fkName}`), literal: 'sql' };
+		}
+	} else if (column.on) {
+		// Unmanaged association: parse on-condition for FK mapping
+		for (let i = 0; i < column.on.length; i++) {
+			const cond = column.on[i];
 			if (cond.ref && cond.ref.length === 2 && cond.ref[0] === assocName) {
 				const targetKey = cond.ref[1];
-				if (i + 1 < assocElement.on.length && assocElement.on[i + 1] === '=') {
-					const fkRef = assocElement.on[i + 2];
+				if (i + 1 < column.on.length && column.on[i + 1] === '=') {
+					const fkRef = column.on[i + 2];
 					if (fkRef?.ref) {
 						const fkField = fkRef.ref[fkRef.ref.length - 1];
-						where[targetKey] = { val: fmt(refRow, fkField), literal: 'sql' };
+						where[targetKey] = { val: colRef(refRow, fkField), literal: 'sql' };
 					}
 				}
 			}

--- a/lib/utils/expression-sql.js
+++ b/lib/utils/expression-sql.js
@@ -64,7 +64,7 @@ function _buildSingleAssocExpression(xpr, entity, assocName, refRow, model, toSQ
 	const where = _buildAssocWhere(assocElement, assocName, refRow, colRef);
 
 	const query = SELECT.one.from(target).columns({ xpr: strippedXpr, as: 'value' }).where(where);
-	return toSQL(query, model);
+	return `(${toSQL(query, model)})`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cap-js/change-tracking",
-	"version": "2.0.0-beta.11",
+	"version": "2.0.0-beta.12",
 	"publishConfig": {
 		"access": "public",
 		"tag": "beta"

--- a/tests/bookshop/db/incidents/schema.cds
+++ b/tests/bookshop/db/incidents/schema.cds
@@ -141,7 +141,7 @@ entity DynamicLocalizationScenarios : cuid {
   status3 : Association to one VHWithMultiKey @changelog : [status3.name]; //Target has multiple keys -> not possible
 
   status4 : String @changelog : [status4Nav.descr]; //Unmanaged association -> possible;
-  status4Nav: Association to one Status on status4Nav.code = status4;
+  status4Nav: Association to one Status on status4Nav.code = status4 @changelog : [status4Nav.descr];
 }
 
 entity VHWithMultiKey : CodeList {

--- a/tests/bookshop/db/incidents/schema.cds
+++ b/tests/bookshop/db/incidents/schema.cds
@@ -30,7 +30,7 @@ entity Addresses : cuid, managed {
 /**
  * Incidents created by Customers.
  */
-@changelog : (customer.name || ': ' || status.descr)
+@changelog : (customer.name || ': ' || customer.address.city || ' - ' || title)
 @title : 'Support Incidents'
 entity Incidents : cuid, managed {
   customer       : Association to Customers @changelog : [customer.name];

--- a/tests/integration/annotation-interpretation.test.js
+++ b/tests/integration/annotation-interpretation.test.js
@@ -653,7 +653,7 @@ describe('@changelog annotation interpretation', () => {
 			// The objectID should be resolved from the entity-level @changelog expression
 			const statusChange = changes.find((c) => c.attribute === 'status' && c.modification === 'update');
 			expect(statusChange).toBeDefined();
-			expect(statusChange.objectID).toEqual('Stormy Weathers: Assigned');
+			expect(statusChange.objectID).toEqual('Stormy Weathers: Munich - Entity-level expression test');
 		});
 	});
 });

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -817,6 +817,31 @@ describe('CDS Features', () => {
 			const valueChangedToLabel = ChangeView.query.SELECT.columns.find((c) => c.as === 'valueChangedToLabel');
 			expect(valueChangedToLabel.xpr.some((r) => r.val === 'status3')).toEqual(false);
 		});
+
+		it('Tracks changes on unmanaged association element with @changelog path annotation', async () => {
+			const {
+				data: { ID: incidentID }
+			} = await POST(`odata/v4/localization/DynamicLocalizationScenarios`, {
+				status4: 'N'
+			});
+			await PATCH(`odata/v4/localization/DynamicLocalizationScenarios(ID=${incidentID})`, {
+				status4: 'R'
+			});
+			const {
+				data: { value: changes }
+			} = await GET(`odata/v4/localization/DynamicLocalizationScenarios(ID=${incidentID})/changes`, {
+				headers: { 'Accept-Language': 'en' }
+			});
+			const statusNavChange = changes.find(
+				(change) => change.attribute === 'status4Nav' && change.modification === 'update' && change.entityKey === incidentID
+			);
+			expect(statusNavChange).toMatchObject({
+				valueChangedFrom: 'N',
+				valueChangedFromLabel: 'New',
+				valueChangedTo: 'R',
+				valueChangedToLabel: 'Resolved'
+			});
+		});
 	});
 
 	describe('Draft', () => {

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -832,9 +832,7 @@ describe('CDS Features', () => {
 			} = await GET(`odata/v4/localization/DynamicLocalizationScenarios(ID=${incidentID})/changes`, {
 				headers: { 'Accept-Language': 'en' }
 			});
-			const statusNavChange = changes.find(
-				(change) => change.attribute === 'status4Nav' && change.modification === 'update' && change.entityKey === incidentID
-			);
+			const statusNavChange = changes.find((change) => change.attribute === 'status4Nav' && change.modification === 'update' && change.entityKey === incidentID);
 			expect(statusNavChange).toMatchObject({
 				valueChangedFrom: 'N',
 				valueChangedFromLabel: 'New',

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -2214,7 +2214,7 @@ describe('Expression-based @changelog annotations', () => {
 		expect(firstNameChange.objectID).toEqual('John Doe');
 	});
 
-	it('uses expression for label when element has @changelog : [(status.code || status.descr)]', async () => {
+	it('uses expression for label when element has @changelog : (status.code || status.descr)', async () => {
 		const {
 			data: { ID }
 		} = await POST(`/odata/v4/localization/ExpressionScenarios`, {


### PR DESCRIPTION
- Guard col.keys access to prevent crash for unmanaged associations
- Fix SQLite trigger OF clause using wrong column name (assocName_fkField → fkField)
- Fix SQLite buildAssocLookup WHERE using entity PK instead of FK field
- Deduplicate OF clause columns in SQLite and HANA triggers
- Add optimization to skip unnecessary subselect when @changelog path matches on-condition target key
- Add test