### PR TITLE
Prepare beta 12 release

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -57,11 +57,11 @@ runs:
           fi
         done
 
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js ${{ inputs.NODE_VERSION}}
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
     - name: Set CDS version-specific dependencies

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -17,8 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: npm i
       - run: npm run lint
       - run: npm run format:check

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         cds-version: [latest]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js 22.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -96,6 +96,8 @@ jobs:
             npm pkg set "overrides.@sap/cds-mtxs=^2"
             npm pkg set "overrides.@sap/cds-dk=^8"
             npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
+            npm pkg set "devDependencies.@cap-js/cds-test=^0"
+            npm pkg set "overrides.@cap-js/cds-test=^0"
             # Update workspace package dependencies to CDS 8 compatible versions
             cd ./tests/performance/perf-bookshop
             npm pkg set "dependencies.@sap/cds=^8.9.8"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -34,11 +34,11 @@ jobs:
         cds-version: [latest, 8]
     steps:
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version}}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 24
         registry-url: https://registry.npmjs.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,11 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
@@ -57,11 +57,11 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set CDS 8 compatible dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 2.0.0-beta.12 - 29.04.26
+## Version 2.0.0-beta.12 - 18.05.26
 
 ### Fixed
 - Build crash when using `@changelog` path annotations on unmanaged associations due to missing guard on `col.keys`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - SQLite update trigger `OF` clause generates correct column names for unmanaged associations (e.g., `assocName_fkField` instead of `fkField`)
 - SQLite association label lookup using the entity's primary key instead of the foreign key field in the `where` clause for unmanaged associations
 - Deduplication of column names in update trigger `OF` clauses when a field is referenced by both a tracked element and an unmanaged association
+- Prevent server crash when no db connection is available during session variable assignment
 
 ### Added
 - Optimization to skip unnecessary subselect lookups for unmanaged associations when the `@changelog` path references a target key that is already available as a local foreign key field

--- a/lib/skipHandlers.js
+++ b/lib/skipHandlers.js
@@ -8,7 +8,7 @@ const { setSkipSessionVariables, resetSkipSessionVariables, resetAutoSkipForServ
  */
 function registerSessionVariableHandlers() {
 	cds.db?.before(['INSERT', 'UPDATE', 'DELETE'], async (req) => {
-		if (!req._tx?.dbc) return; // check for existing db connection 
+		if (!req._tx?.dbc) return; // check for existing db connection
 		const model = cds.context?.model ?? cds.model;
 		const collectedEntities = model.collectEntities || (model.collectEntities = collectEntities(model).collectedEntities);
 		if (!req.target || req.target.name.endsWith('.drafts')) return;

--- a/lib/skipHandlers.js
+++ b/lib/skipHandlers.js
@@ -8,6 +8,7 @@ const { setSkipSessionVariables, resetSkipSessionVariables, resetAutoSkipForServ
  */
 function registerSessionVariableHandlers() {
 	cds.db?.before(['INSERT', 'UPDATE', 'DELETE'], async (req) => {
+		if (!req._tx?.dbc) return; // check for existing db connection 
 		const model = cds.context?.model ?? cds.model;
 		const collectedEntities = model.collectEntities || (model.collectEntities = collectEntities(model).collectedEntities);
 		if (!req.target || req.target.name.endsWith('.drafts')) return;
@@ -17,6 +18,7 @@ function registerSessionVariableHandlers() {
 	});
 
 	cds.db?.after(['INSERT', 'UPDATE', 'DELETE'], async (_, req) => {
+		if (!req._tx?.dbc) return;
 		if (!req.target || req.target.name.endsWith('.drafts') || !req.target._service) return;
 
 		// Reset auto-skip variable if it was set

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -7,7 +7,7 @@
 	},
 	"devDependencies": {
 		"@cap-js/sqlite": "^1 || ^2",
-		"@sap/cds-dk": "^9.8.2",
+		"@sap/cds-dk": "^9",
 		"puppeteer": "^24.40.0",
 		"ui5-test-runner": "^5.13.1"
 	},


### PR DESCRIPTION
# Prepare Beta 12 Release

### Chore

🔖 Updates the release date for version `2.0.0-beta.12` in the changelog from `29.04.26` to `18.05.26`.

### Changes

* `CHANGELOG.md`: Corrected the release date for `2.0.0-beta.12` to `18.05.26`. The changelog entry documents the following fixes and additions in this release:
  - **Fixed**: Build crash with `@changelog` path annotations on unmanaged associations
  - **Fixed**: SQLite update trigger `OF` clause now generates correct column names for unmanaged associations
  - **Fixed**: SQLite association label lookup now uses the foreign key field instead of the primary key in `where` clauses
  - **Fixed**: Deduplication of column names in update trigger `OF` clauses
  - **Added**: Optimization to skip unnecessary subselect lookups for unmanaged associations when the `@changelog` path references a target key available as a local foreign key

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Correlation ID: `05272e30-9bdf-41ab-b519-51d5a579548e`
</details>
