### PR TITLE
Improve CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -12,6 +12,10 @@ jobs:
   label_issues:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - run: gh issue edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -17,6 +17,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/setup-node@v4
       - uses: actions/checkout@v4
       - run: npm i

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -19,6 +19,10 @@ jobs:
       matrix:
         cds-version: [latest]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v5
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -21,6 +21,10 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-js'
     environment: pr-approval
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Approval Step
         run: echo "This job has been approved!"
   perf-tests:
@@ -37,6 +41,10 @@ jobs:
         cds-version: [latest, 8]
     steps:
 
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/prevent-issue-labeling.yml
+++ b/.github/workflows/prevent-issue-labeling.yml
@@ -11,6 +11,10 @@ jobs:
   remove_new_label:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Remove "New" label if applied by non-bot user
         if: >
           contains(github.event.issue.labels.*.name, 'New') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: "Metadata Creation Tool"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: SAP/metadata-creation-tool-for-reuse@main
         with:
           repository_url: "${{ github.server_url }}/${{ github.repository }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/stale@v10
         with:
           close-issue-message: "This issue has been automatically closed due to 2 weeks of inactivity. If you believe this was a mistake, please reopen or comment to continue the discussion."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-js'
     environment: pr-approval
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Approval Step
         run: echo "This job has been approved!"
 
@@ -32,6 +36,10 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -57,6 +65,10 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -108,6 +120,10 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Add dependabot for NPM and GitHub Actions. Weekly checks with 1 day cooldown to avoid pushing freshly compromised deps.

Add [Harden Runner](https://github.com/step-security/harden-runner) to all GitHub Actions to monitor the processes.