### PR TITLE
ci: set CDS 8 compatible dependencies

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -65,6 +65,28 @@ runs:
       with:
         node-version: ${{ inputs.NODE_VERSION }}
 
+    - name: Set CDS version-specific dependencies
+      if: ${{ inputs.CDS_VERSION == '8' }}
+      shell: bash
+      run: |
+        echo "Installing CDS 8 compatible packages..."
+        npm pkg set "devDependencies.@sap/cds=^8.9.8"
+        npm pkg set "devDependencies.@cap-js/sqlite=^1"
+        npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
+        npm pkg set "overrides.@cap-js/sqlite=^1"
+        npm pkg set "overrides.@cap-js/hana=^1"
+        npm pkg set "overrides.@cap-js/db-service=^1"
+        npm pkg set "overrides.@cap-js/postgres=^1"
+        npm pkg set "overrides.@sap/cds-mtxs=^2"
+        npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
+        npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
+        cd tests/bookshop
+        npm pkg set "dependencies.@cap-js/hana=^1"
+        npm pkg set "dependencies.@cap-js/postgres=^1"
+        npm pkg set "devDependencies.@cap-js/sqlite=^1"
+        cd ../bookshop-mtx
+        npm pkg set "dependencies.@sap/cds-mtxs=^2"
+        npm pkg set "devDependencies.@cap-js/sqlite=^1"
     - name: Install global CDS
       shell: bash
       run: npm i -g @sap/cds-dk@${{ inputs.CDS_VERSION }}
@@ -72,11 +94,6 @@ runs:
       shell: bash
       run: npm install
 
-    - name: Pin @sap/cds for CAP 8 matrix
-      if: ${{ inputs.CDS_VERSION == '8' }}
-      shell: bash
-      run: npm i @sap/cds@8 --no-save
-      
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,35 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Set CDS 8 compatible dependencies
+        if: matrix.cds-version == '8'
+        run: |
+          npm pkg set "devDependencies.@sap/cds=^8.9.8"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
+          npm pkg set "overrides.@cap-js/sqlite=^1.0.0"
+          npm pkg set "overrides.@cap-js/hana=^1.0.0"
+          npm pkg set "overrides.@cap-js/db-service=^1.0.0"
+          npm pkg set "overrides.@cap-js/postgres=^1.0.0"
+          npm pkg set "overrides.@sap/cds-mtxs=^2.0.0"
+          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
+          npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
+          cd tests/bookshop
+          npm pkg set "dependencies.@cap-js/hana=^1.0.0"
+          npm pkg set "dependencies.@cap-js/postgres=^1.0.0"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          cd ../bookshop-mtx
+          npm pkg set "dependencies.@sap/cds-mtxs=^2.0.0"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          cd mtx/sidecar
+          npm pkg set "dependencies.@sap/cds=^8.9.8"
+          npm pkg set "dependencies.@cap-js/hana=^1"
+          npm pkg set "dependencies.@sap/cds-mtxs=^2"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1"
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
       - run: cd tests/bookshop && npm i
       - run: cd tests/bookshop-mtx && npm i
-      - name: Pin @sap/cds for CAP 8 matrix
-        if: matrix.cds-version == '8'
-        run: npm i @sap/cds@8 --no-save
       - name: Run SQLite tests
         run: npm run test
 
@@ -69,11 +91,28 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Start PostgreSQL
         run: docker compose -f tests/bookshop/pg-stack.yml up -d --wait
+      - name: Set CDS 8 compatible dependencies
+        if: matrix.cds-version == '8'
+        run: |
+          npm pkg set "devDependencies.@sap/cds=^8.9.8"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          npm pkg set "devDependencies.@cap-js/cds-test=^0.4.1"
+          npm pkg set "overrides.@cap-js/sqlite=^1.0.0"
+          npm pkg set "overrides.@cap-js/hana=^1.0.0"
+          npm pkg set "overrides.@cap-js/db-service=^1.0.0"
+          npm pkg set "overrides.@cap-js/postgres=^1.0.0"
+          npm pkg set "overrides.@sap/cds-mtxs=^2.0.0"
+          npm pkg set "overrides.@cap-js/cds-test=^0.4.1"
+          npm pkg set "devDependencies.@cap-js/cds-types=^0.11"
+          cd tests/bookshop
+          npm pkg set "dependencies.@cap-js/hana=^1.0.0"
+          npm pkg set "dependencies.@cap-js/postgres=^1.0.0"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
+          cd ../bookshop-mtx
+          npm pkg set "dependencies.@sap/cds-mtxs=^2.0.0"
+          npm pkg set "devDependencies.@cap-js/sqlite=^1.0.0"
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
-      - name: Pin @sap/cds for CAP 8 matrix
-        if: matrix.cds-version == '8'
-        run: npm i @sap/cds@8 --no-save
       - name: Deploy to PostgreSQL
         run: cd tests/bookshop && npm run deploy:pg
       - name: Run PostgreSQL tests

--- a/tests/bookshop-mtx/package.json
+++ b/tests/bookshop-mtx/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@cap-js/change-tracking": "file:../../.",
-    "@sap/cds": "^8 || ^9",
     "@sap/cds-mtxs": "^2 || ^3"
   },
   "devDependencies": {

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -3,8 +3,7 @@
     "@cap-js/attachments": "^3",
     "@cap-js/change-tracking": "file:../../.",
     "@cap-js/hana": "^1 || ^2",
-    "@cap-js/postgres": "^1 || ^2",
-    "@sap/cds": "^8 || ^9"
+    "@cap-js/postgres": "^1 || ^2"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1 || ^2",


### PR DESCRIPTION
# CI: Set CDS 8 Compatible Dependencies via `npm pkg set`

### Chore

🔧 Replaces the previous approach of pinning `@sap/cds@8` with a `--no-save` install by proactively setting all CDS 8 compatible dependency versions directly in `package.json` files using `npm pkg set` before running `npm install`.

### Changes

* `.github/actions/integration-tests/action.yml`: Added a new step **"Set CDS version-specific dependencies"** (conditional on `CDS_VERSION == '8'`) that uses `npm pkg set` to configure CDS 8 compatible versions for `@sap/cds`, `@cap-js/sqlite`, `@cap-js/cds-test`, `@cap-js/cds-types`, and several package overrides (`@cap-js/hana`, `@cap-js/db-service`, `@cap-js/postgres`, `@sap/cds-mtxs`). Also updates test project dependencies in `tests/bookshop` and `tests/bookshop-mtx`. Removes the old **"Pin @sap/cds for CAP 8 matrix"** step.

* `.github/workflows/test.yml`: Adds the same **"Set CDS 8 compatible dependencies"** step to both the **SQLite** and **PostgreSQL** test jobs (conditional on `matrix.cds-version == '8'`). The SQLite job additionally covers the `bookshop-mtx/mtx/sidecar` sub-project. Removes the old `npm i @sap/cds@8 --no-save` pin steps in both jobs.

* `tests/bookshop/package.json`: Removed the explicit `@sap/cds: "^8 || ^9"` dependency entry and `@cap-js/postgres` dual-range entry, leaving postgres as `"^1 || ^2"`. The CDS version is now managed dynamically by CI.

* `tests/bookshop-mtx/package.json`: Removed the explicit `@sap/cds: "^8 || ^9"` dependency entry. CDS version is now managed dynamically by CI.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `f21f0009-265b-4dd8-8aa3-ffc329904e58`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
