### PR TITLE
fix: composition link when db level views are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 2.0.2 - tbd
+## Version 2.0.2 - 2026-07-13
 
 ### Fixed
 - Fix `<expr>.cds` compilation error during `cds deploy --to hana` when expression-based `@changelog` annotations (CXL) are used as objectIDs on entities with compositions
 - Prevent `@PersonalData` field values from leaking into `objectID` or `valueChangedToLabel` columns when `@changelog` annotations reference such fields via path expressions or CXL
+- Fix missing `cds.Composition` parent entry and broken `parent_ID` links in generated triggers when a DB-level `select *` view of a parent entity inherits the same composition
 
 
 ## Version 2.0.1 - 2026-06-19

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -407,7 +407,8 @@ function analyzeCompositions(csn) {
           if (!existing || (existing.isView && !isView)) {
             childParentMap.set(element.target, {
               parent: name,
-              compositionField: elemName
+              compositionField: elemName,
+              isView
             });
           }
         }

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -396,13 +396,20 @@ function analyzeCompositions(csn) {
   for (const [name, def] of Object.entries(csn.definitions)) {
     if (def.kind !== 'entity') continue;
 
+    // Only base table entities should own a composition in the parent map
+    const isView = !!(def.query || def.projection);
+
     if (def.elements) {
       for (const [elemName, element] of Object.entries(def.elements)) {
         if (element.type === 'cds.Composition' && element.target) {
-          childParentMap.set(element.target, {
-            parent: name,
-            compositionField: elemName
-          });
+          const existing = childParentMap.get(element.target);
+          // Prefer a base table over any view/projection
+          if (!existing || (existing.isView && !isView)) {
+            childParentMap.set(element.target, {
+              parent: name,
+              compositionField: elemName
+            });
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -1,13 +1,13 @@
 using from './change-logs';
 using from './joins-and-unions';
 using from './batch-inserts';
+using {cuid} from '@sap/cds/common';
 
 
 namespace sap.change_tracking;
 
 @title: 'Different field types'
-entity DifferentFieldTypes {
-  key ID        : UUID;
+entity DifferentFieldTypes : cuid {
       title     : String      @changelog;
       largeText : LargeString @changelog;
       dateTime  : DateTime;
@@ -34,8 +34,7 @@ entity DifferentFieldTypes {
       nonExistent : Association to one NonExistentTable @changelog: [nonExistent.name]; // Unsupported - should trigger warning
 }
 
-entity DifferentFieldTypesChildren {
-  key ID     : UUID;
+entity DifferentFieldTypesChildren : cuid {
       parent : Association to one DifferentFieldTypes;
       double : Double;
 }
@@ -74,8 +73,7 @@ entity Level2Sample {
 
 // By intent no @changelog on the entity level
 @title: '{i18n>bookStore.objectTitle}'
-entity TrackingComposition {
-  key ID                   : UUID;
+entity TrackingComposition : cuid {
       name                 : String;
       children             : Composition of many ComposedEntities
                                on children.parent = $self;
@@ -87,13 +85,11 @@ entity TrackingComposition {
                                on childrenExplicitMany.parent = $self;
 }
 
-aspect CompositionAspect {
-  key ID     : UUID;
+aspect CompositionAspect : cuid {
       aspect : String;
 }
 
-entity ExplicitCompositionOne {
-  key ID       : UUID;
+entity ExplicitCompositionOne : cuid {
       parentID : UUID;
       parent   : Association to one TrackingComposition
                    on parent.ID = parentID;
@@ -101,8 +97,7 @@ entity ExplicitCompositionOne {
       price    : Decimal;
 }
 
-entity ExplicitCompositionMany {
-  key ID       : UUID;
+entity ExplicitCompositionMany : cuid {
       parentID : UUID;
       parent   : Association to one TrackingComposition
                    on parent.ID = parentID;
@@ -112,8 +107,7 @@ entity ExplicitCompositionMany {
 
 // By intent no @changelog on the entity level
 @title: '{i18n>books.objectTitle}'
-entity ComposedEntities {
-  key ID     : UUID;
+entity ComposedEntities : cuid {
       parent : Association to one TrackingComposition;
       title  : String;
       price  : Decimal;
@@ -130,8 +124,7 @@ entity CompositeKeyParent {
 }
 
 @changelog: [title]
-entity ObjectIdFallbackParent {
-  key ID   : UUID;
+entity ObjectIdFallbackParent : cuid {
   title    : String @changelog;
   @changelog
   children : Composition of many ObjectIdFallbackChild
@@ -139,8 +132,7 @@ entity ObjectIdFallbackParent {
 }
 
 @changelog: [fieldA, fieldB]
-entity ObjectIdFallbackChild {
-  key ID   : UUID;
+entity ObjectIdFallbackChild : cuid {
   parent   : Association to one ObjectIdFallbackParent;
   fieldA   : String @changelog;
   fieldB   : String @changelog;
@@ -148,8 +140,7 @@ entity ObjectIdFallbackChild {
 }
 
 @cds.persistence.skip
-entity NonExistentTable {
-  key ID : UUID;
+entity NonExistentTable : cuid {
       name : String;
 }
 
@@ -165,15 +156,13 @@ type CustomType : Association to one TrackingComposition;
 //
 // VersionWithAssignments has a composition 'assignments' pointing to VersionAssignment
 // VersionsForLock is a DB-level view that inherits the same composition
-entity VersionWithAssignments {
-  key ID          : UUID;
+entity VersionWithAssignments : cuid {
       title       : String;
       assignments : Composition of many VersionAssignment
                       on assignments.version = $self;
 }
 
-entity VersionAssignment {
-  key ID      : UUID;
+entity VersionAssignment : cuid {
       version : Association to one VersionWithAssignments @changelog: [version.title];
       tag     : String @changelog;
 }
@@ -184,8 +173,7 @@ entity VersionsForLock as select from VersionWithAssignments { * };
 // `salary` is @PersonalData; a leaky @changelog annotation is applied in
 // feature-testing.cds. The Expr variants differ only in how deeply their
 // annotation nests the manager.salary ref.
-entity Employees {
-  key ID             : UUID;
+entity Employees : cuid {
       name           : String;
       officeLocation : String;
       salary         : Decimal @PersonalData.IsPotentiallyPersonal;

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -161,6 +161,26 @@ entity CustomTypeKeyTable {
 
 type CustomType : Association to one TrackingComposition;
 
+// DB-level view (select *) shadowing the composition parent mapping
+//
+// VersionWithAssignments has a composition 'assignments' pointing to VersionAssignment
+// VersionsForLock is a DB-level view that inherits the same composition
+entity VersionWithAssignments {
+  key ID          : UUID;
+      title       : String;
+      assignments : Composition of many VersionAssignment
+                      on assignments.version = $self;
+}
+
+entity VersionAssignment {
+  key ID      : UUID;
+      version : Association to one VersionWithAssignments @changelog: [version.title];
+      tag     : String @changelog;
+}
+
+// DB-level view that inherits the 'assignments' composition from VersionWithAssignments
+entity VersionsForLock as select from VersionWithAssignments { * };
+
 // `salary` is @PersonalData; a leaky @changelog annotation is applied in
 // feature-testing.cds. The Expr variants differ only in how deeply their
 // annotation nests the manager.salary ref.

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -42,6 +42,10 @@ service VariantTesting {
 
   entity EmployeesFuncExpr as projection on my.EmployeesFuncExpr;
 
+  // Test for DB-level view shadowing the composition parent mapping
+  entity VersionWithAssignments as projection on my.VersionWithAssignments;
+  entity VersionAssignment       as projection on my.VersionAssignment;
+
   entity ServiceLevelTimezoneRenamed as projection on my.DifferentFieldTypes {
     ID,
     srvRenamedDateTimeWDTZ as renamedDateTime,
@@ -148,4 +152,18 @@ annotate VariantTesting.EmployeesNestedExpr with @(changelog: [('Manager earns '
 annotate VariantTesting.EmployeesFuncExpr with @(changelog: [('Manager earns ' || coalesce(manager.salary, 0))]) {
   manager @changelog: [('Salary: ' || coalesce(manager.salary, 0))];
   officeLocation @changelog;
+};
+
+// Test: DB-level view shadowing the composition parent mapping.
+// VersionsForLock (select * from VersionWithAssignments) inherits the 'assignments'
+// composition and overwrites the child->parent map entry in analyzeCompositions.
+// The trigger for VersionAssignment must still emit the cds.Composition parent INSERT
+// wired to the actual VersionWithAssignments table (not the view).
+annotate VariantTesting.VersionWithAssignments with @changelog: [title] {
+  title @changelog;
+};
+
+annotate VariantTesting.VersionAssignment with {
+  version @changelog: [version.title];
+  tag     @changelog;
 };

--- a/tests/integration/composition.test.js
+++ b/tests/integration/composition.test.js
@@ -3,526 +3,602 @@ const bookshop = require('path').resolve(__dirname, './../bookshop');
 const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
-describe('change log generation', () => {
-  describe('composition tracking', () => {
-    it('does not link child entity changes to the root entity when composition field is annotated with @changelog false', async () => {
-      const variantService = await cds.connect.to('VariantTesting');
-      const { ChangeView } = variantService.entities;
+describe('composition tracking', () => {
+  it('does not link child entity changes to the root entity when composition field is annotated with @changelog false', async () => {
+    const variantService = await cds.connect.to('VariantTesting');
+    const { ChangeView } = variantService.entities;
 
-      const parentID = cds.utils.uuid();
-      const childID = cds.utils.uuid();
-      await POST(`/odata/v4/variant-testing/DifferentFieldTypes`, {
-        ID: parentID,
-        title: 'Parent record',
-        children: [{ ID: childID, double: 3.14 }]
-      });
-
-      const changes = await SELECT.one.from(ChangeView).where({ entityKey: childID, attribute: 'double' });
-      expect(changes.entity).toEqual('sap.change_tracking.DifferentFieldTypesChildren');
-      expect(changes.attribute).toEqual('double');
-      expect(changes.modification).toEqual('create');
-      expect(changes.valueChangedFrom).toEqual(null);
-      expect(changes.valueChangedTo).toEqual('3.14');
-      expect(changes.parent_ID).toEqual(null);
+    const parentID = cds.utils.uuid();
+    const childID = cds.utils.uuid();
+    await POST(`/odata/v4/variant-testing/DifferentFieldTypes`, {
+      ID: parentID,
+      title: 'Parent record',
+      children: [{ ID: childID, double: 3.14 }]
     });
 
-    it('automatically links child entity changes to the root entity for auto-tracked compositions', async () => {
-      const processorService = await cds.connect.to('ProcessorService');
-      const { ChangeView } = processorService.entities;
+    const changes = await SELECT.one.from(ChangeView).where({ entityKey: childID, attribute: 'double' });
+    expect(changes.entity).toEqual('sap.change_tracking.DifferentFieldTypesChildren');
+    expect(changes.attribute).toEqual('double');
+    expect(changes.modification).toEqual('create');
+    expect(changes.valueChangedFrom).toEqual(null);
+    expect(changes.valueChangedTo).toEqual('3.14');
+    expect(changes.parent_ID).toEqual(null);
+  });
 
-      const incidentsID = cds.utils.uuid();
-      const taskID = cds.utils.uuid();
-      await POST(`/odata/v4/processor/Incidents`, {
-        ID: incidentsID,
-        tasks: [{ ID: taskID, title: 'Fix bug', description: 'Fix the login bug' }]
-      });
-      await POST(`/odata/v4/processor/Incidents(ID=${incidentsID}, IsActiveEntity=false)/ProcessorService.draftActivate`, {});
+  it('automatically links child entity changes to the root entity for auto-tracked compositions', async () => {
+    const processorService = await cds.connect.to('ProcessorService');
+    const { ChangeView } = processorService.entities;
 
-      const parentChanges = await SELECT.from(ChangeView).where({
-        entity: 'sap.capire.incidents.Incidents',
-        entityKey: incidentsID,
-        attribute: 'tasks',
-        valueDataType: 'cds.Composition'
-      });
-      expect(parentChanges.length).toEqual(1);
-      expect(parentChanges[0].parent_ID).toEqual(null);
+    const incidentsID = cds.utils.uuid();
+    const taskID = cds.utils.uuid();
+    await POST(`/odata/v4/processor/Incidents`, {
+      ID: incidentsID,
+      tasks: [{ ID: taskID, title: 'Fix bug', description: 'Fix the login bug' }]
+    });
+    await POST(`/odata/v4/processor/Incidents(ID=${incidentsID}, IsActiveEntity=false)/ProcessorService.draftActivate`, {});
 
-      // Child changes should be linked to the parent composition entry
-      const childChanges = await SELECT.from(ChangeView).where({
-        entity: 'sap.capire.incidents.IncidentTasks',
-        entityKey: taskID,
-        parent_ID: parentChanges[0].ID
-      });
-      expect(childChanges.length).toEqual(2); // title + description
+    const parentChanges = await SELECT.from(ChangeView).where({
+      entity: 'sap.capire.incidents.Incidents',
+      entityKey: incidentsID,
+      attribute: 'tasks',
+      valueDataType: 'cds.Composition'
+    });
+    expect(parentChanges.length).toEqual(1);
+    expect(parentChanges[0].parent_ID).toEqual(null);
 
-      const titleChange = childChanges.find((c) => c.attribute === 'title');
-      expect(titleChange).toMatchObject({
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: 'Fix bug'
-      });
+    // Child changes should be linked to the parent composition entry
+    const childChanges = await SELECT.from(ChangeView).where({
+      entity: 'sap.capire.incidents.IncidentTasks',
+      entityKey: taskID,
+      parent_ID: parentChanges[0].ID
+    });
+    expect(childChanges.length).toEqual(2); // title + description
 
-      const descChange = childChanges.find((c) => c.attribute === 'description');
-      expect(descChange).toMatchObject({
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: 'Fix the login bug'
-      });
+    const titleChange = childChanges.find((c) => c.attribute === 'title');
+    expect(titleChange).toMatchObject({
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: 'Fix bug'
     });
 
-    // Limitation because deep queries are not run in sequential order
-    it.skip('links child entity changes to the root entity when deep creating nested data', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
-
-      const orderID = cds.utils.uuid();
-      const orderItemID = cds.utils.uuid();
-      const orderItemNoteID = cds.utils.uuid();
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        orderItems: [{ ID: orderItemID, notes: [{ ID: orderItemNoteID, content: 'new content' }] }]
-      });
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, orderItemNoteID]}`;
-      expect(changes.length).toEqual(4);
-
-      // Find the new Order.orderItems entry (different from the one created during initial POST)
-      const orderChange = changes.find((c) => c.entityKey === orderID);
-      expect(orderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: null,
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemChanges = changes.filter((c) => c.entityKey === orderItemID);
-      expect(orderItemChanges.length).toEqual(2);
-
-      const orderItemChangeOrder = orderItemChanges.find((c) => c.attribute === 'order');
-      expect(orderItemChangeOrder).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'order',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: orderID,
-        parent_ID: orderChange.ID,
-        valueDataType: 'cds.Association'
-      });
-
-      const orderItemChangeNotes = orderItemChanges.find((c) => c.attribute === 'notes');
-      expect(orderItemChangeNotes).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'notes',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: null,
-        parent_ID: orderChange.ID,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemNoteChange = changes.find((c) => c.entityKey === orderItemNoteID);
-      expect(orderItemNoteChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItemNote',
-        attribute: 'content',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: 'new content',
-        parent_ID: orderItemChangeNotes.ID,
-        valueDataType: 'cds.String'
-      });
+    const descChange = childChanges.find((c) => c.attribute === 'description');
+    expect(descChange).toMatchObject({
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: 'Fix the login bug'
     });
-    it('links child entity changes to the root entity when creating nested data', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
+  });
 
-      const orderID = cds.utils.uuid();
-      const orderItemID = cds.utils.uuid();
-      const orderItemNoteID = cds.utils.uuid();
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        title: 'Test Order', // Provide title to ensure Order has a 'create' changelog entry
-        orderItems: [{ ID: orderItemID }]
-      });
+  // Limitation because deep queries are not run in sequential order
+  it.skip('links child entity changes to the root entity when deep creating nested data', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
 
-      // Check changes before creating OrderItemNote
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID]}`;
-      expect(changesBefore.length).toEqual(3); // +1 for Order.title 'create' entry
-      const orderChangeBefore = changesBefore.find((c) => c.entityKey === orderID && c.attribute === 'orderItems');
-      expect(orderChangeBefore).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'update',
-        valueChangedFrom: null,
-        valueChangedTo: null,
-        parent_ID: null
-      });
+    const orderID = cds.utils.uuid();
+    const orderItemID = cds.utils.uuid();
+    const orderItemNoteID = cds.utils.uuid();
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      orderItems: [{ ID: orderItemID, notes: [{ ID: orderItemNoteID, content: 'new content' }] }]
+    });
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, orderItemNoteID]}`;
+    expect(changes.length).toEqual(4);
 
-      const orderItemChangeBefore = changesBefore.find((c) => c.entityKey === orderItemID);
-      expect(orderItemChangeBefore).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'order',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: orderID,
-        parent_ID: orderChangeBefore.ID
-      });
-
-      await POST(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes`, {
-        ID: orderItemNoteID,
-        content: 'new content'
-      });
-      // Should create new change for field orderItems on Order with a link to OrderItemNote change (three new changes in total)
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, orderItemNoteID]}`;
-      expect(changes.length).toEqual(6); // +1 for Order.title 'create' entry
-
-      // Find the new Order.orderItems entry (different from the one created during initial POST)
-      const newOrderChange = changes.find((c) => c.entityKey === orderID && c.attribute === 'orderItems' && c.ID !== orderChangeBefore.ID);
-      expect(newOrderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'update',
-        valueChangedFrom: null,
-        valueChangedTo: null,
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      // The OrderItem entry should be for the 'notes' composition field, linking to the Order.orderItems entry
-      const noteChange = changes.find((c) => c.entityKey === orderItemID && c.ID !== orderItemChangeBefore.ID);
-      expect(noteChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'notes',
-        modification: 'update',
-        valueChangedFrom: null,
-        valueChangedTo: null,
-        parent_ID: newOrderChange.ID,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemNoteChange = changes.find((c) => c.entityKey === orderItemNoteID);
-      expect(orderItemNoteChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItemNote',
-        attribute: 'content',
-        modification: 'create',
-        valueChangedFrom: null,
-        valueChangedTo: 'new content',
-        parent_ID: noteChange.ID
-      });
+    // Find the new Order.orderItems entry (different from the one created during initial POST)
+    const orderChange = changes.find((c) => c.entityKey === orderID);
+    expect(orderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: null,
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
     });
 
-    it('logs updated child values as changes on the parent entity', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
+    const orderItemChanges = changes.filter((c) => c.entityKey === orderItemID);
+    expect(orderItemChanges.length).toEqual(2);
 
-      const orderID = cds.utils.uuid();
-      const orderItemID = cds.utils.uuid();
-      const noteID = cds.utils.uuid();
-
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        orderItems: [{ ID: orderItemID, notes: [{ ID: noteID, content: 'original note' }] }]
-      });
-
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
-      expect(changesBefore.length).toBeGreaterThan(0);
-      const transactionID = changesBefore[0].transactionID;
-
-      await PATCH(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`, {
-        content: 'new content'
-      });
-
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]} and transactionID != ${transactionID}`;
-      expect(changes.length).toEqual(3);
-
-      const orderChange = changes.find((c) => c.entityKey === orderID);
-      expect(orderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemChange = changes.find((c) => c.entityKey === orderItemID);
-      expect(orderItemChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'notes',
-        modification: 'update',
-        parent_ID: orderChange.ID,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemNoteChange = changes.find((c) => c.entityKey === noteID);
-      expect(orderItemNoteChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItemNote',
-        attribute: 'content',
-        modification: 'update',
-        parent_ID: orderItemChange.ID,
-        valueDataType: 'cds.String'
-      });
+    const orderItemChangeOrder = orderItemChanges.find((c) => c.attribute === 'order');
+    expect(orderItemChangeOrder).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'order',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: orderID,
+      parent_ID: orderChange.ID,
+      valueDataType: 'cds.Association'
     });
 
-    it('links child entity changes to the root entity when deleting nested data', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
-
-      const orderID = cds.utils.uuid();
-      const orderItemID = cds.utils.uuid();
-      const noteID = cds.utils.uuid();
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        orderItems: [{ ID: orderItemID, notes: [{ ID: noteID, content: 'note to delete' }] }]
-      });
-
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
-      expect(changesBefore.length).toBeGreaterThan(0);
-      const transactionID = changesBefore[0].transactionID;
-
-      await DELETE(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`);
-
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]} and transactionID != ${transactionID}`;
-      expect(changes.length).toEqual(3);
-
-      const orderChange = changes.find((c) => c.entityKey === orderID);
-      expect(orderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      const orderItemChange = changes.find((c) => c.entityKey === orderItemID);
-      expect(orderItemChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        attribute: 'notes',
-        modification: 'update',
-        parent_ID: orderChange.ID,
-        valueDataType: 'cds.Composition'
-      });
-
-      const noteChange = changes.find((c) => c.entityKey === noteID);
-      expect(noteChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItemNote',
-        attribute: 'content',
-        modification: 'delete',
-        valueChangedFrom: 'note to delete',
-        valueChangedTo: null,
-        parent_ID: orderItemChange.ID
-      });
+    const orderItemChangeNotes = orderItemChanges.find((c) => c.attribute === 'notes');
+    expect(orderItemChangeNotes).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'notes',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: null,
+      parent_ID: orderChange.ID,
+      valueDataType: 'cds.Composition'
     });
 
-    it('correctly identifies root entity when URL path contains associated entities', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
+    const orderItemNoteChange = changes.find((c) => c.entityKey === orderItemNoteID);
+    expect(orderItemNoteChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItemNote',
+      attribute: 'content',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: 'new content',
+      parent_ID: orderItemChangeNotes.ID,
+      valueDataType: 'cds.String'
+    });
+  });
+  it('links child entity changes to the root entity when creating nested data', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
 
-      const reportID = cds.utils.uuid();
-      const orderID = cds.utils.uuid();
-      // Report has association to many Orders, changes on OrderItem shall be logged on Order
-      await POST(`/odata/v4/admin/Report`, {
-        ID: reportID
-      });
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        report_ID: reportID,
-        title: 'Test Order' // Provide title to ensure Order has a 'create' changelog entry
-      });
-
-      const { data: orderItem } = await POST(`/odata/v4/admin/Order(ID=${orderID})/orderItems`, {
-        order_ID: orderID,
-        quantity: 10,
-        price: 5
-      });
-
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItem.ID]}`;
-      expect(changes.length).toEqual(4); // +1 for Order.title 'create' entry
-
-      // Order.orderItems composition entry should exist with parent_ID = null
-      const orderChange = changes.find((c) => c.entityKey === orderID && c.attribute === 'orderItems');
-      expect(orderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'orderItems',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      // OrderItem entry should link to Order.orderItems entry
-      const orderItemChange = changes.filter((c) => c.entityKey === orderItem.ID);
-      expect(orderItemChange.length).toEqual(2);
-      const quantityChange = orderItemChange.find((c) => c.attribute === 'quantity');
-      expect(quantityChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        modification: 'create',
-        parent_ID: orderChange.ID
-      });
-
-      const orderItemOrderChange = orderItemChange.find((c) => c.attribute === 'order');
-      expect(orderItemOrderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.OrderItem',
-        modification: 'create',
-        parent_ID: orderChange.ID
-      });
+    const orderID = cds.utils.uuid();
+    const orderItemID = cds.utils.uuid();
+    const orderItemNoteID = cds.utils.uuid();
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      title: 'Test Order', // Provide title to ensure Order has a 'create' changelog entry
+      orderItems: [{ ID: orderItemID }]
     });
 
-    it('tracks changes on child entities during deep update operations', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView, BookStores } = adminService.entities;
+    // Check changes before creating OrderItemNote
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID]}`;
+    expect(changesBefore.length).toEqual(3); // +1 for Order.title 'create' entry
+    const orderChangeBefore = changesBefore.find((c) => c.entityKey === orderID && c.attribute === 'orderItems');
+    expect(orderChangeBefore).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'update',
+      valueChangedFrom: null,
+      valueChangedTo: null,
+      parent_ID: null
+    });
 
-      const bookStoreID = cds.utils.uuid();
-      const bookID = cds.utils.uuid();
-      await INSERT.into(BookStores).entries({
+    const orderItemChangeBefore = changesBefore.find((c) => c.entityKey === orderItemID);
+    expect(orderItemChangeBefore).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'order',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: orderID,
+      parent_ID: orderChangeBefore.ID
+    });
+
+    await POST(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes`, {
+      ID: orderItemNoteID,
+      content: 'new content'
+    });
+    // Should create new change for field orderItems on Order with a link to OrderItemNote change (three new changes in total)
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, orderItemNoteID]}`;
+    expect(changes.length).toEqual(6); // +1 for Order.title 'create' entry
+
+    // Find the new Order.orderItems entry (different from the one created during initial POST)
+    const newOrderChange = changes.find((c) => c.entityKey === orderID && c.attribute === 'orderItems' && c.ID !== orderChangeBefore.ID);
+    expect(newOrderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'update',
+      valueChangedFrom: null,
+      valueChangedTo: null,
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
+    });
+
+    // The OrderItem entry should be for the 'notes' composition field, linking to the Order.orderItems entry
+    const noteChange = changes.find((c) => c.entityKey === orderItemID && c.ID !== orderItemChangeBefore.ID);
+    expect(noteChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'notes',
+      modification: 'update',
+      valueChangedFrom: null,
+      valueChangedTo: null,
+      parent_ID: newOrderChange.ID,
+      valueDataType: 'cds.Composition'
+    });
+
+    const orderItemNoteChange = changes.find((c) => c.entityKey === orderItemNoteID);
+    expect(orderItemNoteChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItemNote',
+      attribute: 'content',
+      modification: 'create',
+      valueChangedFrom: null,
+      valueChangedTo: 'new content',
+      parent_ID: noteChange.ID
+    });
+  });
+
+  it('logs updated child values as changes on the parent entity', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
+
+    const orderID = cds.utils.uuid();
+    const orderItemID = cds.utils.uuid();
+    const noteID = cds.utils.uuid();
+
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      orderItems: [{ ID: orderItemID, notes: [{ ID: noteID, content: 'original note' }] }]
+    });
+
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
+    expect(changesBefore.length).toBeGreaterThan(0);
+    const transactionID = changesBefore[0].transactionID;
+
+    await PATCH(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`, {
+      content: 'new content'
+    });
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]} and transactionID != ${transactionID}`;
+    expect(changes.length).toEqual(3);
+
+    const orderChange = changes.find((c) => c.entityKey === orderID);
+    expect(orderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
+    });
+
+    const orderItemChange = changes.find((c) => c.entityKey === orderItemID);
+    expect(orderItemChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'notes',
+      modification: 'update',
+      parent_ID: orderChange.ID,
+      valueDataType: 'cds.Composition'
+    });
+
+    const orderItemNoteChange = changes.find((c) => c.entityKey === noteID);
+    expect(orderItemNoteChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItemNote',
+      attribute: 'content',
+      modification: 'update',
+      parent_ID: orderItemChange.ID,
+      valueDataType: 'cds.String'
+    });
+  });
+
+  it('links child entity changes to the root entity when deleting nested data', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
+
+    const orderID = cds.utils.uuid();
+    const orderItemID = cds.utils.uuid();
+    const noteID = cds.utils.uuid();
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      orderItems: [{ ID: orderItemID, notes: [{ ID: noteID, content: 'note to delete' }] }]
+    });
+
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]}`;
+    expect(changesBefore.length).toBeGreaterThan(0);
+    const transactionID = changesBefore[0].transactionID;
+
+    await DELETE(`/odata/v4/admin/Order(ID=${orderID})/orderItems(ID=${orderItemID})/notes(ID=${noteID})`);
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, noteID]} and transactionID != ${transactionID}`;
+    expect(changes.length).toEqual(3);
+
+    const orderChange = changes.find((c) => c.entityKey === orderID);
+    expect(orderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
+    });
+
+    const orderItemChange = changes.find((c) => c.entityKey === orderItemID);
+    expect(orderItemChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      attribute: 'notes',
+      modification: 'update',
+      parent_ID: orderChange.ID,
+      valueDataType: 'cds.Composition'
+    });
+
+    const noteChange = changes.find((c) => c.entityKey === noteID);
+    expect(noteChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItemNote',
+      attribute: 'content',
+      modification: 'delete',
+      valueChangedFrom: 'note to delete',
+      valueChangedTo: null,
+      parent_ID: orderItemChange.ID
+    });
+  });
+
+  it('correctly identifies root entity when URL path contains associated entities', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
+
+    const reportID = cds.utils.uuid();
+    const orderID = cds.utils.uuid();
+    // Report has association to many Orders, changes on OrderItem shall be logged on Order
+    await POST(`/odata/v4/admin/Report`, {
+      ID: reportID
+    });
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      report_ID: reportID,
+      title: 'Test Order' // Provide title to ensure Order has a 'create' changelog entry
+    });
+
+    const { data: orderItem } = await POST(`/odata/v4/admin/Order(ID=${orderID})/orderItems`, {
+      order_ID: orderID,
+      quantity: 10,
+      price: 5
+    });
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItem.ID]}`;
+    expect(changes.length).toEqual(4); // +1 for Order.title 'create' entry
+
+    // Order.orderItems composition entry should exist with parent_ID = null
+    const orderChange = changes.find((c) => c.entityKey === orderID && c.attribute === 'orderItems');
+    expect(orderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'orderItems',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
+    });
+
+    // OrderItem entry should link to Order.orderItems entry
+    const orderItemChange = changes.filter((c) => c.entityKey === orderItem.ID);
+    expect(orderItemChange.length).toEqual(2);
+    const quantityChange = orderItemChange.find((c) => c.attribute === 'quantity');
+    expect(quantityChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      modification: 'create',
+      parent_ID: orderChange.ID
+    });
+
+    const orderItemOrderChange = orderItemChange.find((c) => c.attribute === 'order');
+    expect(orderItemOrderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.OrderItem',
+      modification: 'create',
+      parent_ID: orderChange.ID
+    });
+  });
+
+  it('tracks changes on child entities during deep update operations', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView, BookStores } = adminService.entities;
+
+    const bookStoreID = cds.utils.uuid();
+    const bookID = cds.utils.uuid();
+    await INSERT.into(BookStores).entries({
+      ID: bookStoreID,
+      name: 'Shakespeare and Company',
+      books: [{ ID: bookID, title: 'Old Wuthering Heights Test', author_ID: 'd4d4a1b3-5b83-4814-8a20-f039af6f0387' }]
+    });
+
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, bookID]}`;
+    expect(changesBefore.length).toBeGreaterThan(0);
+    const transactionID = changesBefore[0].transactionID;
+
+    // Update the book title through deep update on existing data
+    await UPDATE(BookStores)
+      .where({ ID: bookStoreID })
+      .with({
+        books: [{ ID: bookID, title: 'Wuthering Heights Test' }]
+      });
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, bookID]} and transactionID != ${transactionID}`;
+    expect(changes.length).toEqual(2);
+
+    // BookStores.books composition entry
+    const bookStoreChange = changes.find((c) => c.entityKey === bookStoreID);
+    expect(bookStoreChange).toMatchObject({
+      entity: 'sap.capire.bookshop.BookStores',
+      attribute: 'books',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition',
+      // Composition-of-many: uses parent's @changelog: [name] as objectID
+      objectID: 'Shakespeare and Company'
+    });
+
+    // Books.title field change linked to parent
+    const bookChange = changes.find((c) => c.entityKey === bookID);
+    expect(bookChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Books',
+      attribute: 'title',
+      modification: 'update',
+      parent_ID: bookStoreChange.ID,
+      objectID: 'Wuthering Heights Test, Emily, Brontë',
+      valueChangedFrom: 'Old Wuthering Heights Test',
+      valueChangedTo: 'Wuthering Heights Test'
+    });
+  });
+
+  it('tracks changes on inline composition elements with composite keys', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView } = adminService.entities;
+
+    const orderID = cds.utils.uuid();
+    const orderItemID = cds.utils.uuid();
+    const compositeKey = `${String(orderID).length},${orderID};${String(orderItemID).length},${orderItemID}`;
+
+    await POST(`/odata/v4/admin/Order`, {
+      ID: orderID,
+      Items: [
+        {
+          ID: orderItemID,
+          quantity: 10
+        }
+      ]
+    });
+
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, compositeKey]}`;
+    expect(changesBefore.length).toBeGreaterThan(0);
+    const transactionID = changesBefore[0].transactionID;
+
+    await PATCH(`/odata/v4/admin/Order(ID=${orderID})/Items(ID=${orderItemID})`, {
+      quantity: 12
+    });
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, compositeKey]} and transactionID != ${transactionID}`;
+    expect(changes.length).toEqual(2);
+
+    // Order composition entry (parent)
+    const orderChange = changes.find((c) => c.entityKey === orderID);
+    expect(orderChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order',
+      attribute: 'Items',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition'
+    });
+
+    // Inline item change linked to parent
+    const itemChange = changes.find((c) => c.entityKey === compositeKey);
+    expect(itemChange).toMatchObject({
+      entity: 'sap.capire.bookshop.Order.Items',
+      attribute: 'quantity',
+      modification: 'update',
+      parent_ID: orderChange.ID,
+      valueChangedFrom: '10',
+      valueChangedTo: '12'
+    });
+  });
+
+  it('tracks deletion of child entities during deep delete operations', async () => {
+    const adminService = await cds.connect.to('AdminService');
+    const { ChangeView, BookStores } = adminService.entities;
+
+    const bookStoreID = cds.utils.uuid();
+    const registryID = cds.utils.uuid();
+
+    await adminService.run(
+      INSERT.into(BookStores).entries({
         ID: bookStoreID,
-        name: 'Shakespeare and Company',
-        books: [{ ID: bookID, title: 'Old Wuthering Heights Test', author_ID: 'd4d4a1b3-5b83-4814-8a20-f039af6f0387' }]
-      });
+        name: 'Test Bookstore',
+        registry: {
+          ID: registryID,
+          code: 'TEST-1',
+          validOn: '2012-01-01'
+        }
+      })
+    );
 
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, bookID]}`;
-      expect(changesBefore.length).toBeGreaterThan(0);
-      const transactionID = changesBefore[0].transactionID;
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]}`;
+    expect(changesBefore.length).toBeGreaterThan(0);
+    const transactionID = changesBefore[0].transactionID;
 
