### PR TITLE
chore: fix concurrency for performance tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,7 +25,7 @@ jobs:
     needs: requires-approval
     if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     concurrency:
-      group: performance-tests
+      group: performance-tests-${{ matrix.cds-version }}
     name: Performance tests for ${{ matrix.node-version }} and CAP ${{ matrix.cds-version }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
because otherwise one of the two runs is always cancelled