### PR TITLE
refactor: use statement level trigger for HANA per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed 
 - Composition changelog entries on parents have always 'update' as modification type
+- HANA triggers now use statement-level execution by default for improved bulk DML performance
 
 ### Added
 - Consider `@Common.Timezone` on entities that are change-tracked only via a service-level `@changelog`.  Previously, `valueTimeZone` in `ChangeView` was resolved only for entities annotated with `@changelog` at the DB level
+- `rowLevelTriggers` configuration flag to opt into legacy row-level HANA triggers as a workaround for "invalid RID address" errors
 
 ### Fixed
 - Migration table now correctly handles composite keys from v1 using `HIERARCHY_COMPOSITE_ID` (supports up to 5 key parts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 2.0.0-beta.13 - tbd
+## Version 2.0.0-beta.13 - 2026-06-09
 
 ### Changed 
 - Composition changelog entries on parents have always 'update' as modification type
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Migration table now correctly handles composite keys from v1 using `HIERARCHY_COMPOSITE_ID` (supports up to 5 key parts)
 - `@Capabilities.ReadRestrictions` on ChangeView is now only applied when the view is auto-created by the plugin. Services that explicitly expose ChangeView allow direct read access.
+- HDI deployment failure caused by adding `.hdbindex` artifacts even when Changes table does not exist in the compiled model
 
 ## Version 2.0.0-beta.12 - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,23 @@ entity Status {
 
 Please be aware this means the localized value is then stored and shown in the change log, e.g. if a user speaking another language accesses the change log later, they will still see the value in the language used by the user who caused the change log.
 
+### Use row-level HANA triggers (fallback)
+
+By default, change-tracking emits **statement-level** HANA triggers (`REFERENCING NEW TABLE … FOR EACH STATEMENT`), which fire once per SQL statement and process all affected rows in one set-based operation. This is significantly faster than row-level triggers (`REFERENCING NEW ROW … FOR EACH ROW`) especially for bulk operations.
+
+```json
+"cds": {
+  "requires": {
+    "change-tracking": {
+      "rowLevelTriggers": true
+    }
+  }
+}
+```
+
+> [!NOTE]
+> This flag is a temporary workaround for "invalid RID address" HANA errors observed with statement-level triggers in some scenarios, and will likely be removed once the underlying HANA issue is resolved.
+
 ## Examples
 
 This section describes modelling cases for further reference, from simple to complex, including the following:

--- a/lib/hana/composition-row.js
+++ b/lib/hana/composition-row.js
@@ -1,0 +1,384 @@
+/**
+ * Row-level HANA composition trigger generation
+ *
+ * Builds composition parent inserts using procedural SQLScript
+ * (DECLARE parent_id; SELECT MAX(ID) INTO parent_id;
+ * IF parent_id IS NULL THEN ... INSERT VALUES (...)) — relies on the trigger
+ * firing once per row. Active only when `rowLevelTriggers` is `true`.
+ */
+const utils = require('../utils/change-tracking.js');
+const { toSQL, entityKeyExpr, quote } = require('./sql-expressions.js');
+
+/**
+ * Builds an SQL expression for the parent objectID of a composition-of-many entry.
+ * Resolves @changelog objectIDs from the parent table or falls back to the entityKey string when no objectID is configured. With multiple objectIDs concatenates with ", ".
+ *
+ * @param {object} rootEntity - CSN definition of root entity
+ * @param {Array} rootObjectIDs - @changelog objectID definitions
+ * @param {Array} binding - FK column names on the child pointing to the parent
+ * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {object} model - CSN model
+ * @param {Array} [keyValueExprs] - Pre-built key value expressions; bypass `:${refRow}.${binding[i]}`
+ * @returns {string} A SQL scalar expression
+ */
+function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
+  const keyValues = keyValueExprs ?? binding.map((k) => `:${refRow}.${quote(k)}`);
+  const rootEntityKeyExpr = entityKeyExpr(keyValues);
+
+  if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
+
+  const rootKeys = utils.extractKeys(rootEntity.keys);
+  if (rootKeys.length !== keyValues.length) return rootEntityKeyExpr;
+
+  const where = {};
+  for (let i = 0; i < rootKeys.length; i++) {
+    where[rootKeys[i]] = { val: keyValues[i], literal: 'sql' };
+  }
+
+  const parts = [];
+  for (const oid of rootObjectIDs) {
+    if (oid.expression) {
+      const exprColumn = utils.buildExpressionColumn(oid.expression);
+      const query = SELECT.one.from(rootEntity.name).columns(exprColumn).where(where);
+      parts.push(`TO_NVARCHAR((${toSQL(query, model)}))`);
+    } else {
+      const query = SELECT.one.from(rootEntity.name).columns(oid.name).where(where);
+      parts.push(`TO_NVARCHAR((${toSQL(query, model)}))`);
+    }
+  }
+
+  // Single objectID field: simple COALESCE, no concat needed
+  if (parts.length === 1) {
+    return `COALESCE(${parts[0]}, ${rootEntityKeyExpr})`;
+  }
+
+  // Multiple objectID fields: use concat, fall back to entityKey when ALL are NULL
+  const nullChecks = parts.map((p) => `${p} IS NULL`).join(' AND ');
+  const concatExpr = parts.map((p) => `CASE WHEN ${p} IS NOT NULL THEN ', ' || ${p} ELSE '' END`).join(' || ');
+  return `CASE WHEN ${nullChecks} THEN ${rootEntityKeyExpr} ELSE COALESCE(NULLIF(LTRIM(${concatExpr}, ', '), ''), ${rootEntityKeyExpr}) END`;
+}
+
+/**
+ * Builds context for composition of one parent changelog entry.
+ * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
+ * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
+ */
+function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, refRow, model, childObjectIDExpr = null) {
+  const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
+  const { compositionName, childKeys } = parentKeyBinding;
+
+  // Build the FK field names on the parent that point to this child
+  // For composition of one, CAP generates <compositionName>_<childKey> fields
+  const parentFKFields = childKeys.map((k) => quote(`${compositionName}_${k}`));
+
+  // Build WHERE clause to find the parent entity that has this child
+  const parentEntity = model.definitions[parentEntityName];
+  const parentKeys = utils.extractKeys(parentEntity.keys);
+  const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = :${refRow}.${quote(childKeys[i])}`).join(' AND ');
+
+  // Build the parent key expression via subquery (reverse lookup)
+  const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${quote(pk)} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
+  const parentKeyExpr = entityKeyExpr(parentKeySubqueries);
+
+  // Use child's objectID expression for the composition entry — shows which child was affected
+  // Falls back to parent's own objectID if child objectID is not available
+  const objectIDExpr = childObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
+
+  const declares = 'DECLARE parent_id NVARCHAR(36);';
+
+  const insertSQL = `
+		INSERT INTO SAP_CHANGELOG_CHANGES
+			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+			SELECT
+				parent_id,
+				NULL,
+				'${compositionFieldName}',
+				'${parentEntityName}',
+				${parentKeyExpr},
+				${objectIDExpr},
+				CURRENT_TIMESTAMP,
+				SESSION_CONTEXT('APPLICATIONUSER'),
+				'cds.Composition',
+				'update',
+				CURRENT_UPDATE_TRANSACTION()
+			FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY
+			WHERE EXISTS (
+				SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM SAP_CHANGELOG_CHANGES
+				WHERE entity = '${parentEntityName}'
+				AND entityKey = ${parentKeyExpr}
+				AND attribute = '${compositionFieldName}'
+				AND valueDataType = 'cds.Composition'
+				AND transactionID = CURRENT_UPDATE_TRANSACTION()
+			);`;
+
+  return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr };
+}
+
+/**
+ * Resolves key expressions for each level in a composition hierarchy by building
+ * chained subqueries that navigate from the trigger row up through the ancestors.
+ *
+ * @param {Array} levels - Array of { entityName, compositionFieldName, keyBinding } from immediate parent to outermost ancestor
+ * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {object} model - The CDS model
+ * @returns {{ keyExprs: string[], ancestorKeyValues: string[][] }}
+ */
+function resolveAncestorKeyExpressions(levels, refRow, model) {
+  const parentKeyBinding = levels[0].keyBinding;
+  const keyExprs = [entityKeyExpr(parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`))];
+  const ancestorKeyValues = [parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`)];
+
+  if (levels.length > 1) {
+    const childEntity0 = model.definitions[levels[0].entityName];
+    const childKeys0 = utils.extractKeys(childEntity0.keys);
+    const childWhereClauses = [childKeys0.map((pk, j) => `${quote(pk)} = :${refRow}.${quote(parentKeyBinding[j])}`).join(' AND ')];
+
+    for (let i = 1; i < levels.length; i++) {
+      const childLevel = levels[i - 1];
+      const ancestorLevel = levels[i];
+      const prevWhere = childWhereClauses[i - 1];
+
+      const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT ${quote(fk)} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
+
+      const ancestorEntity = model.definitions[ancestorLevel.entityName];
+      const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
+      const thisWhere = ancestorKeys.map((pk, j) => `${quote(pk)} = ${whereForAncestor[j]}`).join(' AND ');
+      childWhereClauses.push(thisWhere);
+
+      ancestorKeyValues.push(whereForAncestor);
+      keyExprs.push(entityKeyExpr(whereForAncestor));
+    }
+  }
+
+  return { keyExprs, ancestorKeyValues };
+}
+
+/**
+ * Builds the HANA SQLScript context for emitting composition parent changelog entries.
+ * Walks the composition hierarchy from outermost ancestor to the immediate parent and
+ * generates idempotent SELECT-then-INSERT blocks; declares variables for `parent_id` and
+ * each `ancestor_<i>_id` used to chain parent_ID values.
+ *
+ * @param {{ levels: Array, compositionFieldChangelog: Array|null }} compositionHierarchy
+ * @param {Array} parentObjectIDs - @changelog objectIDs of the immediate parent
+ * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {object} model - CSN model
+ * @param {string|null} [childObjectIDExpr] - Optional SQL expression for the trigger entity's objectID
+ * @param {Function|null} [buildFieldObjectIDFn] - `(changelog, parentEntity, parentKeyBinding) => sqlExpr`
+ *   resolving the field-level @changelog objectID
+ * @returns {{ declares: string, insertSQL: string, parentEntityName: string, compositionFieldName: string, parentKeyExpr: string, parentFKNullCheck?: string }}
+ */
+function buildCompositionParentContext(compositionHierarchy, parentObjectIDs, refRow, model, childObjectIDExpr = null, buildFieldObjectIDFn = null) {
+  const { levels, compositionFieldChangelog } = compositionHierarchy;
+  const { entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding } = levels[0];
+
+  // Handle composition of one (parent has FK to child - need reverse lookup)
+  if (parentKeyBinding.type === 'compositionOfOne') {
+    return buildCompositionOfOneParentContext({ parentEntityName, compositionFieldName, parentKeyBinding }, parentObjectIDs, refRow, model, childObjectIDExpr);
+  }
+
+  const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`));
+
+  // Null check for parent FK columns — prevents creating composition entries when FK is null
+  const parentFKNullCheck = parentKeyBinding.map((k) => `:${refRow}.${quote(k)} IS NOT NULL`).join(' AND ');
+
+  // Composition of many: resolve the objectID for the composition field
+  let compositionFieldObjectIDExpr = null;
+  if (buildFieldObjectIDFn) {
+    const parentEntity = model.definitions[parentEntityName];
+    compositionFieldObjectIDExpr = buildFieldObjectIDFn(compositionFieldChangelog, parentEntity, parentKeyBinding);
+  }
+
+  // Resolve objectID for the composition entry:
+  // 1. childObjectIDExpr: child's own @changelog objectID (only for composition-of-one)
+  // 2. compositionFieldObjectIDExpr: @changelog on the composition field (parent elements only, for composition-of-many)
+  // 3. buildCompOfManyRootObjectIDSelect: parent entity-level @changelog / entity keys (fallback)
+  const rootEntity = model.definitions[parentEntityName];
+  const immediateParentObjectIDExpr = compositionFieldObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(rootEntity, parentObjectIDs, parentKeyBinding, refRow, model);
+
+  let declares, insertSQL;
+
+  if (levels.length > 1) {
+    // Resolve key expressions for the composition hierarchy
+    const { keyExprs, ancestorKeyValues } = resolveAncestorKeyExpressions(levels, refRow, model);
+
+    // Declare variables for each level's parent_id
+    const declareStatements = ['DECLARE parent_id NVARCHAR(36);'];
+    for (let i = 1; i < levels.length; i++) {
+      declareStatements.push(`DECLARE ancestor_${i}_id NVARCHAR(36);`);
+    }
+    declares = declareStatements.join('\n\t');
+
+    // Generate INSERT statements from outermost ancestor down to the immediate parent
+    // Row-level triggers: use procedural INSERT ... VALUES with IF NULL checks
+    // For ancestor levels, add a null check on the immediate parent FK to ensure the chain exists.
+    // If the immediate parent FK is null, skip all ancestor levels too.
+    const insertStatements = [];
+
+    // Build a null check on the immediate parent FK columns (these are on the trigger's entity)
+    const immediateParentFKNullCheck = parentKeyBinding.map((k) => `:${refRow}.${quote(k)} IS NOT NULL`).join(' AND ');
+
+    for (let i = levels.length - 1; i >= 0; i--) {
+      const level = levels[i];
+      const levelKeyExpr = keyExprs[i];
+      const isOutermost = i === levels.length - 1;
+      const isImmediateParent = i === 0;
+
+      // Variable name for this level's changelog entry ID
+      const varName = isImmediateParent ? 'parent_id' : `ancestor_${i}_id`;
+
+      // parent_ID: NULL for outermost, variable for inner levels
+      let parentIDValue = 'NULL';
+      if (!isOutermost) {
+        parentIDValue = `ancestor_${i + 1}_id`;
+      }
+
+      // objectID: use child entity's objectID — shows which child was affected
+      let objectIDExpr;
+      if (isImmediateParent) {
+        objectIDExpr = immediateParentObjectIDExpr;
+      } else {
+        // For ancestor levels, resolve the child entity's objectID via subquery
+        const childEntityDef = model.definitions[level.childEntityName];
+        if (childEntityDef && level.childObjectIDs && level.childObjectIDs.length > 0) {
+          const childKeyValues = ancestorKeyValues[i - 1];
+          objectIDExpr = buildCompOfManyRootObjectIDSelect(childEntityDef, level.childObjectIDs, null, null, model, childKeyValues);
+        } else {
+          objectIDExpr = keyExprs[i - 1];
+        }
+      }
+
+      // For non-immediate parent levels (ancestors), wrap in a null check on the immediate parent FK
+      // This prevents creating ancestor composition entries when the child has no parent
+      // (e.g., RootSample inserted without grandParent)
+      const needsFKCheck = !isImmediateParent;
+      const fkCheckOpen = needsFKCheck ? `IF ${immediateParentFKNullCheck} THEN\n\t\t\t` : '';
+      const fkCheckClose = needsFKCheck ? `\n\t\tEND IF;` : '';
+
+      // Look up existing entry for this level, or create one
+      insertStatements.push(`${fkCheckOpen}SELECT MAX(ID) INTO ${varName} FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${level.entityName}'
+			AND entityKey = ${levelKeyExpr}
+			AND attribute = '${level.compositionFieldName}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();
+		IF ${varName} IS NULL THEN
+			${varName} := SYSUUID;
+			INSERT INTO SAP_CHANGELOG_CHANGES
+				(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+				VALUES (
+					${varName},
+					${parentIDValue},
+					'${level.compositionFieldName}',
+					'${level.entityName}',
+					${levelKeyExpr},
+					${objectIDExpr},
+					CURRENT_TIMESTAMP,
+					SESSION_CONTEXT('APPLICATIONUSER'),
+					'cds.Composition',
+					'update',
+					CURRENT_UPDATE_TRANSACTION()
+				);
+		END IF;${fkCheckClose}`);
+    }
+
+    insertSQL = insertStatements.join('\n\t\t');
+  } else {
+    // Simple composition-of-many: single-level parent.
+    declares = 'DECLARE parent_id NVARCHAR(36);';
+
+    insertSQL = `
+		INSERT INTO SAP_CHANGELOG_CHANGES
+			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+			VALUES (
+				parent_id,
+				NULL,
+				'${compositionFieldName}',
+				'${parentEntityName}',
+				${parentKeyExpr},
+				${immediateParentObjectIDExpr},
+				CURRENT_TIMESTAMP,
+				SESSION_CONTEXT('APPLICATIONUSER'),
+				'cds.Composition',
+				'update',
+				CURRENT_UPDATE_TRANSACTION()
+			);`;
+  }
+
+  return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck };
+}
+
+/**
+ * Builds a HANA SELECT-INTO statement that loads the parent composition entry's ID
+ * for the current transaction into the `parent_id` variable.
+ *
+ * @param {string} parentEntityName
+ * @param {string} parentKeyExpr - SQL expression for the parent's entityKey
+ * @param {string} compositionFieldName - The composition element name (attribute)
+ * @returns {string}
+ */
+function buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName) {
+  return `SELECT MAX(ID) INTO parent_id FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${parentEntityName}'
+			AND entityKey = ${parentKeyExpr}
+			AND attribute = '${compositionFieldName}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION();`;
+}
+
+/**
+ * Builds an SQLScript fragment that looks up `parent_id`; if not present, creates it
+ * via the provided `compositionParentContext.insertSQL`. Wraps everything in the
+ * `parentFKNullCheck` when present (skips creation if FK is null).
+ *
+ * @param {{ insertSQL: string, parentEntityName: string, compositionFieldName: string, parentKeyExpr: string, parentFKNullCheck?: string }} compositionParentContext
+ * @returns {string}
+ */
+function buildParentLookupOrCreateSQL(compositionParentContext) {
+  const { insertSQL: compInsertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck } = compositionParentContext;
+  const lookupSQL = buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName);
+  // Wrap in FK null check to skip composition entry creation when parent FK is null
+  if (parentFKNullCheck) {
+    return `IF ${parentFKNullCheck} THEN
+			${lookupSQL}
+		IF parent_id IS NULL THEN
+			parent_id := SYSUUID;
+			${compInsertSQL}
+		END IF;
+		END IF;`;
+  }
+  return `${lookupSQL}
+		IF parent_id IS NULL THEN
+			parent_id := SYSUUID;
+			${compInsertSQL}
+		END IF;`;
+}
+
+/**
+ * Builds a HANA trigger body when the entity has only composition tracking and
+ * no tracked columns of its own.
+ *
+ * @param {string} entityName
+ * @param {object} compositionParentContext - Result from `buildCompositionParentContext`
+ * @param {string} [prefixSQL] - Optional SQL to inject before the parent-lookup-or-create
+ * @returns {string}
+ */
+function buildCompositionOnlyBody(entityName, compositionParentContext, prefixSQL = '') {
+  const { getSkipCheckCondition } = require('./sql-expressions.js');
+  const { declares } = compositionParentContext;
+  const prefix = prefixSQL ? `\n\t\t${prefixSQL}` : '';
+  return `${declares}
+	IF ${getSkipCheckCondition(entityName)} THEN${prefix}
+		${buildParentLookupOrCreateSQL(compositionParentContext)}
+	END IF;`;
+}
+
+module.exports = {
+  buildCompOfManyRootObjectIDSelect,
+  buildCompositionParentContext,
+  buildParentLookupOrCreateSQL,
+  buildCompositionOnlyBody
+};