-      // Update the book title through deep update on existing data
-      await UPDATE(BookStores)
-        .where({ ID: bookStoreID })
-        .with({
-          books: [{ ID: bookID, title: 'Wuthering Heights Test' }]
-        });
-
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, bookID]} and transactionID != ${transactionID}`;
-      expect(changes.length).toEqual(2);
-
-      // BookStores.books composition entry
-      const bookStoreChange = changes.find((c) => c.entityKey === bookStoreID);
-      expect(bookStoreChange).toMatchObject({
-        entity: 'sap.capire.bookshop.BookStores',
-        attribute: 'books',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition',
-        // Composition-of-many: uses parent's @changelog: [name] as objectID
-        objectID: 'Shakespeare and Company'
-      });
-
-      // Books.title field change linked to parent
-      const bookChange = changes.find((c) => c.entityKey === bookID);
-      expect(bookChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Books',
-        attribute: 'title',
-        modification: 'update',
-        parent_ID: bookStoreChange.ID,
-        objectID: 'Wuthering Heights Test, Emily, Brontë',
-        valueChangedFrom: 'Old Wuthering Heights Test',
-        valueChangedTo: 'Wuthering Heights Test'
-      });
+    await UPDATE(BookStores).where({ ID: bookStoreID }).with({
+      registry: null,
+      registry_ID: null
     });
 
-    it('tracks changes on inline composition elements with composite keys', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView } = adminService.entities;
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]} and transactionID != ${transactionID}`;
+    expect(changes.length).toEqual(2);
 
