### PR TITLE
fix: prevent merge duplicate error in restore backlinks procedure

### DIFF
--- a/lib/hana/restoreProcedure.js
+++ b/lib/hana/restoreProcedure.js
@@ -265,6 +265,10 @@ function _generateCompositionBlock(comp, model) {
 				'<>',
 				{ val: 'cds.Composition' },
 				'and',
+				{ ref: ['c', 'entityKey'] },
+				'is not',
+				'null',
+				'and',
 				'not',
 				'exists',
 				{
@@ -369,10 +373,16 @@ function _generateCompositionBlock(comp, model) {
 			from: step2From,
 			columns: [
 				{ ref: ['c2', 'ID'], as: 'CHILD_ID' },
-				{ ref: ['p', 'ID'], as: 'PARENT_ID' },
-				{ ...childObjectIdCQN, as: 'CHILD_OBJECTID' }
+				{ func: 'min', args: [{ ref: ['p', 'ID'] }], as: 'PARENT_ID' },
+				{ func: 'min', args: [{ ...childObjectIdCQN }], as: 'CHILD_OBJECTID' }
 			],
-			where: [{ ref: ['c2', 'entity'] }, '=', { val: childEntityName }, 'and', { ref: ['c2', 'parent_ID'] }, 'is', 'null', 'and', { ref: ['c2', 'valueDataType'] }, '<>', { val: 'cds.Composition' }]
+			where: [
+				{ ref: ['c2', 'entity'] }, '=', { val: childEntityName },
+				'and', { ref: ['c2', 'parent_ID'] }, 'is', 'null',
+				'and', { ref: ['c2', 'valueDataType'] }, '<>', { val: 'cds.Composition' },
+				'and', { ref: ['c2', 'entityKey'] }, 'is not', 'null'
+			],
+			groupBy: [{ ref: ['c2', 'ID'] }]
 		}
 	};
 
@@ -469,6 +479,10 @@ function _generateCompositionBlock(comp, model) {
 					'is',
 					'null',
 					'and',
+					{ ref: ['comp2', 'entityKey'] },
+					'is not',
+					'null',
+					'and',
 					'not',
 					'exists',
 					{
@@ -545,7 +559,7 @@ function _generateCompositionBlock(comp, model) {
 				},
 				columns: [
 					{ ref: ['comp2', 'ID'], as: 'COMP_ID' },
-					{ ref: ['gp', 'ID'], as: 'GRANDPARENT_ID' }
+					{ func: 'min', args: [{ ref: ['gp', 'ID'] }], as: 'GRANDPARENT_ID' }
 				],
 				where: [
 					{ ref: ['comp2', 'entity'] },
@@ -562,8 +576,13 @@ function _generateCompositionBlock(comp, model) {
 					'and',
 					{ ref: ['comp2', 'parent_ID'] },
 					'is',
+					'null',
+					'and',
+					{ ref: ['comp2', 'entityKey'] },
+					'is not',
 					'null'
-				]
+				],
+				groupBy: [{ ref: ['comp2', 'ID'] }]
 			}
 		};
 

--- a/tests/integration/configuration.test.js
+++ b/tests/integration/configuration.test.js
@@ -914,6 +914,43 @@ describe('Configuration Options', () => {
 		expect(restoredChange).toBeTruthy();
 		expect(restoredChange.objectID).toEqual(parentID);
 	});
+
+	it('handles entries with NULL entityKey gracefully (no MERGE duplicate error)', async () => {
+		// Simulate broken v1 data: entries with NULL entityKey that would cause
+		// HANA error 689 "duplicate rowid matched during merge into"
+		const txID = cds.utils.uuid();
+		const nullKeyEntries = Array.from({ length: 5 }, () => ({
+			ID: cds.utils.uuid(),
+			entity: 'sap.change_tracking.Level2Sample',
+			entityKey: null,
+			attribute: 'title',
+			objectID: null,
+			modification: 'update',
+			valueChangedFrom: 'old',
+			valueChangedTo: 'new',
+			valueDataType: 'cds.String',
+			parent_ID: null,
+			transactionID: txID,
+			createdAt: new Date().toISOString(),
+			createdBy: 'test-user'
+		}));
+
+		await INSERT.into('sap.changelog.Changes').entries(nullKeyEntries);
+
+		// This should NOT throw "duplicate rowid matched during merge into"
+		await cds.run(`CALL "SAP_CHANGELOG_RESTORE_BACKLINKS"();`);
+
+		// The NULL entityKey entries should remain unlinked (parent_ID still NULL)
+		const unlinked = await SELECT.from('sap.changelog.Changes').where({
+			transactionID: txID,
+			entity: 'sap.change_tracking.Level2Sample',
+			parent_ID: null
+		});
+		expect(unlinked.length).toBe(5);
+
+		// Cleanup
+		await cds.delete('sap.changelog.Changes').where({ transactionID: txID });
+	});
 });
 describe('MTX Build', () => {
 	it('adds changes association only during runtime compilation, not during xtended CSN build', async () => {


### PR DESCRIPTION
# Fix: Prevent Merge Duplicate Error in Restore Backlinks Procedure

### Bug Fix

🐛 Resolved a HANA error 689 ("duplicate rowid matched during merge into") that could occur during the `RESTORE_BACKLINKS` procedure when processing legacy (v1) change entries with `NULL` `entityKey` values. Multiple rows with `NULL` `entityKey` caused ambiguous matches in `MERGE INTO` operations, leading to duplicate row conflicts.

### Changes

* `lib/hana/restoreProcedure.js`:
  - Added `entityKey IS NOT NULL` filter conditions to the `WHERE` clauses of the relevant query steps (step1, step2, step3b), ensuring entries with `NULL` `entityKey` are excluded from backlink restoration processing.
  - Wrapped `PARENT_ID`, `CHILD_OBJECTID`, and `GRANDPARENT_ID` column references in `min()` aggregate functions to prevent duplicate row issues when multiple records match the same join key.
  - Added `GROUP BY` clauses to step2 and step3b queries to align with the aggregate functions and ensure deterministic results.
  - Reformatted the `WHERE` clause of step2 for improved readability.

* `tests/integration/configuration.test.js`:
  - Added a new integration test case: `'handles entries with NULL entityKey gracefully (no MERGE duplicate error)'` that inserts multiple broken v1-style change entries with `NULL` `entityKey` and verifies that calling `SAP_CHANGELOG_RESTORE_BACKLINKS` does not throw a duplicate merge error. Also asserts that those entries remain unlinked (`parent_ID` still `NULL`) after the procedure runs.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `5df852ba-96cf-44d4-8f41-561a595ac69f`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
