### PR TITLE
test: handle @changelog annotation mismatch when service projections rename associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.1 - 2026-06-19
+
+### Fixed
+- Resolve false "Conflicting @changelog annotations" error when a service projection flattens association and inherits plain `true` instead of a specific `@changelog` annotation value (e.g., `[author.name]`) due to CDS annotation propagation
+
 ## Version 2.0.0 - 2026-06-12
 
 ### Added

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -176,9 +176,17 @@ function _mergeChangelogAnnotations(dbEntity, serviceEntities) {
     // Merge entity-level @changelog (ObjectID definition)
     if (entityAnnotation !== undefined) {
       if (mergedEntityAnnotation !== undefined && !_annotationsEqual(mergedEntityAnnotation, entityAnnotation)) {
-        throw new Error(
-          `Conflicting @changelog annotations on entity '${dbEntity.name}': ` + `'${mergedEntityAnnotationSource}' has ${JSON.stringify(mergedEntityAnnotation)} but ` + `'${srvEntity.name}' has ${JSON.stringify(entityAnnotation)}`
-        );
+        // Keep the more specific annotation (not a real conflict) when service projection is just 'true' (generic from CDS propagation)
+        if (entityAnnotation === true) {
+          // existing is more specific, keep it
+        } else if (mergedEntityAnnotation === true) {
+          mergedEntityAnnotation = entityAnnotation;
+          mergedEntityAnnotationSource = srvEntity.name;
+        } else {
+          throw new Error(
+            `Conflicting @changelog annotations on entity '${dbEntity.name}': ` + `'${mergedEntityAnnotationSource}' has ${JSON.stringify(mergedEntityAnnotation)} but ` + `'${srvEntity.name}' has ${JSON.stringify(entityAnnotation)}`
+          );
+        }
       }
       if (mergedEntityAnnotation === undefined) {
         mergedEntityAnnotation = entityAnnotation;
@@ -193,9 +201,22 @@ function _mergeChangelogAnnotations(dbEntity, serviceEntities) {
 
       const existing = mergedElementAnnotations.get(dbElemName);
       if (existing && !_annotationsEqual(existing.annotation, annotation)) {
-        throw new Error(
-          `Conflicting @changelog annotations on element '${dbElemName}' of entity '${dbEntity.name}': ` + `'${existing.sourceName}' has ${JSON.stringify(existing.annotation)} but ` + `'${srvEntity.name}' has ${JSON.stringify(annotation)}`
-        );
+        // When one side is just 'true' (generic marker from CDS propagation) and the other is a
+        // specific annotation value (array/object), keep the more specific one - not a real conflict.
+        if (annotation === true) {
+          // existing is more specific, keep it
+        } else if (existing.annotation === true) {
+          mergedElementAnnotations.set(dbElemName, {
+            annotation,
+            sourceName: srvEntity.name
+          });
+        } else {
+          throw new Error(
+            `Conflicting @changelog annotations on element '${dbElemName}' of entity '${dbEntity.name}': ` +
+              `'${existing.sourceName}' has ${JSON.stringify(existing.annotation)} but ` +
+              `'${srvEntity.name}' has ${JSON.stringify(annotation)}`
+          );
+        }
       }
       if (!existing) {
         mergedElementAnnotations.set(dbElemName, {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format:check": "npx -y prettier@3 --check ."
   },
   "peerDependencies": {
-    "@sap/cds": "^9.9.1"
+    "@sap/cds": ">=8.5"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",
@@ -29,7 +29,7 @@
     "format:check": "npx -y prettier@3 --check ."
   },
   "peerDependencies": {
-    "@sap/cds": ">=8.5"
+    "@sap/cds": "^9.9.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/tests/bookshop/db/change-logs.cds
+++ b/tests/bookshop/db/change-logs.cds
@@ -101,6 +101,7 @@ annotate bookshop.Books with {
     authorWithAssocObjectID.dateOfBirth,
     authorWithAssocObjectID.name.lastName
   ];
+  author @changelog: [author.name.firstName, author.name.lastName];
 }
 
 annotate bookshop.OrderItem with {

--- a/tests/bookshop/srv/cat-service.cds
+++ b/tests/bookshop/srv/cat-service.cds
@@ -2,11 +2,11 @@ using { sap.capire.bookshop as my } from '../db/schema';
 service CatalogService @(path:'/browse') {
 
   /** For displaying lists of Books */
-  @readonly entity ListOfBooks as projection on Books
+  @readonly entity ListOfBooks as projection on my.Books
   excluding { descr };
 
   /** For display in details pages */
-  @readonly entity Books as projection on my.Books { *,
+  @readonly @cds.redirection.target entity Books as projection on my.Books { *,
     @changelog: false
     author.name as author
   } excluding { createdBy, modifiedBy };

--- a/tests/bookshop/srv/cat-service.cds
+++ b/tests/bookshop/srv/cat-service.cds
@@ -2,12 +2,11 @@ using { sap.capire.bookshop as my } from '../db/schema';
 service CatalogService @(path:'/browse') {
 
   /** For displaying lists of Books */
-  @readonly entity ListOfBooks as projection on my.Books
+  @readonly entity ListOfBooks as projection on Books
   excluding { descr };
 
   /** For display in details pages */
-  @readonly @cds.redirection.target entity Books as projection on my.Books { *,
-    @changelog: false
+  @readonly entity Books as projection on my.Books { *,
     author.name as author
   } excluding { createdBy, modifiedBy };
 

--- a/tests/integration/annotation-interpretation.test.js
+++ b/tests/integration/annotation-interpretation.test.js
@@ -606,7 +606,7 @@ describe('@changelog annotation interpretation', () => {
     });
   });
 
-  describe('service projections with element renames', () => {
+  describe('different annotations in service projections', () => {
     it('does not conflict when a service renames an element but @changelog annotations are inherited unchanged', async () => {
       const {
         data: { ID: incidentID }
@@ -654,6 +654,52 @@ describe('@changelog annotation interpretation', () => {
       const statusChange = changes.find((c) => c.attribute === 'status' && c.modification === 'update');
       expect(statusChange).toBeDefined();
       expect(statusChange.objectID).toEqual('Stormy Weathers: Munich - Entity-level expression test');
+    });
+
+    it('does not conflict when a service projection inherits a specific @changelog as true', async () => {
+      // CatalogService.ListOfBooks is a simple projection on my.Books.
+      // The DB entity Books has author @changelog: [author.name.firstName, author.name.lastName] (specific).
+      // CDS propagation may simplify this to just 'true' on the projected element.
+      // AdminService.Books also has author @changelog: [author.name.firstName, author.name.lastName] (specific).
+      // The merge must not throw a conflict error when encountering 'true' vs the specific annotation.
+      const adminService = await cds.connect.to('AdminService');
+      const { ChangeView } = adminService.entities;
+
+      const bookStoreID = cds.utils.uuid();
+      const bookID = cds.utils.uuid();
+      const authorID1 = cds.utils.uuid();
+      const authorID2 = cds.utils.uuid();
+
+      await INSERT.into('sap.capire.bookshop.Authors').entries([
+        { ID: authorID1, name_firstName: 'Jane', name_lastName: 'Austen' },
+        { ID: authorID2, name_firstName: 'Mark', name_lastName: 'Twain' }
+      ]);
+
+      await POST(`/odata/v4/admin/BookStores`, { ID: bookStoreID, name: 'Test BookStore' });
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/AdminService.draftActivate`, {});
+
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=true)/AdminService.draftEdit`, {});
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/books`, {
+        ID: bookID,
+        title: 'Test Book',
+        author_ID: authorID1
+      });
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/AdminService.draftActivate`, {});
+
+      // Update the author association via AdminService (which has specific @changelog on author)
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=true)/AdminService.draftEdit`, {});
+      await PATCH(`/odata/v4/admin/Books(ID=${bookID},IsActiveEntity=false)`, { author_ID: authorID2 });
+      await POST(`/odata/v4/admin/BookStores(ID=${bookStoreID},IsActiveEntity=false)/AdminService.draftActivate`, {});
+
+      const changes = await SELECT.from(ChangeView).where({
+        attribute: 'author',
+        entityKey: bookID,
+        modification: 'update'
+      });
+
+      expect(changes.length).toBeGreaterThan(0);
+      // The specific annotation [author.name.firstName, author.name.lastName] should be used for display
+      expect(changes[0].valueChangedTo).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
When a service projection replaces an association with a scalar (e.g. `author.name as author`), the CDS compiler flattens inherited @changelog annotations from a specific value like `[author.name.firstName, author.name.lastName]` to just `true`. If another service projection retains the original association with its specific `@changelog`, the annotation merge must keep the more specific value instead of throwing a conflict error.