-      const orderID = cds.utils.uuid();
-      const orderItemID = cds.utils.uuid();
-      const compositeKey = `${String(orderID).length},${orderID};${String(orderItemID).length},${orderItemID}`;
-
-      await POST(`/odata/v4/admin/Order`, {
-        ID: orderID,
-        Items: [
-          {
-            ID: orderItemID,
-            quantity: 10
-          }
-        ]
-      });
-
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[orderID, orderItemID, compositeKey]}`;
-      expect(changesBefore.length).toBeGreaterThan(0);
-      const transactionID = changesBefore[0].transactionID;
-
-      await PATCH(`/odata/v4/admin/Order(ID=${orderID})/Items(ID=${orderItemID})`, {
-        quantity: 12
-      });
-
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[orderID, compositeKey]} and transactionID != ${transactionID}`;
-      expect(changes.length).toEqual(2);
-
-      // Order composition entry (parent)
-      const orderChange = changes.find((c) => c.entityKey === orderID);
-      expect(orderChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order',
-        attribute: 'Items',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition'
-      });
-
-      // Inline item change linked to parent
-      const itemChange = changes.find((c) => c.entityKey === compositeKey);
-      expect(itemChange).toMatchObject({
-        entity: 'sap.capire.bookshop.Order.Items',
-        attribute: 'quantity',
-        modification: 'update',
-        parent_ID: orderChange.ID,
-        valueChangedFrom: '10',
-        valueChangedTo: '12'
-      });
+    // BookStores.registry composition entry (parent)
+    const bookStoreChange = changes.find((c) => c.entityKey === bookStoreID);
+    expect(bookStoreChange).toMatchObject({
+      entity: 'sap.capire.bookshop.BookStores',
+      attribute: 'registry',
+      modification: 'update',
+      parent_ID: null,
+      valueDataType: 'cds.Composition',
+      // BookStoreRegistry objectID : [code]
+      objectID: 'TEST-1'
     });
 
