### PR TITLE
fix: allow direct read on explicitly exposed ChangeView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 - Migration table now correctly handles composite keys from v1 using `HIERARCHY_COMPOSITE_ID` (supports up to 5 key parts)
+- `@Capabilities.ReadRestrictions` on ChangeView is now only applied when the view is auto-created by the plugin. Services that explicitly expose ChangeView allow direct read access.
 
 ## Version 2.0.0-beta.12 - 2026-05-18
 

--- a/index.cds
+++ b/index.cds
@@ -30,10 +30,6 @@ entity aspect @(UI.Facets: [{
 //   substring($user.locale, 0, (case when indexof($user.locale, '_') >= 0 then indexof($user.locale, '_') else length($user.locale) end))
 //   This would extract 'en' from 'en_GB', 'de' from 'de_DE', etc. (indexof was introduced in CDS 9)
 @readonly
-@cds.autoexpose
-@Capabilities.ReadRestrictions : {
-  Readable: false,
-}
 view ChangeView as
   select from Changes as change
   left outer join i18nKeys as attributeI18n

--- a/lib/csn-enhancements/index.js
+++ b/lib/csn-enhancements/index.js
@@ -184,6 +184,9 @@ function enhanceModel(m) {
             }
           }
           enhanceChangeViewWithLocalization(serviceName, `${serviceName}.ChangeView`, m);
+          m.definitions[`${serviceName}.ChangeView`]['@Capabilities.ReadRestrictions.Readable'] = false;
+        } else {
+          enhanceChangeViewWithLocalization(serviceName, `${serviceName}.ChangeView`, m);
         }
 
         DEBUG?.(

--- a/tests/bookshop/srv/admin-service.cds
+++ b/tests/bookshop/srv/admin-service.cds
@@ -1,11 +1,8 @@
 using {sap.capire.bookshop as my} from '../db/schema';
-using {sap.changelog as change} from '@cap-js/change-tracking';
 
 service AdminService {
   @odata.draft.enabled
   entity BookStores @(cds.autoexpose) as projection on my.BookStores;
-
-  entity ChangeView                   as projection on change.ChangeView;
 
   entity Authors                      as projection on my.Authors;
   entity Report                       as projection on my.Report;

--- a/tests/bookshop/srv/services.cds
+++ b/tests/bookshop/srv/services.cds
@@ -1,4 +1,5 @@
 using { sap.capire.incidents as my } from '../db/schema';
+using {sap.changelog as ct} from '@cap-js/change-tracking';
 
 /**
  * Service used by support personell, i.e. the incidents' 'processors'.
@@ -19,6 +20,8 @@ service ProcessorService {
 
   entity Orders as projection on my.Orders;
   entity ExpressionScenarios as projection on my.ExpressionScenarios;
+
+  entity ChangeView as projection on ct.ChangeView;
 }
 
 /**

--- a/tests/integration/change-tracking.test.js
+++ b/tests/integration/change-tracking.test.js
@@ -2593,6 +2593,11 @@ describe('ChangeView access restrictions', () => {
     }
   });
 
+  it('allows direct read of ChangeView when explicitly exposed in the service', async () => {
+    const response = await GET(`/odata/v4/processor/ChangeView`);
+    expect(response.status).toBe(200);
+  });
+
   it('allows reading changes via entity navigation', async () => {
     const { data: bookStore } = await POST(`/odata/v4/admin/BookStores`, {
       name: 'Access Test Store'


### PR DESCRIPTION
Currently, the read restrictions are set declaratively in the `index.cds` on the **ChangeView** definition:

```cds
@cds.autoexpose
@Capabilities.ReadRestrictions : {
  Readable: false,
}
view ChangeView as ...
```

This requires application developers who explicitly expose **ChangeView** in their service to override the `ReadRestrictions` annotation to access the entity directly:

```cds
using {sap.changelog as ct} from '@cap-js/change-tracking';

service ProcessorService {
  @Capabilities.ReadRestrictions : {
     Readable: false,
   }
  entity ChangeView as projection on ct.ChangeView;
}
```

This PR adds the `Capabilities.ReadRestrictions` dynamically during CSN enhancement only when the entity is not explicitly exposed in a service.