### PR TITLE
ci: add pin step for cds 8

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -71,6 +71,11 @@ runs:
     - name: Install all dependencies
       shell: bash
       run: npm install
+
+    - name: Pin @sap/cds for CAP 8 matrix
+      if: ${{ inputs.CDS_VERSION == '8' }}
+      shell: bash
+      run: npm i @sap/cds@8 --no-save
       
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
+      - run: cd tests/bookshop && npm i
+      - run: cd tests/bookshop-mtx && npm i
       - name: Pin @sap/cds for CAP 8 matrix
         if: matrix.cds-version == '8'
         run: npm i @sap/cds@8 --no-save
-      - run: cd tests/bookshop && npm i
-      - run: cd tests/bookshop-mtx && npm i
       - name: Run SQLite tests
         run: npm run test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
+      - name: Pin @sap/cds for CAP 8 matrix
+        if: matrix.cds-version == '8'
+        run: npm i @sap/cds@8 --no-save
       - run: cd tests/bookshop && npm i
       - run: cd tests/bookshop-mtx && npm i
       - name: Run SQLite tests
@@ -68,6 +71,9 @@ jobs:
         run: docker compose -f tests/bookshop/pg-stack.yml up -d --wait
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
+      - name: Pin @sap/cds for CAP 8 matrix
+        if: matrix.cds-version == '8'
+        run: npm i @sap/cds@8 --no-save
       - name: Deploy to PostgreSQL
         run: cd tests/bookshop && npm run deploy:pg
       - name: Run PostgreSQL tests
@@ -81,8 +87,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
-        cds-version: [latest, 8]
+        node-version: [22.x]
+        cds-version: [8]
     steps:
       - name: Run HANA integration tests
         uses: cap-js/change-tracking/.github/actions/integration-tests@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x]
-        cds-version: [8]
+        node-version: [20.x, 22.x]
+        cds-version: [latest, 8]
     steps:
       - name: Run HANA integration tests
         uses: cap-js/change-tracking/.github/actions/integration-tests@main

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     }
   },
   "jest": {
-    "testTimeout": 180000
+    "testTimeout": 200000
   },
   "workspaces": [
     "tests/*"

--- a/tests/bookshop-mtx/package.json
+++ b/tests/bookshop-mtx/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@cap-js/change-tracking": "file:../../.",
+    "@sap/cds": "^8 || ^9",
     "@sap/cds-mtxs": "^2 || ^3"
   },
   "devDependencies": {

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -3,7 +3,8 @@
     "@cap-js/attachments": "^3",
     "@cap-js/change-tracking": "file:../../.",
     "@cap-js/hana": "^1 || ^2",
-    "@cap-js/postgres": "^1 || ^2"
+    "@cap-js/postgres": "^1 || ^2",
+    "@sap/cds": "^8 || ^9"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1 || ^2",


### PR DESCRIPTION
# CI: Add `@sap/cds` Pin Step for CDS 8 Matrix

### Chore

🔧 Added a pinning step for `@sap/cds@8` across CI workflows to ensure tests run against the correct CDS version when the matrix uses `cds-version: 8`. This prevents accidental upgrades to CDS 9 during test runs for the CDS 8 matrix.

### Changes

* `.github/actions/integration-tests/action.yml`: Added a conditional step `Pin @sap/cds for CAP 8 matrix` that runs `npm i @sap/cds@8 --no-save` when `CDS_VERSION == '8'`, ensuring the correct `@sap/cds` version is used during HANA integration tests.
* `.github/workflows/test.yml`: Added the same `@sap/cds@8` pinning step for both SQLite and PostgreSQL test jobs. Also narrowed the HANA integration test matrix to `node-version: [22.x]` and `cds-version: [8]` only.
* `package.json`: Increased the Jest `testTimeout` from `180000` to `200000` ms.
* `tests/bookshop/package.json`: Added explicit `@sap/cds: "^8 || ^9"` dependency to the bookshop test app.
* `tests/bookshop-mtx/package.json`: Added explicit `@sap/cds: "^8 || ^9"` dependency to the bookshop-mtx test app.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Correlation ID: `5e12a47e-3389-4585-ad44-ec94de711a62`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