-    it('tracks deletion of child entities during deep delete operations', async () => {
-      const adminService = await cds.connect.to('AdminService');
-      const { ChangeView, BookStores } = adminService.entities;
+    // Registry change linked to parent
+    const registryChange = changes.find((c) => c.entityKey === registryID);
+    expect(registryChange).toMatchObject({
+      entity: 'sap.capire.bookshop.BookStoreRegistry',
+      attribute: 'validOn',
+      modification: 'delete',
+      parent_ID: bookStoreChange.ID,
+      objectID: 'TEST-1',
+      valueChangedFrom: '2012-01-01',
+      valueChangedTo: null
+    });
+  });
 
-      const bookStoreID = cds.utils.uuid();
-      const registryID = cds.utils.uuid();
+  it('links child field changes to the parent composition entry on create, even when a DB-level select-* view (VersionsForLock) is defined', async () => {
+    // DB-level view doing `select * from ParentEntity { * }` inherits composition and overrides the map
+    // VersionWithAssignments  { assignments: Composition of many VersionAssignment }
+    // VersionsForLock as select from VersionWithAssignments { * }
+    const variantService = await cds.connect.to('VariantTesting');
+    const { ChangeView } = variantService.entities;
 
-      await adminService.run(
-        INSERT.into(BookStores).entries({
-          ID: bookStoreID,
-          name: 'Test Bookstore',
-          registry: {
-            ID: registryID,
-            code: 'TEST-1',
-            validOn: '2012-01-01'
-          }
-        })
-      );
+    const versionID = cds.utils.uuid();
+    const assignmentID = cds.utils.uuid();
 
-      const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]}`;
-      expect(changesBefore.length).toBeGreaterThan(0);
-      const transactionID = changesBefore[0].transactionID;
+    await POST(`/odata/v4/variant-testing/VersionWithAssignments`, {
+      ID: versionID,
+      title: 'v1',
+      assignments: [{ ID: assignmentID, tag: 'alpha' }]
+    });
 
-      await UPDATE(BookStores).where({ ID: bookStoreID }).with({
-        registry: null,
-        registry_ID: null
-      });
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[versionID, assignmentID]}`;
 