--- a/lib/hana/composition.js
+++ b/lib/hana/composition.js
@@ -1,21 +1,20 @@
 const utils = require('../utils/change-tracking.js');
-const { toSQL, entityKeyExpr, quote } = require('./sql-expressions.js');
+const { toSQL, entityKeyExpr, quote, colRef } = require('./sql-expressions.js');
 
 /**
- * Builds an SQL expression for the parent objectID of a composition-of-many entry.
+ * Builds an SQL expression for the parent objectID of a composition entry.
  * Resolves @changelog objectIDs from the parent table or falls back to the entityKey string
  * when no objectID is configured. With multiple objectIDs concatenates with ", ".
  *
  * @param {object} rootEntity - CSN definition of root entity
  * @param {Array} rootObjectIDs - @changelog objectID definitions
  * @param {Array} binding - FK column names on the child pointing to the parent
- * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {string} refRow - Transition-table alias (e.g. 'nr' or 'o')
  * @param {object} model - CSN model
- * @param {Array} [keyValueExprs] - Pre-built key value expressions; bypass `:${refRow}.${binding[i]}`
- * @returns {string} A SQL scalar expression
+ * @param {Array} [keyValueExprs] - Pre-built key value expressions; bypass colRef(refRow, binding[i])
  */
 function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, refRow, model, keyValueExprs = null) {
-  const keyValues = keyValueExprs ?? binding.map((k) => `:${refRow}.${quote(k)}`);
+  const keyValues = keyValueExprs ?? binding.map((k) => colRef(refRow, k));
   const rootEntityKeyExpr = entityKeyExpr(keyValues);
 
   if (!rootObjectIDs || rootObjectIDs.length === 0) return rootEntityKeyExpr;
@@ -52,62 +51,76 @@ function buildCompOfManyRootObjectIDSelect(rootEntity, rootObjectIDs, binding, r
 }
 
 /**
- * Builds context for composition of one parent changelog entry.
- * In composition of one, the parent entity has FK to the child (e.g., BookStores.registry_ID -> BookStoreRegistry.ID)
- * So we need to do a reverse lookup: find the parent record that has FK pointing to this child.
+ * Builds a correlated lookup expression that resolves the parent changelog entry's ID
+ * for a row of the transition table, keyed by (entity, entityKey, attribute, txn).
+ *
+ * Used as the `parent_ID` value when inserting child changelog entries (or inner-ancestor
+ * composition entries) at statement level. The row inserted earlier in this trigger body
+ * (and matched by the same transactionID) is found by content.
+ */
+function buildParentIdLookupExpr(parentEntityName, parentKeyExpr, compositionFieldName) {
+  return `(SELECT MAX(ID) FROM SAP_CHANGELOG_CHANGES WHERE entity = '${parentEntityName}' AND entityKey = ${parentKeyExpr} AND attribute = '${compositionFieldName}' AND valueDataType = 'cds.Composition' AND transactionID = CURRENT_UPDATE_TRANSACTION())`;
+}
+
+/**
+ * Composition-of-one parent context (statement-level).
+ *
+ * For composition-of-one, the parent entity has the FK to the child. Reverse-lookup from
+ * the parent table finds the parent key for each child row in the transition table.
+ *
+ * @returns {{ parentEntityName: string, compositionFieldName: string, parentInsertSQL: string, parentIdLookupExpr: string, parentEntityKeyExpr: string }}
  */
 function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs, refRow, model, childObjectIDExpr = null) {
   const { parentEntityName, compositionFieldName, parentKeyBinding } = compositionParentInfo;
   const { compositionName, childKeys } = parentKeyBinding;
 
-  // Build the FK field names on the parent that point to this child
-  // For composition of one, CAP generates <compositionName>_<childKey> fields
   const parentFKFields = childKeys.map((k) => quote(`${compositionName}_${k}`));
-
-  // Build WHERE clause to find the parent entity that has this child
   const parentEntity = model.definitions[parentEntityName];
   const parentKeys = utils.extractKeys(parentEntity.keys);
-  const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = :${refRow}.${quote(childKeys[i])}`).join(' AND ');
 
-  // Build the parent key expression via subquery (reverse lookup)
-  const parentKeySubqueries = parentKeys.map((pk) => `(SELECT ${quote(pk)} FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
-  const parentKeyExpr = entityKeyExpr(parentKeySubqueries);
+  // Reverse-lookup WHERE: parent.<fk> = nr.<childKey> — references outer transition row.
+  const parentWhereClause = parentFKFields.map((fk, i) => `${fk} = ${colRef(refRow, childKeys[i])}`).join(' AND ');
 
-  // Use child's objectID expression for the composition entry — shows which child was affected
-  // Falls back to parent's own objectID if child objectID is not available
+  // Subquery yielding the parent's PK columns. There is at most one parent per child row
+  // (composition-of-one), so MAX() is safe and avoids the correlated TOP/LIMIT restriction.
+  const parentKeySubqueries = parentKeys.map((pk) => `(SELECT MAX(${quote(pk)}) FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})`);
+  const parentEntityKeyExpr = entityKeyExpr(parentKeySubqueries);
+
+  // objectID for the parent composition entry: child's own objectID if provided, else parent objectID.
   const objectIDExpr = childObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(parentEntity, rootObjectIDs, null, null, model, parentKeySubqueries);
 
-  const declares = 'DECLARE parent_id NVARCHAR(36);';
+  // Parent INSERT (set-based, deduped against existing entries in this transaction).
+  // The FROM source is the full transition table because the objectID expression may
+  // reference any column on the child (not just the FK keys). The NOT EXISTS dedup
+  // still prevents duplicate parent entries for the same parent key.
+  const parentInsertSQL = `INSERT INTO SAP_CHANGELOG_CHANGES
+		(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+		SELECT
+			SYSUUID,
+			NULL,
+			'${compositionFieldName}',
+			'${parentEntityName}',
+			${parentEntityKeyExpr},
+			${objectIDExpr},
+			CURRENT_TIMESTAMP,
+			SESSION_CONTEXT('APPLICATIONUSER'),
+			'cds.Composition',
+			'update',
+			CURRENT_UPDATE_TRANSACTION()
+		FROM :${refRow === 'o' ? 'old_rows' : 'new_rows'} ${refRow}
+		WHERE EXISTS (SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause})
+		AND NOT EXISTS (
+			SELECT 1 FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${parentEntityName}'
+			AND entityKey = ${parentEntityKeyExpr}
+			AND attribute = '${compositionFieldName}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		);`;
 
-  const insertSQL = `
-		INSERT INTO SAP_CHANGELOG_CHANGES
-			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			SELECT
-				parent_id,
-				NULL,
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${objectIDExpr},
-				CURRENT_TIMESTAMP,
-				SESSION_CONTEXT('APPLICATIONUSER'),
-				'cds.Composition',
-				'update',
-				CURRENT_UPDATE_TRANSACTION()
-			FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY
-			WHERE EXISTS (
-				SELECT 1 FROM ${utils.transformName(parentEntityName)} WHERE ${parentWhereClause}
-			)
-			AND NOT EXISTS (
-				SELECT 1 FROM SAP_CHANGELOG_CHANGES
-				WHERE entity = '${parentEntityName}'
-				AND entityKey = ${parentKeyExpr}
-				AND attribute = '${compositionFieldName}'
-				AND valueDataType = 'cds.Composition'
-				AND transactionID = CURRENT_UPDATE_TRANSACTION()
-			);`;
+  const parentIdLookupExpr = buildParentIdLookupExpr(parentEntityName, parentEntityKeyExpr, compositionFieldName);
 
-  return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr };
+  return { parentEntityName, compositionFieldName, parentInsertSQL, parentIdLookupExpr, parentEntityKeyExpr };
 }
 
 /**
@@ -115,26 +128,28 @@ function buildCompositionOfOneParentContext(compositionParentInfo, rootObjectIDs
  * chained subqueries that navigate from the trigger row up through the ancestors.
  *
  * @param {Array} levels - Array of { entityName, compositionFieldName, keyBinding } from immediate parent to outermost ancestor
- * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {string} refRow - Transition-table alias
  * @param {object} model - The CDS model
  * @returns {{ keyExprs: string[], ancestorKeyValues: string[][] }}
  */
 function resolveAncestorKeyExpressions(levels, refRow, model) {
   const parentKeyBinding = levels[0].keyBinding;
-  const keyExprs = [entityKeyExpr(parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`))];
-  const ancestorKeyValues = [parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`)];
+  const keyExprs = [entityKeyExpr(parentKeyBinding.map((k) => colRef(refRow, k)))];
+  const ancestorKeyValues = [parentKeyBinding.map((k) => colRef(refRow, k))];
 
   if (levels.length > 1) {
     const childEntity0 = model.definitions[levels[0].entityName];
     const childKeys0 = utils.extractKeys(childEntity0.keys);
-    const childWhereClauses = [childKeys0.map((pk, j) => `${quote(pk)} = :${refRow}.${quote(parentKeyBinding[j])}`).join(' AND ')];
+    const childWhereClauses = [childKeys0.map((pk, j) => `${quote(pk)} = ${colRef(refRow, parentKeyBinding[j])}`).join(' AND ')];
 
     for (let i = 1; i < levels.length; i++) {
       const childLevel = levels[i - 1];
       const ancestorLevel = levels[i];
       const prevWhere = childWhereClauses[i - 1];
 
-      const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT ${quote(fk)} FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
+      // Wrap subqueries with MAX() to avoid HANA's correlated-subquery TOP/ORDER BY restriction.
+      // Composition FKs have at-most-one parent so MAX is safe.
+      const whereForAncestor = ancestorLevel.keyBinding.map((fk) => `(SELECT MAX(${quote(fk)}) FROM ${utils.transformName(childLevel.entityName)} WHERE ${prevWhere})`);
 
       const ancestorEntity = model.definitions[ancestorLevel.entityName];
       const ancestorKeys = utils.extractKeys(ancestorEntity.keys);
@@ -150,91 +165,76 @@ function resolveAncestorKeyExpressions(levels, refRow, model) {
 }
 
 /**
- * Builds the HANA SQLScript context for emitting composition parent changelog entries.
- * Walks the composition hierarchy from outermost ancestor to the immediate parent and
- * generates idempotent SELECT-then-INSERT blocks; declares variables for `parent_id` and
- * each `ancestor_<i>_id` used to chain parent_ID values.
+ * Builds the set of statement-level INSERT … SELECT statements that materialize the
+ * composition parent entries (ancestor levels + immediate parent). These are emitted
+ * outermost-first so each inner level's `parent_ID` lookup finds the outer entry.
  *
  * @param {{ levels: Array, compositionFieldChangelog: Array|null }} compositionHierarchy
  * @param {Array} parentObjectIDs - @changelog objectIDs of the immediate parent
- * @param {string} refRow - Trigger row reference ('new' or 'old')
- * @param {object} model - CSN model
- * @param {string|null} [childObjectIDExpr] - Optional SQL expression for the trigger entity's objectID
- * @param {Function|null} [buildFieldObjectIDFn] - `(changelog, parentEntity, parentKeyBinding) => sqlExpr`
- *   resolving the field-level @changelog objectID
- * @returns {{ declares: string, insertSQL: string, parentEntityName: string, compositionFieldName: string, parentKeyExpr: string, parentFKNullCheck?: string }}
+ * @param {string} refRow - Transition-table alias ('nr' or 'o')
+ * @param {object} model
+ * @param {string|null} childObjectIDExpr - Optional SQL expression for the trigger entity's objectID
+ * @param {Function|null} buildFieldObjectIDFn - Field-level @changelog objectID resolver
+ * @returns {{ parentInsertsSQL: string, immediateParentEntityName: string, immediateParentCompositionFieldName: string, immediateParentEntityKeyExpr: string, parentIdLookupExpr: string }}
  */
 function buildCompositionParentContext(compositionHierarchy, parentObjectIDs, refRow, model, childObjectIDExpr = null, buildFieldObjectIDFn = null) {
   const { levels, compositionFieldChangelog } = compositionHierarchy;
   const { entityName: parentEntityName, compositionFieldName, keyBinding: parentKeyBinding } = levels[0];
 
-  // Handle composition of one (parent has FK to child - need reverse lookup)
+  // Composition-of-one is a special case: parent has FK to child (reverse lookup).
   if (parentKeyBinding.type === 'compositionOfOne') {
-    return buildCompositionOfOneParentContext({ parentEntityName, compositionFieldName, parentKeyBinding }, parentObjectIDs, refRow, model, childObjectIDExpr);
+    const ctx = buildCompositionOfOneParentContext({ parentEntityName, compositionFieldName, parentKeyBinding }, parentObjectIDs, refRow, model, childObjectIDExpr);
+    return {
+      parentInsertsSQL: ctx.parentInsertSQL,
+      immediateParentEntityName: ctx.parentEntityName,
+      immediateParentCompositionFieldName: ctx.compositionFieldName,
+      immediateParentEntityKeyExpr: ctx.parentEntityKeyExpr,
+      parentIdLookupExpr: ctx.parentIdLookupExpr
+    };
   }
 
-  const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => `:${refRow}.${quote(k)}`));
+  // Composition-of-many: child has FK to parent.
+  const parentKeyExpr = entityKeyExpr(parentKeyBinding.map((k) => colRef(refRow, k)));
 
-  // Null check for parent FK columns — prevents creating composition entries when FK is null
-  const parentFKNullCheck = parentKeyBinding.map((k) => `:${refRow}.${quote(k)} IS NOT NULL`).join(' AND ');
-
-  // Composition of many: resolve the objectID for the composition field
+  // Resolve objectID for the immediate parent composition entry.
   let compositionFieldObjectIDExpr = null;
   if (buildFieldObjectIDFn) {
     const parentEntity = model.definitions[parentEntityName];
     compositionFieldObjectIDExpr = buildFieldObjectIDFn(compositionFieldChangelog, parentEntity, parentKeyBinding);
   }
-
-  // Resolve objectID for the composition entry:
-  // 1. childObjectIDExpr: child's own @changelog objectID (only for composition-of-one)
-  // 2. compositionFieldObjectIDExpr: @changelog on the composition field (parent elements only, for composition-of-many)
-  // 3. buildCompOfManyRootObjectIDSelect: parent entity-level @changelog / entity keys (fallback)
   const rootEntity = model.definitions[parentEntityName];
   const immediateParentObjectIDExpr = compositionFieldObjectIDExpr ?? buildCompOfManyRootObjectIDSelect(rootEntity, parentObjectIDs, parentKeyBinding, refRow, model);
 
-  let declares, insertSQL;
+  // Distinct parent key set per transition row, used as the FROM source for parent inserts.
+  const distinctParentKeysSrc = `(SELECT DISTINCT ${parentKeyBinding.map((k) => `${refRow}.${quote(k)}`).join(', ')} FROM :${refRow === 'o' ? 'old_rows' : 'new_rows'} ${refRow} WHERE ${parentKeyBinding.map((k) => `${refRow}.${quote(k)} IS NOT NULL`).join(' AND ')}) ${refRow}`;
+
+  const inserts = [];
 
   if (levels.length > 1) {
-    // Resolve key expressions for the composition hierarchy
+    // Resolve key expressions for each level (immediate parent through outermost ancestor).
     const { keyExprs, ancestorKeyValues } = resolveAncestorKeyExpressions(levels, refRow, model);
 
-    // Declare variables for each level's parent_id
-    const declareStatements = ['DECLARE parent_id NVARCHAR(36);'];
-    for (let i = 1; i < levels.length; i++) {
-      declareStatements.push(`DECLARE ancestor_${i}_id NVARCHAR(36);`);
-    }
-    declares = declareStatements.join('\n\t');
-
-    // Generate INSERT statements from outermost ancestor down to the immediate parent
-    // Row-level triggers: use procedural INSERT ... VALUES with IF NULL checks
-    // For ancestor levels, add a null check on the immediate parent FK to ensure the chain exists.
-    // If the immediate parent FK is null, skip all ancestor levels too.
-    const insertStatements = [];
-
-    // Build a null check on the immediate parent FK columns (these are on the trigger's entity)
-    const immediateParentFKNullCheck = parentKeyBinding.map((k) => `:${refRow}.${quote(k)} IS NOT NULL`).join(' AND ');
-
+    // Emit INSERTs from outermost ancestor inward. Each inner level's parent_ID is a
+    // correlated lookup against the row inserted in the preceding step.
     for (let i = levels.length - 1; i >= 0; i--) {
       const level = levels[i];
-      const levelKeyExpr = keyExprs[i];
       const isOutermost = i === levels.length - 1;
-      const isImmediateParent = i === 0;
+      const isImmediate = i === 0;
 
-      // Variable name for this level's changelog entry ID
-      const varName = isImmediateParent ? 'parent_id' : `ancestor_${i}_id`;
+      const levelKeyExpr = keyExprs[i];
 
-      // parent_ID: NULL for outermost, variable for inner levels
+      // parent_ID for this level
       let parentIDValue = 'NULL';
       if (!isOutermost) {
-        parentIDValue = `ancestor_${i + 1}_id`;
+        const outerLevel = levels[i + 1];
+        parentIDValue = buildParentIdLookupExpr(outerLevel.entityName, keyExprs[i + 1], outerLevel.compositionFieldName);
       }
 
-      // objectID: use child entity's objectID — shows which child was affected
+      // objectID for this level's composition entry: child entity's objectID if known.
       let objectIDExpr;
-      if (isImmediateParent) {
+      if (isImmediate) {
         objectIDExpr = immediateParentObjectIDExpr;
       } else {
-        // For ancestor levels, resolve the child entity's objectID via subquery
         const childEntityDef = model.definitions[level.childEntityName];
         if (childEntityDef && level.childObjectIDs && level.childObjectIDs.length > 0) {
           const childKeyValues = ancestorKeyValues[i - 1];
@@ -244,134 +244,70 @@ function buildCompositionParentContext(compositionHierarchy, parentObjectIDs, re
         }
       }
 
-      // For non-immediate parent levels (ancestors), wrap in a null check on the immediate parent FK
-      // This prevents creating ancestor composition entries when the child has no parent
-      // (e.g., RootSample inserted without grandParent)
-      const needsFKCheck = !isImmediateParent;
-      const fkCheckOpen = needsFKCheck ? `IF ${immediateParentFKNullCheck} THEN\n\t\t\t` : '';
-      const fkCheckClose = needsFKCheck ? `\n\t\tEND IF;` : '';
-
-      // Look up existing entry for this level, or create one
-      insertStatements.push(`${fkCheckOpen}SELECT MAX(ID) INTO ${varName} FROM SAP_CHANGELOG_CHANGES
+      inserts.push(`INSERT INTO SAP_CHANGELOG_CHANGES
+		(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+		SELECT
+			SYSUUID,
+			${parentIDValue},
+			'${level.compositionFieldName}',
+			'${level.entityName}',
+			${levelKeyExpr},
+			${objectIDExpr},
+			CURRENT_TIMESTAMP,
+			SESSION_CONTEXT('APPLICATIONUSER'),
+			'cds.Composition',
+			'update',
+			CURRENT_UPDATE_TRANSACTION()
+		FROM ${distinctParentKeysSrc}
+		WHERE NOT EXISTS (
+			SELECT 1 FROM SAP_CHANGELOG_CHANGES
 			WHERE entity = '${level.entityName}'
 			AND entityKey = ${levelKeyExpr}
 			AND attribute = '${level.compositionFieldName}'
 			AND valueDataType = 'cds.Composition'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();
-		IF ${varName} IS NULL THEN
-			${varName} := SYSUUID;
-			INSERT INTO SAP_CHANGELOG_CHANGES
-				(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-				VALUES (
-					${varName},
-					${parentIDValue},
-					'${level.compositionFieldName}',
-					'${level.entityName}',
-					${levelKeyExpr},
-					${objectIDExpr},
-					CURRENT_TIMESTAMP,
-					SESSION_CONTEXT('APPLICATIONUSER'),
-					'cds.Composition',
-					'update',
-					CURRENT_UPDATE_TRANSACTION()
-				);
-		END IF;${fkCheckClose}`);
+			AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		);`);
     }
-
-    insertSQL = insertStatements.join('\n\t\t');
   } else {
-    // Simple composition-of-many: single-level parent.
-    declares = 'DECLARE parent_id NVARCHAR(36);';
-
-    insertSQL = `
-		INSERT INTO SAP_CHANGELOG_CHANGES
-			(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
-			VALUES (
-				parent_id,
-				NULL,
-				'${compositionFieldName}',
-				'${parentEntityName}',
-				${parentKeyExpr},
-				${immediateParentObjectIDExpr},
-				CURRENT_TIMESTAMP,
-				SESSION_CONTEXT('APPLICATIONUSER'),
-				'cds.Composition',
-				'update',
-				CURRENT_UPDATE_TRANSACTION()
-			);`;
-  }
-
-  return { declares, insertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck };
-}
-
-/**
- * Builds a HANA SELECT-INTO statement that loads the parent composition entry's ID
- * for the current transaction into the `parent_id` variable.
- *
- * @param {string} parentEntityName
- * @param {string} parentKeyExpr - SQL expression for the parent's entityKey
- * @param {string} compositionFieldName - The composition element name (attribute)
- * @returns {string}
- */
-function buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName) {
-  return `SELECT MAX(ID) INTO parent_id FROM SAP_CHANGELOG_CHANGES
+    // Simple single-level composition.
+    inserts.push(`INSERT INTO SAP_CHANGELOG_CHANGES
+		(ID, parent_ID, attribute, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+		SELECT
+			SYSUUID,
+			NULL,
+			'${compositionFieldName}',
+			'${parentEntityName}',
+			${parentKeyExpr},
+			${immediateParentObjectIDExpr},
+			CURRENT_TIMESTAMP,
+			SESSION_CONTEXT('APPLICATIONUSER'),
+			'cds.Composition',
+			'update',
+			CURRENT_UPDATE_TRANSACTION()
+		FROM ${distinctParentKeysSrc}
+		WHERE NOT EXISTS (
+			SELECT 1 FROM SAP_CHANGELOG_CHANGES
 			WHERE entity = '${parentEntityName}'
 			AND entityKey = ${parentKeyExpr}
 			AND attribute = '${compositionFieldName}'
 			AND valueDataType = 'cds.Composition'
-			AND transactionID = CURRENT_UPDATE_TRANSACTION();`;
-}
-
-/**
- * Builds an SQLScript fragment that looks up `parent_id`; if not present, creates it
- * via the provided `compositionParentContext.insertSQL`. Wraps everything in the
- * `parentFKNullCheck` when present (skips creation if FK is null).
- *
- * @param {{ insertSQL: string, parentEntityName: string, compositionFieldName: string, parentKeyExpr: string, parentFKNullCheck?: string }} compositionParentContext
- * @returns {string}
- */
-function buildParentLookupOrCreateSQL(compositionParentContext) {
-  const { insertSQL: compInsertSQL, parentEntityName, compositionFieldName, parentKeyExpr, parentFKNullCheck } = compositionParentContext;
-  const lookupSQL = buildParentLookupSQL(parentEntityName, parentKeyExpr, compositionFieldName);
-  // Wrap in FK null check to skip composition entry creation when parent FK is null
-  if (parentFKNullCheck) {
-    return `IF ${parentFKNullCheck} THEN
-			${lookupSQL}
-		IF parent_id IS NULL THEN
-			parent_id := SYSUUID;
-			${compInsertSQL}
-		END IF;
-		END IF;`;
+			AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		);`);
   }
-  return `${lookupSQL}
-		IF parent_id IS NULL THEN
-			parent_id := SYSUUID;
-			${compInsertSQL}
-		END IF;`;
-}
 
-/**
- * Builds a HANA trigger body when the entity has only composition tracking and
- * no tracked columns of its own.
- *
- * @param {string} entityName
- * @param {object} compositionParentContext - Result from `buildCompositionParentContext`
- * @param {string} [prefixSQL] - Optional SQL to inject before the parent-lookup-or-create
- * @returns {string}
- */
-function buildCompositionOnlyBody(entityName, compositionParentContext, prefixSQL = '') {
-  const { getSkipCheckCondition } = require('./sql-expressions.js');
-  const { declares } = compositionParentContext;
-  const prefix = prefixSQL ? `\n\t\t${prefixSQL}` : '';
-  return `${declares}
-	IF ${getSkipCheckCondition(entityName)} THEN${prefix}
-		${buildParentLookupOrCreateSQL(compositionParentContext)}
-	END IF;`;
+  const parentIdLookupExpr = buildParentIdLookupExpr(parentEntityName, parentKeyExpr, compositionFieldName);
+
+  return {
+    parentInsertsSQL: inserts.join('\n\t\t'),
+    immediateParentEntityName: parentEntityName,
+    immediateParentCompositionFieldName: compositionFieldName,
+    immediateParentEntityKeyExpr: parentKeyExpr,
+    parentIdLookupExpr
+  };
 }
 
 module.exports = {
   buildCompOfManyRootObjectIDSelect,
   buildCompositionParentContext,
-  buildParentLookupOrCreateSQL,
-  buildCompositionOnlyBody
+  buildParentIdLookupExpr
 };

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -12,6 +12,11 @@ function hasMigrationTable() {
 function registerHDICompilerHook() {
   const _hdi_migration = cds.compiler.to.hdi.migration;
   cds.compiler.to.hdi.migration = function (csn, options, beforeImage) {
+    // Check if the plugin's base model is part of the CSN
+    if (!csn.definitions?.['sap.changelog.Changes']) {
+      return _hdi_migration(csn, options, beforeImage);
+    }
+
     const config = cds.env.requires?.['change-tracking'];
     // Trigger style: statement-level by default; opt-in row-level via config flag.
     const { generateHANATriggers } = config?.rowLevelTriggers ? require('./triggers-row.js') : require('./triggers.js');

--- a/lib/hana/register.js
+++ b/lib/hana/register.js
@@ -12,7 +12,9 @@ function hasMigrationTable() {
 function registerHDICompilerHook() {
   const _hdi_migration = cds.compiler.to.hdi.migration;
   cds.compiler.to.hdi.migration = function (csn, options, beforeImage) {
-    const { generateHANATriggers } = require('./triggers.js');
+    const config = cds.env.requires?.['change-tracking'];
+    // Trigger style: statement-level by default; opt-in row-level via config flag.
+    const { generateHANATriggers } = config?.rowLevelTriggers ? require('./triggers-row.js') : require('./triggers.js');
     const { runtimeCSN, hierarchy, entities } = prepareCSNForTriggers(csn, true);
 
     const triggers = generateTriggersForEntities(runtimeCSN, hierarchy, entities, generateHANATriggers);
@@ -43,8 +45,6 @@ function registerHDICompilerHook() {
         }
       );
     }
-
-    const config = cds.env.requires?.['change-tracking'];
 
     // Generate restore backlinks procedure if enabled via feature flag
     if (config?.procedureForRestoringBacklinks) {

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -5,15 +5,43 @@ const { createTriggerCQN2SQL } = require('../TriggerCQN2SQL.js');
 let HANACQN2SQL;
 let _quoter;
 
-function toSQL(query, model) {
-  const cqn4sql = require('@cap-js/db-service/lib/cqn4sql');
+function _getInstance() {
   if (!HANACQN2SQL) {
     const { CQN2SQL } = require('@cap-js/hana');
     const TriggerCQN2SQL = createTriggerCQN2SQL(CQN2SQL);
     HANACQN2SQL = new TriggerCQN2SQL();
   }
+  return HANACQN2SQL;
+}
+
+/**
+ * Strips `LIMIT` / `one` from a CQN SELECT query (recursively into compound queries).
+ *
+ * Statement-level triggers reference the outer transition table aliases (e.g. `nr.<col>`)
+ * inside scalar subqueries (association/text-table lookups). HANA forbids `TOP`/`ORDER BY`
+ * in correlated subqueries, so the `LIMIT 1` that `SELECT.one` emits causes the trigger
+ * to be rejected at deploy time. Uniqueness is guaranteed by the PK / locale composite key
+ * of the lookup target, so dropping the LIMIT is safe.
+ */
+function _stripLimit(query) {
+  if (!query) return;
+  if (query.SELECT) {
+    query.SELECT.limit = undefined;
+    query.SELECT.one = false;
+    if (query.SELECT.from) _stripLimit(query.SELECT.from);
+  }
+  if (Array.isArray(query.args)) query.args.forEach(_stripLimit);
+}
+
+/**
+ * Compiles a CQN query to HANA SQL for use inside a statement-level trigger body.
+ * Always strips `LIMIT` to satisfy the HANA correlated-subquery restriction.
+ */
+function toSQL(query, model) {
+  const cqn4sql = require('@cap-js/db-service/lib/cqn4sql');
   const sqlCQN = cqn4sql(query, model);
-  return HANACQN2SQL.SELECT(sqlCQN);
+  _stripLimit(sqlCQN);
+  return _getInstance().SELECT(sqlCQN);
 }
 
 /**
@@ -22,6 +50,16 @@ function toSQL(query, model) {
 function quote(name) {
   if (!_quoter) _quoter = new (require('@cap-js/hana').CQN2SQL)();
   return _quoter.quote(name);
+}
+
+/**
+ * Returns the SQL fragment for referencing a column on a transition row.
+ *
+ * `refRow` is the alias of the transition table (e.g. 'nr' for `:new_rows nr`,
+ * 'o' for `:old_rows o`). Yields `<alias>.<col>`.
+ */
+function colRef(refRow, col) {
+  return `${refRow}.${quote(col)}`;
 }
 
 function getSkipCheckCondition(entityName) {
@@ -51,20 +89,19 @@ function wrapLargeString(val, isLob = false) {
 
 /**
  * Returns SQL expression for a column's raw value.
- * Uses HANA row-level trigger syntax: :refRow.column
  */
 function getValueExpr(col, refRow) {
   if (col.type === 'cds.Boolean') {
-    return `:${refRow}.${quote(col.name)}`;
+    return colRef(refRow, col.name);
   }
   if (col.target && col.foreignKeys) {
-    return col.foreignKeys.map((fk) => `TO_NVARCHAR(:${refRow}.${quote(`${col.name}_${fk}`)})`).join(" || ' ' || ");
+    return col.foreignKeys.map((fk) => `TO_NVARCHAR(${colRef(refRow, `${col.name}_${fk}`)})`).join(" || ' ' || ");
   }
   if (col.target && col.on) {
-    return col.on.map((m) => `TO_NVARCHAR(:${refRow}.${quote(m.foreignKeyField)})`).join(" || ' ' || ");
+    return col.on.map((m) => `TO_NVARCHAR(${colRef(refRow, m.foreignKeyField)})`).join(" || ' ' || ");
   }
   // Scalar value
-  let raw = `:${refRow}.${quote(col.name)}`;
+  let raw = colRef(refRow, col.name);
   if (col.type === 'cds.LargeString') {
     return wrapLargeString(raw, true);
   }
@@ -76,39 +113,44 @@ function getValueExpr(col, refRow) {
 
 /**
  * Null-safe change detection: (old <> new OR old IS NULL OR new IS NULL) AND NOT (old IS NULL AND new IS NULL)
- * Uses HANA row-level trigger syntax: :old.column, :new.column
  */
-function nullSafeChanged(column, isLob = false) {
+function nullSafeChanged(column, isLob, newRef, oldRef) {
   // For LOB types, convert to NVARCHAR before comparison
-  const qCol = quote(column);
-  const o = isLob ? `TO_NVARCHAR(:old.${qCol})` : `:old.${qCol}`;
-  const n = isLob ? `TO_NVARCHAR(:new.${qCol})` : `:new.${qCol}`;
+  const oRaw = colRef(oldRef, column);
+  const nRaw = colRef(newRef, column);
+  const o = isLob ? `TO_NVARCHAR(${oRaw})` : oRaw;
+  const n = isLob ? `TO_NVARCHAR(${nRaw})` : nRaw;
   return `(${o} <> ${n} OR ${o} IS NULL OR ${n} IS NULL) AND NOT (${o} IS NULL AND ${n} IS NULL)`;
 }
 
 /**
  * Returns SQL WHERE condition for detecting column changes (null-safe comparison).
- * Uses HANA row-level trigger syntax.
+ *
+ * @param {object} col
+ * @param {'create'|'update'|'delete'} modification
+ * @param {{ newRef: string, oldRef: string }} refs - Transition-table aliases
  */
-function getWhereCondition(col, modification) {
+function getWhereCondition(col, modification, refs) {
   const isLob = col.type === 'cds.LargeString';
+  const { newRef, oldRef } = refs;
+
   if (modification === 'update') {
     const checkCols = col.foreignKeys ? col.foreignKeys.map((fk) => `${col.name}_${fk}`) : col.on ? col.on.map((m) => m.foreignKeyField) : [col.name];
-    return checkCols.map((k) => nullSafeChanged(k, isLob)).join(' OR ');
+    return checkCols.map((k) => nullSafeChanged(k, isLob, newRef, oldRef)).join(' OR ');
   }
   // CREATE or DELETE: check value is not null
-  const refRow = modification === 'create' ? 'new' : 'old';
+  const refRow = modification === 'create' ? newRef : oldRef;
   if (col.target && col.foreignKeys) {
-    return col.foreignKeys.map((fk) => `:${refRow}.${quote(`${col.name}_${fk}`)} IS NOT NULL`).join(' OR ');
+    return col.foreignKeys.map((fk) => `${colRef(refRow, `${col.name}_${fk}`)} IS NOT NULL`).join(' OR ');
   }
   if (col.target && col.on) {
-    return col.on.map((m) => `:${refRow}.${quote(m.foreignKeyField)} IS NOT NULL`).join(' OR ');
+    return col.on.map((m) => `${colRef(refRow, m.foreignKeyField)} IS NOT NULL`).join(' OR ');
   }
   // For LOB types, convert to NVARCHAR before null check
   if (isLob) {
-    return `TO_NVARCHAR(:${refRow}.${quote(col.name)}) IS NOT NULL`;
+    return `TO_NVARCHAR(${colRef(refRow, col.name)}) IS NOT NULL`;
   }
-  return `:${refRow}.${quote(col.name)} IS NOT NULL`;
+  return `${colRef(refRow, col.name)} IS NOT NULL`;
 }
 
 /**
@@ -118,12 +160,12 @@ function buildAssocLookup(col, assocPaths, refRow, model) {
   let where = {};
   if (col.foreignKeys) {
     where = col.foreignKeys.reduce((acc, k) => {
-      acc[k] = { val: `:${refRow}.${quote(`${col.name}_${k}`)}`, literal: 'sql' };
+      acc[k] = { val: colRef(refRow, `${col.name}_${k}`), literal: 'sql' };
       return acc;
     }, {});
   } else if (col.on) {
     where = col.on.reduce((acc, mapping) => {
-      acc[mapping.targetKey] = { val: `:${refRow}.${quote(mapping.foreignKeyField)}`, literal: 'sql' };
+      acc[mapping.targetKey] = { val: colRef(refRow, mapping.foreignKeyField), literal: 'sql' };
       return acc;
     }, {});
   }
@@ -153,8 +195,7 @@ function getLabelExpr(col, refRow, model, entity) {
   // Expression-based labels: translate CDS expression to SQL with trigger row refs
   if (col.altExpression) {
     const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-    // Cast to NVARCHAR to ensure UNION compatibility — expression results may be numeric/date/etc.
-    return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entity, refRow, model, toSQL, (r, c) => `:${r}.${quote(c)}`, CQN2SQLClass)})`;
+    return `TO_NVARCHAR(${buildExpressionSQL(col.altExpression, entity, refRow, model, toSQL, colRef, CQN2SQLClass)})`;
   }
 
   if (!col.alt || col.alt.length === 0) return `NULL`;
@@ -174,7 +215,7 @@ function getLabelExpr(col, refRow, model, entity) {
       assocBatch.push(entry.path);
     } else {
       flushAssocBatch();
-      parts.push(`TO_NVARCHAR(:${refRow}.${quote(entry.path)})`);
+      parts.push(`TO_NVARCHAR(${colRef(refRow, entry.path)})`);
     }
   }
   flushAssocBatch();
@@ -185,7 +226,6 @@ function getLabelExpr(col, refRow, model, entity) {
 /**
  * Builds SQL expression for objectID based on @changelog annotation. Supports direct field references and expressions.
  * Falls back to entity keys when all fields are NULL.
- * Uses a two-pass approach: first computes selectSQL for each objectID, then assembles the final expression.
  */
 function buildObjectIDExpr(objectIDs, entity, refRow, model) {
   if (!objectIDs || objectIDs.length === 0) return null;
@@ -195,10 +235,10 @@ function buildObjectIDExpr(objectIDs, entity, refRow, model) {
     if (objectID.included) continue;
     if (objectID.expression) {
       const CQN2SQLClass = require('@cap-js/hana').CQN2SQL;
-      objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, toSQL, (r, c) => `:${r}.${quote(c)}`, CQN2SQLClass);
+      objectID.selectSQL = buildExpressionSQL(objectID.expression, entity, refRow, model, toSQL, colRef, CQN2SQLClass);
     } else {
       const where = keys.reduce((acc, k) => {
-        acc[k] = { val: `:${refRow}.${quote(k)}`, literal: 'sql' };
+        acc[k] = { val: colRef(refRow, k), literal: 'sql' };
         return acc;
       }, {});
       const query = SELECT.one.from(entity.name).columns(objectID.name).where(where);
@@ -206,18 +246,18 @@ function buildObjectIDExpr(objectIDs, entity, refRow, model) {
     }
   }
 
-  const entityKey = entityKeyExpr(keys.map((k) => `:${refRow}.${quote(k)}`));
+  const entityKey = entityKeyExpr(keys.map((k) => colRef(refRow, k)));
 
   // Single objectID field: simple COALESCE, no concat needed
   if (objectIDs.length === 1) {
     const id = objectIDs[0];
-    const valueExpr = id.included ? `TO_NVARCHAR(:${refRow}.${quote(id.name)})` : `TO_NVARCHAR((${id.selectSQL}))`;
+    const valueExpr = id.included ? `TO_NVARCHAR(${colRef(refRow, id.name)})` : `TO_NVARCHAR((${id.selectSQL}))`;
     return `COALESCE(${valueExpr}, ${entityKey})`;
   }
 
   // Multiple objectID fields: HANA-specific concat idiom; same outer fallback shape
-  const parts = objectIDs.map((id) => (id.included ? `COALESCE(TO_NVARCHAR(:${refRow}.${quote(id.name)}), '<empty>')` : `TO_NVARCHAR((${id.selectSQL}))`));
-  const nullChecks = objectIDs.map((id) => (id.included ? `:${refRow}.${quote(id.name)} IS NULL` : `(${id.selectSQL}) IS NULL`));
+  const parts = objectIDs.map((id) => (id.included ? `COALESCE(TO_NVARCHAR(${colRef(refRow, id.name)}), '<empty>')` : `TO_NVARCHAR((${id.selectSQL}))`));
+  const nullChecks = objectIDs.map((id) => (id.included ? `${colRef(refRow, id.name)} IS NULL` : `(${id.selectSQL}) IS NULL`));
   const allNullCondition = nullChecks.join(' AND ');
   const concatExpr = parts.map((p) => `CASE WHEN ${p} IS NOT NULL THEN ', ' || ${p} ELSE '' END`).join(' || ');
   return `(CASE WHEN ${allNullCondition} THEN ${entityKey} ELSE COALESCE(NULLIF(LTRIM(${concatExpr}, ', '), ''), ${entityKey}) END)`;
@@ -228,13 +268,13 @@ function buildObjectIDExpr(objectIDs, entity, refRow, model) {
  *
  * @param {object} entity - The CDS entity definition
  * @param {Array} objectIDs - @changelog objectIDs of the entity
- * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {string} refRow - Transition-table alias (e.g. 'nr' or 'o')
  * @param {object} model - The CDS model (CSN)
  * @returns {{ entityKey: string, objectID: string }}
  */
 function buildTriggerContext(entity, objectIDs, refRow, model) {
   const keys = utils.extractKeys(entity.keys);
-  const entityKey = entityKeyExpr(keys.map((k) => `:${refRow}.${quote(k)}`));
+  const entityKey = entityKeyExpr(keys.map((k) => colRef(refRow, k)));
   const objectID = buildObjectIDExpr(objectIDs, entity, refRow, model) ?? entityKey;
 
   return { entityKey, objectID };
@@ -243,6 +283,7 @@ function buildTriggerContext(entity, objectIDs, refRow, model) {
 module.exports = {
   toSQL,
   quote,
+  colRef,
   getSkipCheckCondition,
   getElementSkipCondition,
   entityKeyExpr,

--- a/lib/hana/sql-expressions.js
+++ b/lib/hana/sql-expressions.js
@@ -55,10 +55,15 @@ function quote(name) {
 /**
  * Returns the SQL fragment for referencing a column on a transition row.
  *
- * `refRow` is the alias of the transition table (e.g. 'nr' for `:new_rows nr`,
- * 'o' for `:old_rows o`). Yields `<alias>.<col>`.
+ * Accepts two forms of `refRow` so that both trigger-generation strategies can
+ * share the helpers in this file:
+ *  - 'new' / 'old' for row-level scalar reference (e.g. `:new.col`)
+ *  - any other string  for transition-table alias (e.g. `nr.col`, `o.col`)
  */
 function colRef(refRow, col) {
+  if (refRow === 'new' || refRow === 'old') {
+    return `:${refRow}.${quote(col)}`;
+  }
   return `${refRow}.${quote(col)}`;
 }
 
@@ -128,9 +133,10 @@ function nullSafeChanged(column, isLob, newRef, oldRef) {
  *
  * @param {object} col
  * @param {'create'|'update'|'delete'} modification
- * @param {{ newRef: string, oldRef: string }} refs - Transition-table aliases
+ * @param {{ newRef: string, oldRef: string }} [refs] - Row-refs. Defaults to
+ *   `{ newRef: 'new', oldRef: 'old' }` for the row-level path.
  */
-function getWhereCondition(col, modification, refs) {
+function getWhereCondition(col, modification, refs = { newRef: 'new', oldRef: 'old' }) {
   const isLob = col.type === 'cds.LargeString';
   const { newRef, oldRef } = refs;
 

--- a/lib/hana/triggers-row.js
+++ b/lib/hana/triggers-row.js
@@ -1,0 +1,238 @@
+/**
+ * Row-level HANA trigger generation (LEGACY / FALLBACK)
+ *
+ * Emits triggers using `REFERENCING NEW ROW new / OLD ROW old` form
+ * with implicit FOR EACH ROW semantics.
+ * Used when `cds.requires['change-tracking'].rowLevelTriggers === true`
+ */
+const cds = require('@sap/cds');
+const utils = require('../utils/change-tracking.js');
+const config = cds.env.requires['change-tracking'];
+const { getCompositionHierarchy, parseCompositionFieldChangelog } = require('../utils/composition-helpers.js');
+const { getSkipCheckCondition, getElementSkipCondition, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr, buildTriggerContext, quote } = require('./sql-expressions.js');
+const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody } = require('./composition-row.js');
+
+/**
+ * Builds an objectID SQL expression from a parsed composition-field @changelog annotation.
+ * Returns `null` when the annotation cannot be parsed.
+ *
+ * @param {Array} compositionFieldChangelog - Normalized @changelog entries on the composition field
+ * @param {object} parentEntity - The parent entity definition
+ * @param {Array} parentKeyBinding - FK fields on the child pointing to the parent
+ * @param {string} refRow - Trigger row reference ('new' or 'old')
+ * @param {object} model - CSN model
+ * @returns {string|null}
+ */
+function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, model) {
+  const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, `:${refRow}`, quote);
+  if (!parsed) return null;
+
+  if (parsed.type === 'expression') {
+    const query = SELECT.one.from(parentEntity.name).columns(parsed.exprColumn).where(parsed.where);
+    const { toSQL } = require('./sql-expressions.js');
+    return `TO_NVARCHAR((${toSQL(query, model)}))`;
+  }
+
+  const { buildCompOfManyRootObjectIDSelect } = require('./composition-row.js');
+  return buildCompOfManyRootObjectIDSelect(parentEntity, parsed.objectIDs, parentKeyBinding, refRow, model);
+}
+
+function buildInsertSQL(entity, columns, modification, ctx, model) {
+  // Generate single UNION ALL query for all changed columns
+  const unionQuery = columns
+    .map((col) => {
+      const whereCondition = getWhereCondition(col, modification);
+      const elementSkipCondition = getElementSkipCondition(entity.name, col.name);
+      let fullWhere = `(${whereCondition}) AND ${elementSkipCondition}`;
+
+      // For composition-of-one columns, add deduplication check to prevent duplicate entries
+      // when child trigger has already created a composition entry for this transaction
+      if (col.type === 'cds.Composition' && ctx.entityKey) {
+        fullWhere += ` AND NOT EXISTS (
+			SELECT 1 FROM SAP_CHANGELOG_CHANGES
+			WHERE entity = '${entity.name}'
+			AND entityKey = ${ctx.entityKey}
+			AND attribute = '${col.name}'
+			AND valueDataType = 'cds.Composition'
+			AND transactionID = CURRENT_UPDATE_TRANSACTION()
+		)`;
+      }
+
+      const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
+      const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
+      const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity);
+      const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity);
+
+      const dataType = col.altExpression ? 'cds.String' : col.type;
+
+      return `SELECT '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${dataType}' AS valueDataType FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY WHERE ${fullWhere}`;
+    })
+    .join('\nUNION ALL\n');
+
+  return `INSERT INTO SAP_CHANGELOG_CHANGES
+		(ID, parent_ID, attribute, valueChangedFrom, valueChangedTo, valueChangedFromLabel, valueChangedToLabel, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
+		SELECT
+			SYSUUID,
+			${ctx.parentLookupExpr ?? 'NULL'},
+			attribute,
+			valueChangedFrom,
+			valueChangedTo,
+			valueChangedFromLabel,
+			valueChangedToLabel,
+			'${entity.name}',
+			${ctx.entityKey},
+			${ctx.objectID},
+			CURRENT_TIMESTAMP,
+			SESSION_CONTEXT('APPLICATIONUSER'),
+			valueDataType,
+			'${modification}',
+			CURRENT_UPDATE_TRANSACTION()
+		FROM (
+			${unionQuery}
+		);`;
+}
+
+function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null) {
+  if (compositionParentContext) {
+    const { declares } = compositionParentContext;
+    return `${declares}
+	IF ${getSkipCheckCondition(entityName)} THEN
+		${buildParentLookupOrCreateSQL(compositionParentContext)}
+		${insertSQL}
+	END IF;`;
+  }
+  return `IF ${getSkipCheckCondition(entityName)} THEN
+		${insertSQL}
+	END IF;`;
+}
+
+/**
+ * Generates a single HANA trigger (CREATE / UPDATE / DELETE) for an entity.
+ * Combines optional cleanup (delete mode), composition parent INSERTs, and
+ * column-change INSERTs into one trigger body.
+ *
+ * @param {object} entity - The CDS entity definition
+ * @param {Array} columns - Tracked column descriptors
+ * @param {Array} objectIDs - @changelog objectIDs of the entity
+ * @param {Array} parentObjectIDs - @changelog objectIDs of the immediate parent entity
+ * @param {object} model - The CDS model (CSN)
+ * @param {'create'|'update'|'delete'} modification - The modification type
+ * @param {object|null} compositionHierarchy - Composition hierarchy from `getCompositionHierarchy`
+ * @returns {{ name: string, sql: string, suffix: string }}
+ */
+function generateTrigger(entity, columns, objectIDs, parentObjectIDs, model, modification, compositionHierarchy) {
+  const refRow = modification === 'delete' ? 'old' : 'new';
+  const ctx = buildTriggerContext(entity, objectIDs, refRow, model);
+
+  // Build context for composition parent entry if this is a tracked composition target
+  const compositionParentContext = compositionHierarchy
+    ? buildCompositionParentContext(compositionHierarchy, parentObjectIDs, refRow, model, buildObjectIDExpr(objectIDs, entity, refRow, model), (changelog, parentEntity, keyBinding) =>
+        buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, refRow, model)
+      )
+    : null;
+
+  if (compositionParentContext) ctx.parentLookupExpr = 'parent_id';
+
+  // Optional cleanup for non-preserve delete
+  const deleteSQL = modification === 'delete' && !config?.preserveDeletes ? `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey = ${ctx.entityKey};` : '';
+
+  // Build trigger body
+  let body;
+  if (columns.length === 0 && compositionParentContext) {
+    // Composition-only case: only insert composition parent entry, no child column inserts
+    body = buildCompositionOnlyBody(entity.name, compositionParentContext, deleteSQL);
+  } else if (compositionParentContext) {
+    // Mixed case: both composition parent entry and child column inserts
+    const insertSQL = buildInsertSQL(entity, columns, modification, ctx, model);
+    const { declares } = compositionParentContext;
+    const prefix = deleteSQL ? `${deleteSQL}\n\t\t` : '';
+    body = `${declares}
+	IF ${getSkipCheckCondition(entity.name)} THEN
+		${prefix}${buildParentLookupOrCreateSQL(compositionParentContext)}
+		${insertSQL}
+	END IF;`;
+  } else {
+    // No composition: standard insert (with optional delete cleanup)
+    const insertSQL = buildInsertSQL(entity, columns, modification, ctx, model);
+    const innerSQL = deleteSQL ? `${deleteSQL}\n\t\t${insertSQL}` : insertSQL;
+    body = wrapInSkipCheck(entity.name, innerSQL);
+  }
+
+  // Build event clause and REFERENCING clause
+  let eventClause, referencing;
+  if (modification === 'create') {
+    eventClause = 'AFTER INSERT';
+    referencing = 'REFERENCING NEW ROW new';
+  } else if (modification === 'update') {
+    const ofColumns = [
+      ...new Set(
+        columns.flatMap((c) => {
+          if (!c.target) return [quote(c.name)];
+          if (c.foreignKeys) return c.foreignKeys.map((k) => quote(`${c.name}_${k.replaceAll(/\./g, '_')}`));
+          if (c.on) return c.on.map((m) => quote(m.foreignKeyField));
+          return [];
+        })
+      )
+    ];
+    const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
+    eventClause = `AFTER UPDATE ${ofClause}`;
+    referencing = 'REFERENCING NEW ROW new, OLD ROW old';
+  } else {
+    eventClause = 'AFTER DELETE';
+    referencing = 'REFERENCING OLD ROW old';
+  }
+
+  const upper = modification.toUpperCase();
+  return {
+    name: `${entity.name}_CT_${upper}`,
+    sql: `TRIGGER ${utils.transformName(entity.name)}_CT_${upper} ${eventClause}
+ON ${utils.transformName(entity.name)}
+${referencing}
+BEGIN
+	${body}
+END;`,
+    suffix: '.hdbtrigger'
+  };
+}
+
+/**
+ * Generates HANA hdbtrigger artifacts for an entity (CREATE / UPDATE / DELETE).
+ * Returns an empty array when the entity is neither tracked nor a tracked composition target.
+ *
+ * @param {object} csn - The CDS model (CSN)
+ * @param {object} entity
+ * @param {object|null} [parentEntity]
+ * @param {object} [mergedAnnotations]
+ * @param {object} [parentMergedAnnotations]
+ * @param {object} [grandParentContext]
+ * @returns {Array<{ name: string, sql: string, suffix: string }>}
+ */
+function generateHANATriggers(csn, entity, parentEntity = null, mergedAnnotations = null, parentMergedAnnotations = null, grandParentContext = {}) {
+  const triggers = [];
+  const { columns: trackedColumns } = utils.extractTrackedColumns(entity, csn, mergedAnnotations);
+  const objectIDs = utils.getObjectIDs(entity, csn, mergedAnnotations?.entityAnnotation);
+  const parentObjectIDs = utils.getObjectIDs(parentEntity, csn, parentMergedAnnotations?.entityAnnotation);
+
+  const keys = utils.extractKeys(entity.keys);
+  if (keys.length === 0 && trackedColumns.length > 0) return triggers;
+
+  // Resolve composition hierarchy (immediate parent + ancestors)
+  const { ancestorChain } = grandParentContext;
+  const compositionHierarchy = getCompositionHierarchy(entity, parentEntity, parentMergedAnnotations, ancestorChain ?? [], csn);
+
+  // Skip if no tracked columns and not a composition target with tracked composition
+  if (trackedColumns.length === 0 && !compositionHierarchy) return triggers;
+
+  const modifications = [];
+  if (!config?.disableCreateTracking) modifications.push('create');
+  if (!config?.disableUpdateTracking) modifications.push('update');
+  if (!config?.disableDeleteTracking) modifications.push('delete');
+
+  for (const modification of modifications) {
+    triggers.push(generateTrigger(entity, trackedColumns, objectIDs, parentObjectIDs, csn, modification, compositionHierarchy));
+  }
+
+  return triggers;
+}
+
+module.exports = { generateHANATriggers };

--- a/lib/hana/triggers.js
+++ b/lib/hana/triggers.js
@@ -2,27 +2,24 @@ const cds = require('@sap/cds');
 const utils = require('../utils/change-tracking.js');
 const config = cds.env.requires['change-tracking'];
 const { getCompositionHierarchy, parseCompositionFieldChangelog } = require('../utils/composition-helpers.js');
-const { getSkipCheckCondition, getElementSkipCondition, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr, buildTriggerContext, quote } = require('./sql-expressions.js');
-const { buildCompositionParentContext, buildParentLookupOrCreateSQL, buildCompositionOnlyBody } = require('./composition.js');
+const { getSkipCheckCondition, getElementSkipCondition, getValueExpr, getWhereCondition, getLabelExpr, buildObjectIDExpr, buildTriggerContext, quote, toSQL } = require('./sql-expressions.js');
+const { buildCompositionParentContext } = require('./composition.js');
+
+// HANA transition-table aliases used inside the trigger body.
+// 'nr' / 'o' are non-reserved HANA identifiers and bind to :new_rows / :old_rows.
+const NEW = 'nr';
+const OLD = 'o';
 
 /**
  * Builds an objectID SQL expression from a parsed composition-field @changelog annotation.
  * Returns `null` when the annotation cannot be parsed.
- *
- * @param {Array} compositionFieldChangelog - Normalized @changelog entries on the composition field
- * @param {object} parentEntity - The parent entity definition
- * @param {Array} parentKeyBinding - FK fields on the child pointing to the parent
- * @param {string} refRow - Trigger row reference ('new' or 'old')
- * @param {object} model - CSN model
- * @returns {string|null}
  */
 function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, model) {
-  const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, `:${refRow}`, quote);
+  const parsed = parseCompositionFieldChangelog(compositionFieldChangelog, parentEntity, parentKeyBinding, refRow, quote);
   if (!parsed) return null;
 
   if (parsed.type === 'expression') {
     const query = SELECT.one.from(parentEntity.name).columns(parsed.exprColumn).where(parsed.where);
-    const { toSQL } = require('./sql-expressions.js');
     return `TO_NVARCHAR((${toSQL(query, model)}))`;
   }
 
@@ -30,18 +27,45 @@ function buildCompositionFieldObjectID(compositionFieldChangelog, parentEntity, 
   return buildCompOfManyRootObjectIDSelect(parentEntity, parsed.objectIDs, parentKeyBinding, refRow, model);
 }
 
-function buildInsertSQL(entity, columns, modification, ctx, model) {
-  // Generate single UNION ALL query for all changed columns
-  const unionQuery = columns
-    .map((col) => {
-      const whereCondition = getWhereCondition(col, modification);
-      const elementSkipCondition = getElementSkipCondition(entity.name, col.name);
-      let fullWhere = `(${whereCondition}) AND ${elementSkipCondition}`;
+/**
+ * Statement-level INSERT body — emits one `INSERT … SELECT` per tracked column,
+ * reading directly from the transition tables (`:new_rows nr` / `:old_rows o`).
+ *
+ * For UPDATE, NEW and OLD must be joined on the primary key because transition
+ * tables are unordered sets; pre/post pairs for the same logical row must be
+ * matched explicitly.
+ */
+function buildStmtInsertSQL(entity, columns, modification, ctx, model) {
+  const keys = utils.extractKeys(entity.keys);
 
-      // For composition-of-one columns, add deduplication check to prevent duplicate entries
-      // when child trigger has already created a composition entry for this transaction
-      if (col.type === 'cds.Composition' && ctx.entityKey) {
-        fullWhere += ` AND NOT EXISTS (
+  let fromClause;
+  let refs;
+  if (modification === 'create') {
+    fromClause = `FROM :new_rows ${NEW}`;
+    refs = { newRef: NEW, oldRef: NEW };
+  } else if (modification === 'delete') {
+    fromClause = `FROM :old_rows ${OLD}`;
+    refs = { newRef: OLD, oldRef: OLD };
+  } else {
+    // UPDATE: join on PK
+    const joinCond = keys.map((k) => `${NEW}.${quote(k)} = ${OLD}.${quote(k)}`).join(' AND ');
+    fromClause = `FROM :new_rows ${NEW} JOIN :old_rows ${OLD} ON ${joinCond}`;
+    refs = { newRef: NEW, oldRef: OLD };
+  }
+
+  const inserts = columns.map((col) => {
+    const whereCondition = getWhereCondition(col, modification, refs);
+    const elementSkipCondition = getElementSkipCondition(entity.name, col.name);
+    let fullWhere = `(${whereCondition}) AND ${elementSkipCondition}`;
+
+    // For composition-of-one columns, dedupe against any composition entry the child's
+    // delete/create trigger may have already inserted for this transaction. Without this,
+    // a deep delete (UPDATE parent SET comp=null) yields both:
+    //   (a) parent's own UPDATE-trigger composition entry, and
+    //   (b) the child DELETE-trigger's composition parent entry,
+    // because the BookStores row still has the FK at the moment the child's DELETE fires.
+    if (col.type === 'cds.Composition') {
+      fullWhere += ` AND NOT EXISTS (
 			SELECT 1 FROM SAP_CHANGELOG_CHANGES
 			WHERE entity = '${entity.name}'
 			AND entityKey = ${ctx.entityKey}
@@ -49,60 +73,43 @@ function buildInsertSQL(entity, columns, modification, ctx, model) {
 			AND valueDataType = 'cds.Composition'
 			AND transactionID = CURRENT_UPDATE_TRANSACTION()
 		)`;
-      }
+    }
 
-      const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, 'old');
-      const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, 'new');
-      const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, 'old', model, entity);
-      const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, 'new', model, entity);
+    const oldVal = modification === 'create' ? 'NULL' : getValueExpr(col, refs.oldRef);
+    const newVal = modification === 'delete' ? 'NULL' : getValueExpr(col, refs.newRef);
+    const oldLabel = modification === 'create' ? 'NULL' : getLabelExpr(col, refs.oldRef, model, entity);
+    const newLabel = modification === 'delete' ? 'NULL' : getLabelExpr(col, refs.newRef, model, entity);
 
-      const dataType = col.altExpression ? 'cds.String' : col.type;
+    const dataType = col.altExpression ? 'cds.String' : col.type;
+    const parentIdExpr = ctx.parentIdLookupExpr ?? 'NULL';
 
-      return `SELECT '${col.name}' AS attribute, ${oldVal} AS valueChangedFrom, ${newVal} AS valueChangedTo, ${oldLabel} AS valueChangedFromLabel, ${newLabel} AS valueChangedToLabel, '${dataType}' AS valueDataType FROM SAP_CHANGELOG_CHANGE_TRACKING_DUMMY WHERE ${fullWhere}`;
-    })
-    .join('\nUNION ALL\n');
-
-  return `INSERT INTO SAP_CHANGELOG_CHANGES
+    return `INSERT INTO SAP_CHANGELOG_CHANGES
 		(ID, parent_ID, attribute, valueChangedFrom, valueChangedTo, valueChangedFromLabel, valueChangedToLabel, entity, entityKey, objectID, createdAt, createdBy, valueDataType, modification, transactionID)
 		SELECT
 			SYSUUID,
-			${ctx.parentLookupExpr ?? 'NULL'},
-			attribute,
-			valueChangedFrom,
-			valueChangedTo,
-			valueChangedFromLabel,
-			valueChangedToLabel,
+			${parentIdExpr},
+			'${col.name}',
+			${oldVal},
+			${newVal},
+			${oldLabel},
+			${newLabel},
 			'${entity.name}',
 			${ctx.entityKey},
 			${ctx.objectID},
 			CURRENT_TIMESTAMP,
 			SESSION_CONTEXT('APPLICATIONUSER'),
-			valueDataType,
+			'${dataType}',
 			'${modification}',
 			CURRENT_UPDATE_TRANSACTION()
-		FROM (
-			${unionQuery}
-		);`;
-}
+		${fromClause}
+		WHERE ${fullWhere};`;
+  });
 
-function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null) {
-  if (compositionParentContext) {
-    const { declares } = compositionParentContext;
-    return `${declares}
-	IF ${getSkipCheckCondition(entityName)} THEN
-		${buildParentLookupOrCreateSQL(compositionParentContext)}
-		${insertSQL}
-	END IF;`;
-  }
-  return `IF ${getSkipCheckCondition(entityName)} THEN
-		${insertSQL}
-	END IF;`;
+  return inserts.join('\n\t');
 }
 
 /**
  * Generates a single HANA trigger (CREATE / UPDATE / DELETE) for an entity.
- * Combines optional cleanup (delete mode), composition parent INSERTs, and
- * column-change INSERTs into one trigger body.
  *
  * @param {object} entity - The CDS entity definition
  * @param {Array} columns - Tracked column descriptors
@@ -114,48 +121,42 @@ function wrapInSkipCheck(entityName, insertSQL, compositionParentContext = null)
  * @returns {{ name: string, sql: string, suffix: string }}
  */
 function generateTrigger(entity, columns, objectIDs, parentObjectIDs, model, modification, compositionHierarchy) {
-  const refRow = modification === 'delete' ? 'old' : 'new';
+  // Use OLD on delete (only :old_rows is populated); NEW otherwise.
+  const refRow = modification === 'delete' ? OLD : NEW;
+
   const ctx = buildTriggerContext(entity, objectIDs, refRow, model);
 
-  // Build context for composition parent entry if this is a tracked composition target
+  // Build composition parent context (set-based parent INSERTs + parent_ID lookup expression).
   const compositionParentContext = compositionHierarchy
     ? buildCompositionParentContext(compositionHierarchy, parentObjectIDs, refRow, model, buildObjectIDExpr(objectIDs, entity, refRow, model), (changelog, parentEntity, keyBinding) =>
         buildCompositionFieldObjectID(changelog, parentEntity, keyBinding, refRow, model)
       )
     : null;
 
-  if (compositionParentContext) ctx.parentLookupExpr = 'parent_id';
-
-  // Optional cleanup for non-preserve delete
-  const deleteSQL = modification === 'delete' && !config?.preserveDeletes ? `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey = ${ctx.entityKey};` : '';
-
-  // Build trigger body
-  let body;
-  if (columns.length === 0 && compositionParentContext) {
-    // Composition-only case: only insert composition parent entry, no child column inserts
-    body = buildCompositionOnlyBody(entity.name, compositionParentContext, deleteSQL);
-  } else if (compositionParentContext) {
-    // Mixed case: both composition parent entry and child column inserts
-    const insertSQL = buildInsertSQL(entity, columns, modification, ctx, model);
-    const { declares } = compositionParentContext;
-    const prefix = deleteSQL ? `${deleteSQL}\n\t\t` : '';
-    body = `${declares}
-	IF ${getSkipCheckCondition(entity.name)} THEN
-		${prefix}${buildParentLookupOrCreateSQL(compositionParentContext)}
-		${insertSQL}
-	END IF;`;
-  } else {
-    // No composition: standard insert (with optional delete cleanup)
-    const insertSQL = buildInsertSQL(entity, columns, modification, ctx, model);
-    const innerSQL = deleteSQL ? `${deleteSQL}\n\t\t${insertSQL}` : insertSQL;
-    body = wrapInSkipCheck(entity.name, innerSQL);
+  if (compositionParentContext) {
+    ctx.parentIdLookupExpr = compositionParentContext.parentIdLookupExpr;
   }
 
-  // Build event clause and REFERENCING clause
-  let eventClause, referencing;
+  // Set-based delete cleanup for non-preserve delete.
+  const deleteSQL = modification === 'delete' && !config?.preserveDeletes ? `DELETE FROM SAP_CHANGELOG_CHANGES WHERE entity = '${entity.name}' AND entityKey IN (SELECT ${ctx.entityKey} FROM :old_rows ${OLD});` : '';
+
+  const insertSQL = columns.length > 0 ? buildStmtInsertSQL(entity, columns, modification, ctx, model) : '';
+  const parentInsertsSQL = compositionParentContext?.parentInsertsSQL ?? '';
+
+  // Body order: optional delete cleanup, parent (composition) inserts, child column inserts.
+  const innerSQL = [deleteSQL, parentInsertsSQL, insertSQL].filter(Boolean).join('\n\t\t');
+
+  const body = `IF ${getSkipCheckCondition(entity.name)} THEN
+		${innerSQL}
+	END IF;`;
+
+  // Build event clause and REFERENCING clause.
+  // NOTE: HANA requires a comma between transition-table specifications.
+  let eventClause;
+  let referencing;
   if (modification === 'create') {
     eventClause = 'AFTER INSERT';
-    referencing = 'REFERENCING NEW ROW new';
+    referencing = 'REFERENCING NEW TABLE new_rows';
   } else if (modification === 'update') {
     const ofColumns = [
       ...new Set(
@@ -169,11 +170,12 @@ function generateTrigger(entity, columns, objectIDs, parentObjectIDs, model, mod
     ];
     const ofClause = columns.length > 0 ? `OF ${ofColumns.join(', ')} ` : '';
     eventClause = `AFTER UPDATE ${ofClause}`;
-    referencing = 'REFERENCING NEW ROW new, OLD ROW old';
+    referencing = 'REFERENCING NEW TABLE new_rows, OLD TABLE old_rows';
   } else {
     eventClause = 'AFTER DELETE';
-    referencing = 'REFERENCING OLD ROW old';
+    referencing = 'REFERENCING OLD TABLE old_rows';
   }
+  referencing = `${referencing}\nFOR EACH STATEMENT`;
 
   const upper = modification.toUpperCase();
   return {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "testTimeout": 200000
   },
   "workspaces": [
-    "tests/*"
+    "tests/*",
+    "tests/performance/"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "publishConfig": {
     "access": "public",
     "tag": "beta"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test:sqlite": "CDS_ENV=sqlite npx jest --silent",
     "test:pg": "npm run start:pg && CDS_ENV=pg npx jest --silent",
     "test:hana": "cds bind --exec -- npx jest --silent",
+    "deploy:hana": "cd tests/bookshop && cds deploy -2 hana && cd ../../",
+    "deploy:hana:rowlevel": "cd tests/bookshop && CDS_ENV=rowlevel cds deploy -2 hana && cd ../../",
     "start:pg": "cd tests/bookshop/ && docker compose -f pg-stack.yml up -d && npm run deploy:pg && cd ../..",
     "deploy:pg": "CDS_ENV=pg cds build --production && cds deploy --profile pg",
     "test:all": "npm run test:sqlite && npm run test:pg && npm run test:hana",
@@ -46,7 +48,8 @@
         "model": "@cap-js/change-tracking",
         "maxDisplayHierarchyDepth": 3,
         "preserveDeletes": false,
-        "procedureForRestoringBacklinks": true
+        "procedureForRestoringBacklinks": true,
+        "rowLevelTriggers": false
       }
     }
   },

--- a/tests/bookshop/.cdsrc.yaml
+++ b/tests/bookshop/.cdsrc.yaml
@@ -19,3 +19,6 @@ requires:
         destroyTimeoutMillis: 1000
     "[hana]":
       kind: hana
+  change-tracking:
+    "[rowlevel]":
+      rowLevelTriggers: true


### PR DESCRIPTION
# Migrate HANA Triggers to Statement-Level Execution by Default

### Refactor

♻️ Refactored HANA change-tracking triggers to use **statement-level** execution (`REFERENCING NEW TABLE … FOR EACH STATEMENT`) instead of row-level triggers. Statement-level triggers fire once per SQL statement and process all affected rows as a set-based operation, significantly improving performance for bulk DML operations. A `rowLevelTriggers` configuration flag is added as an opt-in fallback for the legacy row-level behavior.

### Changes

* `lib/hana/triggers.js`: Rewritten to emit statement-level triggers using `REFERENCING NEW TABLE new_rows / OLD TABLE old_rows` with `FOR EACH STATEMENT`. The old `buildInsertSQL` function is replaced by `buildStmtInsertSQL`, which reads directly from transition tables (`:new_rows nr` / `:old_rows o`), joining them on PK for UPDATE. Procedural `DECLARE`/`IF` blocks are removed in favor of pure `INSERT … SELECT` statements.

* `lib/hana/triggers-row.js`: New file containing the **legacy row-level** trigger generation logic (previously in `triggers.js`). Used when `rowLevelTriggers: true` is configured.

* `lib/hana/composition.js`: Refactored composition parent context builders for statement-level triggers. Switched from procedural `SELECT INTO … IF NULL THEN INSERT VALUES` to set-based `INSERT … SELECT … NOT EXISTS` patterns. Removed `buildParentLookupOrCreateSQL`, `buildCompositionOnlyBody`, and `buildParentLookupSQL` (moved to `composition-row.js`). Added `buildParentIdLookupExpr` for correlated parent ID lookups.

* `lib/hana/composition-row.js`: New file containing the **row-level** composition trigger helpers extracted from the original `composition.js`, including procedural parent lookup/create logic.

* `lib/hana/sql-expressions.js`: Added `colRef(refRow, col)` helper to unify column reference syntax for both row-level (`:new.col`) and statement-level (`nr.col`) contexts. Updated `nullSafeChanged`, `getWhereCondition`, `getValueExpr`, `getLabelExpr`, `buildObjectIDExpr`, and `buildTriggerContext` to accept configurable `newRef`/`oldRef` parameters. Added `_stripLimit` to remove `LIMIT 1`/`SELECT.one` from subqueries (HANA disallows `TOP`/`ORDER BY` in correlated subqueries inside statement-level triggers).

* `lib/hana/register.js`: Dynamically selects trigger generator based on the `rowLevelTriggers` config flag — loads `triggers-row.js` for row-level, `triggers.js` (statement-level) by default. Also adds an early guard to skip hook processing when the plugin's base model is not in the CSN.

* `package.json`: Bumped version to `2.0.0-beta.13`, added `rowLevelTriggers: false` default config, added workspace entry for `tests/performance/`, and added `deploy:hana` / `deploy:hana:rowlevel` convenience scripts.

* `tests/bookshop/.cdsrc.yaml`: Added `[rowlevel]` CDS environment profile setting `rowLevelTriggers: true` for testing/deploying with the legacy trigger style.

* `README.md`: Added documentation section explaining statement-level vs. row-level triggers and the `rowLevelTriggers` opt-in flag.

* `CHANGELOG.md`: Updated for version `2.0.0-beta.13` with changelog entries for the trigger change and the new `rowLevelTriggers` configuration flag.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.4`

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `3a3a8aed-9287-484b-993a-85f08997383a`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
