### PR TITLE
feat: dynamic datetime formatting with service-level `@changelog` and `@Common.TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 2.0.0-beta.13 - tbd
 
+### Added
+- Consider `@Common.Timezone` on entities that are change-tracked only via a service-level `@changelog`.  Previously, `valueTimeZone` in `ChangeView` was resolved only for entities annotated with `@changelog` at the DB level
+
 ### Fixed
 - Migration table now correctly handles composite keys from v1 using `HIERARCHY_COMPOSITE_ID` (supports up to 5 key parts)
 

--- a/lib/csn-enhancements/timezoneProperties.js
+++ b/lib/csn-enhancements/timezoneProperties.js
@@ -1,32 +1,68 @@
 const cds = require('@sap/cds');
+const LOG = cds.log('change-tracking');
 const { entityKeyExpr: entityKeyExprSqlite } = require('../sqlite/sql-expressions');
 const { entityKeyExpr: entityKeyExprHANA } = require('../hana/sql-expressions');
 const { entityKeyExpr: entityKeyExprPG } = require('../postgres/sql-expressions');
-const { isChangeTracked } = require('../utils/entity-collector');
+const { isChangeTracked, getBaseEntity, normalizeAnnotationRefs, getDbElementName } = require('../utils/entity-collector');
+
+function _buildTimezoneValue(annotation, dbEntityName) {
+  if (annotation?.['=']) {
+    // build a sub-SELECT against the DB entity for dynamic timezone
+    return SELECT.from(dbEntityName).alias('timezoneSubSelect').where('1 = 1').columns(annotation['=']);
+  }
+  return annotation;
+}
 
 function collectTrackedPropertiesWithTimezone(m) {
-  const timezoneProperties = [];
+  // Map keyed by "dbEntityName::dbElementName" → { property, entity, timezone }
+  const collected = new Map();
+
   for (const name in m.definitions) {
     const entity = m.definitions[name];
-    if (entity.kind !== 'entity' || entity.query || entity.projection || !isChangeTracked(entity)) {
-      continue;
-    }
-    for (const ele in entity.elements) {
-      const element = entity.elements[ele];
-      if (!element['@Common.Timezone'] || element._foreignKey4) {
+    if (entity.kind !== 'entity' || !isChangeTracked(entity)) continue;
+
+    // Resolve DB entity (self for DB entities, base for projections/views)
+    const isServiceEntity = !!(entity.query || entity.projection);
+    let dbEntityName, dbEntity;
+    if (isServiceEntity) {
+      const baseInfo = getBaseEntity(entity, m);
+      if (!baseInfo) {
+        LOG.debug(`Tracked Timezone Properties: DB Entity for ${name} not found!`);
         continue;
       }
-      timezoneProperties.push({
-        property: ele,
-        entity: name,
-        timezone: element['@Common.Timezone']?.['=']
-          ? // Where condition is replaced when select is inserted into ChangeView
-            SELECT.from(name).alias('timezoneSubSelect').where('1 = 1').columns(element['@Common.Timezone']['='])
-          : element['@Common.Timezone']
+      dbEntityName = baseInfo.baseRef;
+      dbEntity = baseInfo.baseEntity;
+    } else {
+      dbEntityName = name;
+      dbEntity = entity;
+    }
+
+    for (const ele in entity.elements) {
+      const element = entity.elements[ele];
+      if (!element['@Common.Timezone'] || element._foreignKey4) continue;
+
+      // For service entities, map service element name to DB element name (handles renaming/flattening)
+      const dbElemName = isServiceEntity ? getDbElementName(entity, ele, m) : ele;
+
+      // Skip if the DB element doesn't exist (e.g. computed/virtual service columns)
+      if (!dbEntity.elements[dbElemName]) continue;
+
+      const key = `${dbEntityName}::${dbElemName}`;
+      if (collected.has(key)) continue;
+
+      // REVISIT: maybe use additional CSN next to runtimeCSN which hasn't resolved annotations already
+      // For service entities, normalize annotation refs back to DB-level (handles renamed columns in dynamic timezone path)
+      const annotation = isServiceEntity ? normalizeAnnotationRefs(element['@Common.Timezone'], entity, m) : element['@Common.Timezone'];
+
+      collected.set(key, {
+        property: dbElemName,
+        entity: dbEntityName,
+        timezone: _buildTimezoneValue(annotation, dbEntityName)
       });
     }
   }
-  return timezoneProperties;
+
+  return [...collected.values()];
 }
 
 function isDeploy2Check(target) {

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -155,7 +155,7 @@ function _normalizeEntry(entry, srvEntity, model) {
   return entryChanged ? normalized : entry;
 }
 
-function _mergeChangelogAnnotations(dbEntity, serviceEntities, model) {
+function _mergeChangelogAnnotations(dbEntity, serviceEntities) {
   // Track merged annotations for conflict detection
   let mergedEntityAnnotation = dbEntity['@changelog'];
   let mergedEntityAnnotationSource = mergedEntityAnnotation ? dbEntity.name : null;
@@ -186,11 +186,8 @@ function _mergeChangelogAnnotations(dbEntity, serviceEntities, model) {
       }
     }
 
-    // Merge element-level @changelog annotations
-    for (const [srvElemName, annotation] of Object.entries(elementAnnotations)) {
-      // Map service element name to DB element name (handles renaming)
-      const dbElemName = _getDbElementName(srvEntity, srvElemName, model);
-
+    // Merge element-level @changelog annotations (keys are already DB element names)
+    for (const [dbElemName, annotation] of Object.entries(elementAnnotations)) {
       // Skip if annotation is false/null (explicit opt-out)
       if (annotation === false || annotation === null) continue;
 
@@ -223,6 +220,7 @@ function _mergeChangelogAnnotations(dbEntity, serviceEntities, model) {
 
 function _extractServiceAnnotations(serviceEntity, dbEntity, model) {
   const entityAnnotation = _normalizeAnnotationRefs(serviceEntity['@changelog'], serviceEntity, model);
+  // Keys are DB element names, service -> DB mapping happens here so downstream consumers can use them directly
   const elementAnnotations = {};
   for (const element of serviceEntity.elements) {
     if (element['@changelog'] !== undefined) {
@@ -230,7 +228,7 @@ function _extractServiceAnnotations(serviceEntity, dbEntity, model) {
       const dbElemName = _getDbElementName(serviceEntity, element.name, model);
       // Skip if the DB entity doesn't have this element (e.g., computed/virtual columns)
       if (dbEntity && !dbEntity.elements[dbElemName]) continue;
-      elementAnnotations[element.name] = _normalizeAnnotationRefs(element['@changelog'], serviceEntity, model);
+      elementAnnotations[dbElemName] = _normalizeAnnotationRefs(element['@changelog'], serviceEntity, model);
     }
   }
   return { entity: serviceEntity, entityAnnotation, elementAnnotations };
@@ -257,7 +255,7 @@ function _collectServiceEntities(model, collected, result, processed) {
     }
 
     try {
-      const mergedAnnotations = _mergeChangelogAnnotations(dbEntity, serviceEntities, model);
+      const mergedAnnotations = _mergeChangelogAnnotations(dbEntity, serviceEntities);
       result.push({ dbEntityName, mergedAnnotations });
       DEBUG?.(`Merged annotations for ${dbEntityName} from ${serviceEntities.length} service entities`);
     } catch (error) {

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -226,9 +226,10 @@ function _extractServiceAnnotations(serviceEntity, dbEntity, model) {
   const elementAnnotations = {};
   for (const element of serviceEntity.elements) {
     if (element['@changelog'] !== undefined) {
-      // Skip renamed elements — they don't exist in the DB entity
-      // and carry rewritten annotation refs (e.g., renamedStatus)
-      if (dbEntity && !dbEntity.elements[element.name]) continue;
+      // Map service element name to DB element name (handles renaming/flattening)
+      const dbElemName = _getDbElementName(serviceEntity, element.name, model);
+      // Skip if the DB entity doesn't have this element (e.g., computed/virtual columns)
+      if (dbEntity && !dbEntity.elements[dbElemName]) continue;
       elementAnnotations[element.name] = _normalizeAnnotationRefs(element['@changelog'], serviceEntity, model);
     }
   }
@@ -471,5 +472,7 @@ module.exports = {
   analyzeCompositions,
   getService,
   collectEntities,
-  getBaseElement
+  getBaseElement,
+  normalizeAnnotationRefs: _normalizeAnnotationRefs,
+  getDbElementName: _getDbElementName
 };

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -27,6 +27,7 @@ entity DifferentFieldTypes {
       srvDateTimeWTZ          : DateTime @Common.Timezone : 'Europe/Berlin';
       srvDateTimeWDTZ         : DateTime @Common.Timezone : timeZone;
       srvRenamedDateTimeWDTZ  : DateTime @Common.Timezone : timeZone;
+      plainDateTime           : DateTime;
       @changelog: false
       children  : Composition of many DifferentFieldTypesChildren
                     on children.parent = $self;

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -23,6 +23,10 @@ entity DifferentFieldTypes {
       dppField1 : String      @PersonalData.IsPotentiallyPersonal;
       dppField2 : String      @PersonalData.IsPotentiallySensitive;
       dppField3 : String      @PersonalData.FieldSemantics: 'DataControllerID';
+      // Elements for testing @Common.Timezone with service-level-only @changelog
+      srvDateTimeWTZ          : DateTime @Common.Timezone : 'Europe/Berlin';
+      srvDateTimeWDTZ         : DateTime @Common.Timezone : timeZone;
+      srvRenamedDateTimeWDTZ  : DateTime @Common.Timezone : timeZone;
       @changelog: false
       children  : Composition of many DifferentFieldTypesChildren
                     on children.parent = $self;

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -34,6 +34,11 @@ service VariantTesting {
 
   entity CustomTypeKeyTable as projection on my.CustomTypeKeyTable;
 
+  entity ServiceLevelTimezoneRenamed as projection on my.DifferentFieldTypes {
+    ID,
+    srvRenamedDateTimeWDTZ as renamedDateTime,
+    timeZone as renamedTimeZone
+  };
 }
 
 // Test: changes facet nested in CollectionFacet targeting changes/@UI.LineItem — plugin must not add a duplicate
@@ -84,3 +89,14 @@ annotate VariantTesting.CompositeKeyParent with @(UI.Facets: [{
     }]
   }]
 }]);
+
+// Test: service-level-only @changelog on elements that have @Common.Timezone at DB level
+annotate VariantTesting.DifferentFieldTypes with {
+  srvDateTimeWTZ  @changelog;
+  srvDateTimeWDTZ @changelog;
+};
+
+// Test: service-level-only @changelog + @Common.Timezone on renamed columns
+annotate VariantTesting.ServiceLevelTimezoneRenamed with {
+  renamedDateTime @changelog @Common.Timezone : renamedTimeZone;
+};

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -39,6 +39,12 @@ service VariantTesting {
     srvRenamedDateTimeWDTZ as renamedDateTime,
     timeZone as renamedTimeZone
   };
+
+  entity ServiceOnlyTimezoneRenamed as projection on my.DifferentFieldTypes {
+    ID,
+    plainDateTime as renamedPlain,
+    timeZone as renamedTimezone
+  };
 }
 
 // Test: changes facet nested in CollectionFacet targeting changes/@UI.LineItem — plugin must not add a duplicate
@@ -99,4 +105,10 @@ annotate VariantTesting.DifferentFieldTypes with {
 // Test: service-level-only @changelog + @Common.Timezone on renamed columns
 annotate VariantTesting.ServiceLevelTimezoneRenamed with {
   renamedDateTime @changelog @Common.Timezone : renamedTimeZone;
+};
+
+// Test: service-level-only @changelog AND @Common.Timezone on a renamed column.
+// DB element 'plainDateTime' has no @Common.Timezone of its own.
+annotate VariantTesting.ServiceOnlyTimezoneRenamed with {
+  renamedPlain @changelog @Common.Timezone : renamedTimezone;
 };

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -161,6 +161,24 @@ describe('CDS Features', () => {
       let change = changes[0];
       expect(change.valueTimeZone).toEqual('Europe/Amsterdam');
     });
+
+    it('timezone resolves when both @changelog and @Common.Timezone are service-level only on a renamed column', async () => {
+      const { ServiceOnlyTimezoneRenamed } = testingSRV.entities;
+      const data = {
+        ID: cds.utils.uuid(),
+        renamedPlain: new Date('2024-10-16T08:53:48Z'),
+        renamedTimezone: 'Asia/Tokyo'
+      };
+      await INSERT.into(ServiceOnlyTimezoneRenamed).entries(data);
+      let changes = await SELECT.from({ ref: [{ id: ServiceOnlyTimezoneRenamed.name, where: [{ ref: ['ID'] }, '=', { val: data.ID }] }, 'changes'] }).where({
+        entity: 'sap.change_tracking.DifferentFieldTypes',
+        entityKey: data.ID,
+        attribute: 'plainDateTime'
+      });
+      expect(changes.length).toEqual(1);
+      let change = changes[0];
+      expect(change.valueTimeZone).toEqual('Asia/Tokyo');
+    });
   });
 
   describe('tracking dates', () => {

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -160,6 +160,14 @@ describe('CDS Features', () => {
       expect(changes.length).toEqual(1);
       let change = changes[0];
       expect(change.valueTimeZone).toEqual('Europe/Amsterdam');
+
+      await UPDATE.entity(ServiceLevelTimezoneRenamed).where({ ID: rootEntityData.ID }).set({ renamedTimeZone: 'Asia/Tokyo' });
+      changes = await SELECT.from({ ref: [{ id: ServiceLevelTimezoneRenamed.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+        ID: change.ID
+      });
+      expect(changes.length).toEqual(1);
+      change = changes[0];
+      expect(change.valueTimeZone).toEqual('Asia/Tokyo');
     });
 
     it('timezone resolves when both @changelog and @Common.Timezone are service-level only on a renamed column', async () => {
@@ -178,6 +186,14 @@ describe('CDS Features', () => {
       expect(changes.length).toEqual(1);
       let change = changes[0];
       expect(change.valueTimeZone).toEqual('Asia/Tokyo');
+
+      await UPDATE.entity(ServiceOnlyTimezoneRenamed).where({ ID: data.ID }).set({ renamedTimezone: 'Europe/Berlin' });
+      changes = await SELECT.from({ ref: [{ id: ServiceOnlyTimezoneRenamed.name, where: [{ ref: ['ID'] }, '=', { val: data.ID }] }, 'changes'] }).where({
+        ID: change.ID
+      });
+      expect(changes.length).toEqual(1);
+      change = changes[0];
+      expect(change.valueTimeZone).toEqual('Europe/Berlin');
     });
   });
 

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -12,12 +12,13 @@ describe('CDS Features', () => {
       testingSRV = await cds.connect.to('VariantTesting');
     });
     it('timezone field is null in case of no timezone', async () => {
+      const { DifferentFieldTypes } = testingSRV.entities;
       const rootEntityData = {
         ID: cds.utils.uuid(),
         dateTime: new Date('2024-10-16T08:53:48Z')
       };
-      await INSERT.into(testingSRV.entities.DifferentFieldTypes).entries(rootEntityData);
-      let changes = await SELECT.from({ ref: [{ id: testingSRV.entities.DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+      await INSERT.into(DifferentFieldTypes).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
         entity: 'sap.change_tracking.DifferentFieldTypes',
         entityKey: rootEntityData.ID,
         attribute: 'dateTime'
@@ -28,12 +29,13 @@ describe('CDS Features', () => {
     });
 
     it('timezone field has timezone for static annotation value', async () => {
+      const { DifferentFieldTypes } = testingSRV.entities;
       const rootEntityData = {
         ID: cds.utils.uuid(),
         dateTimeWTZ: new Date('2024-10-16T08:53:48Z')
       };
-      await INSERT.into(testingSRV.entities.DifferentFieldTypes).entries(rootEntityData);
-      let changes = await SELECT.from({ ref: [{ id: testingSRV.entities.DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+      await INSERT.into(DifferentFieldTypes).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
         entity: 'sap.change_tracking.DifferentFieldTypes',
         entityKey: rootEntityData.ID,
         attribute: 'dateTimeWTZ'
@@ -44,12 +46,13 @@ describe('CDS Features', () => {
     });
 
     it('timezone field has timezone for dynamic annotation value', async () => {
+      const { DifferentFieldTypes } = testingSRV.entities;
       const rootEntityData = {
         ID: cds.utils.uuid(),
         dateTimeWDTZ: new Date('2024-10-16T08:53:48Z')
       };
-      await INSERT.into(testingSRV.entities.DifferentFieldTypes).entries(rootEntityData);
-      let changes = await SELECT.from({ ref: [{ id: testingSRV.entities.DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+      await INSERT.into(DifferentFieldTypes).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
         entity: 'sap.change_tracking.DifferentFieldTypes',
         entityKey: rootEntityData.ID,
         attribute: 'dateTimeWDTZ'
@@ -58,8 +61,8 @@ describe('CDS Features', () => {
       let change = changes[0];
       expect(change.valueTimeZone).toEqual('Europe/Berlin');
 
-      await UPDATE.entity(testingSRV.entities.DifferentFieldTypes).where({ ID: rootEntityData.ID }).set({ timeZone: 'Europe/Amsterdam' });
-      changes = await SELECT.from({ ref: [{ id: testingSRV.entities.DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+      await UPDATE.entity(DifferentFieldTypes).where({ ID: rootEntityData.ID }).set({ timeZone: 'Europe/Amsterdam' });
+      changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
         entity: 'sap.change_tracking.DifferentFieldTypes',
         entityKey: rootEntityData.ID,
         attribute: 'dateTimeWDTZ'
@@ -104,6 +107,59 @@ describe('CDS Features', () => {
         attribute: 'timezone'
       });
       expect(changes.length).toEqual(1);
+    });
+
+    it('timezone field has static timezone when @changelog is only on service level', async () => {
+      const { DifferentFieldTypes } = testingSRV.entities;
+      const rootEntityData = {
+        ID: cds.utils.uuid(),
+        srvDateTimeWTZ: new Date('2024-10-16T08:53:48Z')
+      };
+      await INSERT.into(DifferentFieldTypes).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+        entity: 'sap.change_tracking.DifferentFieldTypes',
+        entityKey: rootEntityData.ID,
+        attribute: 'srvDateTimeWTZ'
+      });
+      expect(changes.length).toEqual(1);
+      let change = changes[0];
+      expect(change.valueTimeZone).toEqual('Europe/Berlin');
+    });
+
+    it('timezone field has dynamic timezone when @changelog is only on service level', async () => {
+      const { DifferentFieldTypes } = testingSRV.entities;
+      const rootEntityData = {
+        ID: cds.utils.uuid(),
+        srvDateTimeWDTZ: new Date('2024-10-16T08:53:48Z'),
+        timeZone: 'Europe/Amsterdam'
+      };
+      await INSERT.into(DifferentFieldTypes).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: DifferentFieldTypes.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+        entity: 'sap.change_tracking.DifferentFieldTypes',
+        entityKey: rootEntityData.ID,
+        attribute: 'srvDateTimeWDTZ'
+      });
+      expect(changes.length).toEqual(1);
+      let change = changes[0];
+      expect(change.valueTimeZone).toEqual('Europe/Amsterdam');
+    });
+
+    it('timezone field resolves dynamic timezone with renamed columns on service level', async () => {
+      const { ServiceLevelTimezoneRenamed } = testingSRV.entities;
+      const rootEntityData = {
+        ID: cds.utils.uuid(),
+        renamedDateTime: new Date('2024-10-16T08:53:48Z'),
+        renamedTimeZone: 'Europe/Amsterdam'
+      };
+      await INSERT.into(ServiceLevelTimezoneRenamed).entries(rootEntityData);
+      let changes = await SELECT.from({ ref: [{ id: ServiceLevelTimezoneRenamed.name, where: [{ ref: ['ID'] }, '=', { val: rootEntityData.ID }] }, 'changes'] }).where({
+        entity: 'sap.change_tracking.DifferentFieldTypes',
+        entityKey: rootEntityData.ID,
+        attribute: 'srvRenamedDateTimeWDTZ'
+      });
+      expect(changes.length).toEqual(1);
+      let change = changes[0];
+      expect(change.valueTimeZone).toEqual('Europe/Amsterdam');
     });
   });
 


### PR DESCRIPTION
Previously, `@Common.TimeZone` properties for dynamic datetime formatting were only collected when the database entity had a `@changelog` annotation. This PR extends this behavior to support both `@changelog` and `@Common.TimeZone` annotations just defined at the service level.

Closes #307 