-      const changes = await SELECT.from(ChangeView).where`entityKey in ${[bookStoreID, registryID]} and transactionID != ${transactionID}`;
-      expect(changes.length).toEqual(2);
+    // There must be a cds.Composition entry for VersionWithAssignments.assignments
+    const compositionEntry = changes.find((c) => c.entity === 'sap.change_tracking.VersionWithAssignments' && c.valueDataType === 'cds.Composition');
+    expect(compositionEntry).toBeDefined();
+    expect(compositionEntry).toMatchObject({
+      entity: 'sap.change_tracking.VersionWithAssignments',
+      entityKey: versionID,
+      attribute: 'assignments',
+      valueDataType: 'cds.Composition',
+      parent_ID: null
+    });
 
-      // BookStores.registry composition entry (parent)
-      const bookStoreChange = changes.find((c) => c.entityKey === bookStoreID);
-      expect(bookStoreChange).toMatchObject({
-        entity: 'sap.capire.bookshop.BookStores',
-        attribute: 'registry',
-        modification: 'update',
-        parent_ID: null,
-        valueDataType: 'cds.Composition',
-        // BookStoreRegistry objectID : [code]
-        objectID: 'TEST-1'
-      });
+    // VersionAssignment field changes must be linked to that composition entry
+    const assignmentChanges = changes.filter((c) => c.entityKey === assignmentID);
+    expect(assignmentChanges.length).toBeGreaterThan(0);
+    for (const change of assignmentChanges) {
+      expect(change.parent_ID).toEqual(compositionEntry.ID);
+    }
+  });
 
