### PR TITLE
ci: adjust cds dependencies for cds 8 tests

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -64,35 +64,6 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
-    - name: Set CDS version-specific dependencies
-      shell: bash
-      run: |
-        if [ "${{ inputs.CDS_VERSION }}" == "8" ]; then
-          echo "Installing CDS 8 compatible packages..."
-          # Add @sap/cds as direct devDependency to anchor the version
-          # This prevents npm from resolving to v9 due to open-ended peer deps like ">=8"
-          npm pkg set "devDependencies.@sap/cds=^8.9.8"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1"
-          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
-          # Root overrides enforce versions across the entire workspace
-          npm pkg set "overrides.@cap-js/sqlite=^1"
-          npm pkg set "overrides.@cap-js/hana=^1"
-          npm pkg set "overrides.@cap-js/db-service=^1"
-          npm pkg set "overrides.@cap-js/postgres=^1"
-          npm pkg set "overrides.@sap/cds-mtxs=^2"
-          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
-          npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
-          # Update workspace package dependencies to CDS 8 compatible versions
-          cd tests/bookshop
-          npm pkg set "dependencies.@cap-js/hana=^1"
-          npm pkg set "dependencies.@cap-js/postgres=^1"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1"
-          cd ../..
-          cd tests/bookshop-mtx
-          npm pkg set "dependencies.@sap/cds-mtxs=^2"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1"
-          cd ../..
-        fi
 
     - name: Install global CDS
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,30 +64,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Set CDS 8 compatible dependencies
-        if: matrix.cds-version == 8
-        run: |
-          # Add @sap/cds as direct devDependency to anchor the version
-          npm pkg set "devDependencies.@sap/cds=^8.9.8"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
-          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
-          # Root overrides enforce versions across the entire workspace
-          npm pkg set "overrides.@cap-js/sqlite=^1.0.0"
-          npm pkg set "overrides.@cap-js/hana=^1.0.0"
-          npm pkg set "overrides.@cap-js/db-service=^1.0.0"
-          npm pkg set "overrides.@cap-js/postgres=^1.0.0"
-          npm pkg set "overrides.@sap/cds-mtxs=^2.0.0"
-          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
-          npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
-          # Update workspace package dependencies
-          cd tests/bookshop
-          npm pkg set "dependencies.@cap-js/hana=^1.0.0"
-          npm pkg set "dependencies.@cap-js/postgres=^1.0.0"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
-          cd ../..
-          cd tests/bookshop-mtx
-          npm pkg set "dependencies.@sap/cds-mtxs=^2.0.0"
-          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
       - name: Start PostgreSQL
         run: docker compose -f tests/bookshop/pg-stack.yml up -d --wait
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@cap-js/cds-test": "*",
-    "@cap-js/cds-types": "^0.17.0"
+    "@cap-js/cds-test": "^0 || ^1",
+    "@cap-js/cds-types": "^0"
   },
   "cds": {
     "requires": {

--- a/tests/bookshop-mtx/mtx/sidecar/package.json
+++ b/tests/bookshop-mtx/mtx/sidecar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookshop-mtx",
   "dependencies": {
-    "@cap-js/change-tracking": "*",
+    "@cap-js/change-tracking": "file:../../../.",
     "@cap-js/hana": "^1 || ^2",
     "@sap/cds": "^8 || ^9",
     "@sap/cds-mtxs": "^2 || ^3",

--- a/tests/bookshop-mtx/mtx/sidecar/package.json
+++ b/tests/bookshop-mtx/mtx/sidecar/package.json
@@ -1,14 +1,15 @@
 {
   "name": "bookshop-mtx",
   "dependencies": {
-    "@cap-js/hana": "^2",
-    "@sap/cds": "^9",
-    "@sap/cds-mtxs": "^3",
+    "@cap-js/change-tracking": "*",
+    "@cap-js/hana": "^1 || ^2",
+    "@sap/cds": "^8 || ^9",
+    "@sap/cds-mtxs": "^2 || ^3",
     "@sap/xssec": "^4",
     "express": "^4"
   },
   "devDependencies": {
-    "@cap-js/sqlite": "^2"
+    "@cap-js/sqlite": "^1 || ^2"
   },
   "engines": {
     "node": ">=20"

--- a/tests/bookshop-mtx/package.json
+++ b/tests/bookshop-mtx/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@cap-js/change-tracking": "file:../../.",
-    "@sap/cds-mtxs": "^3"
+    "@sap/cds-mtxs": "^2 || ^3"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1 || ^2"
@@ -12,7 +12,8 @@
         "kind": "sql"
       },
       "[production]": {
-        "multitenancy": true
+        "multitenancy": true,
+        "extensibility": true
       },
       "[with-mtx]": {
         "multitenancy": true

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -2,12 +2,12 @@
   "dependencies": {
     "@cap-js/attachments": "^3",
     "@cap-js/change-tracking": "file:../../.",
-    "@cap-js/hana": "^2",
+    "@cap-js/hana": "^1 || ^2",
     "@cap-js/postgres": "^1 || ^2"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1 || ^2",
-    "@sap/cds-dk": "^9",
+    "@sap/cds-dk": "^8 || ^9",
     "puppeteer": "^24.40.0",
     "ui5-test-runner": "^5.13.1"
   },


### PR DESCRIPTION
# CI: Adjust CDS Dependencies for CDS 8 Test Compatibility

### Chore

♻️ **Refactor**: Removed inline CI steps that manually patched `package.json` files for CDS 8 compatibility and instead updated version ranges directly in the respective `package.json` files to support both CDS 8 and CDS 9.

### Changes

* `.github/actions/integration-tests/action.yml`: Removed the `Set CDS version-specific dependencies` step that dynamically patched `npm pkg` fields for CDS 8 compatibility during CI runs.
* `.github/workflows/test.yml`: Removed the `Set CDS 8 compatible dependencies` step from the PostgreSQL test workflow for the same reason.
* `package.json`: Updated `@cap-js/cds-test` to `^0 || ^1` and `@cap-js/cds-types` to `^0` to accommodate both CDS 8 and CDS 9 compatible versions.
* `tests/bookshop/package.json`: Broadened `@cap-js/hana` to `^1 || ^2` and `@sap/cds-dk` to `^8 || ^9` to support CDS 8 environments.
* `tests/bookshop-mtx/package.json`: Updated `@sap/cds-mtxs` to `^2 || ^3` and added `extensibility: true` to the `[production]` CDS profile configuration.
* `tests/bookshop-mtx/mtx/sidecar/package.json`: Added `@cap-js/change-tracking: "*"` dependency and widened version ranges for `@cap-js/hana`, `@sap/cds`, `@sap/cds-mtxs`, and `@cap-js/sqlite` to support both CDS 8 and CDS 9.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `669a016e-c9d7-4044-801e-b6577f1d327a`
</details>