-      // Registry change linked to parent
-      const registryChange = changes.find((c) => c.entityKey === registryID);
-      expect(registryChange).toMatchObject({
-        entity: 'sap.capire.bookshop.BookStoreRegistry',
-        attribute: 'validOn',
-        modification: 'delete',
-        parent_ID: bookStoreChange.ID,
-        objectID: 'TEST-1',
-        valueChangedFrom: '2012-01-01',
-        valueChangedTo: null
-      });
+  it('links child field changes to the parent composition entry on update, even when a DB-level select-* view (VersionsForLock) is defined', async () => {
+    const variantService = await cds.connect.to('VariantTesting');
+    const { ChangeView } = variantService.entities;
+
+    const versionID = cds.utils.uuid();
+    const assignmentID = cds.utils.uuid();
+
+    await POST(`/odata/v4/variant-testing/VersionWithAssignments`, {
+      ID: versionID,
+      title: 'v1',
+      assignments: [{ ID: assignmentID, tag: 'alpha' }]
+    });
+
+    const changesBefore = await SELECT.from(ChangeView).where`entityKey in ${[versionID, assignmentID]}`;
+    const txBefore = changesBefore[0].transactionID;
+
+    await PATCH(`/odata/v4/variant-testing/VersionAssignment(ID=${assignmentID})`, { tag: 'beta' });
+
+    const changes = await SELECT.from(ChangeView).where`entityKey in ${[versionID, assignmentID]} and transactionID != ${txBefore}`;
+
+    // There must be a cds.Composition entry for the update on VersionWithAssignments.assignments
+    const compositionEntry = changes.find((c) => c.entity === 'sap.change_tracking.VersionWithAssignments' && c.valueDataType === 'cds.Composition');
+    expect(compositionEntry).toBeDefined();
+    expect(compositionEntry).toMatchObject({
+      entityKey: versionID,
+      attribute: 'assignments',
+      modification: 'update',
+      parent_ID: null
+    });
+
+    // The tag field change must be linked to that composition entry
+    const tagChange = changes.find((c) => c.entityKey === assignmentID && c.attribute === 'tag');
+    expect(tagChange).toBeDefined();
+    expect(tagChange).toMatchObject({
+      modification: 'update',
+      valueChangedFrom: 'alpha',
+      valueChangedTo: 'beta',
+      parent_ID: compositionEntry.ID
     });
   });
 });


### PR DESCRIPTION
# Fix: Composition Link When DB-Level Views Are Defined

### Bug Fix

🐛 Fixed missing `cds.Composition` parent entry and broken `parent_ID` links in generated change log triggers when a DB-level `select *` view of a parent entity inherits the same composition as the base table entity.

Previously, when a DB-level view (e.g., `VersionsForLock as select from VersionWithAssignments { * }`) was defined, the `analyzeCompositions` function would overwrite the child→parent map entry with the view instead of the original table entity. This caused the composition tracking to wire child change entries to the view rather than the actual base table, breaking `parent_ID` links.

### Changes

* `lib/utils/entity-collector.js`: Updated `analyzeCompositions` to detect view/projection entities via `def.query || def.projection`. When building the child→parent composition map, the logic now **prefers base table entities** over views/projections, preventing a DB-level view from overriding the correct parent mapping.

* `tests/bookshop/db/index.cds`: Added new test entities `VersionWithAssignments`, `VersionAssignment`, and DB-level view `VersionsForLock` to reproduce the bug scenario. Also refactored multiple existing entities to use the `cuid` aspect instead of manually defining `key ID: UUID`.

* `tests/bookshop/srv/feature-testing.cds`: Exposed `VersionWithAssignments` and `VersionAssignment` in the `VariantTesting` service and added `@changelog` annotations to cover the bug scenario.

* `tests/integration/composition.test.js`: Refactored the test suite to remove the outer `describe('change log generation')` wrapper (flattening the structure), and added two new integration tests verifying that `parent_ID` links are correctly generated for child entities even when a DB-level `select *` view (`VersionsForLock`) inherits the same composition.

* `package.json`: Bumped version from `2.0.1` to `2.0.2`.

* `CHANGELOG.md`: Added release entry for version `2.0.2` documenting this fix.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `e0206af0-7eb4-11f1-81be-34f2d4f31c98`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
