### PR TITLE
test: replace jest with vitest

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -100,7 +100,7 @@ runs:
       shell: bash
 
     # Run tests in hybrid mode
-    - run: cds bind --exec -- npx jest --testPathIgnorePatterns='tests/mtx/mtx.test.js' --silent
+    - run: cds bind --exec -- npx vitest --silent --exclude='tests/mtx/mtx.test.js'
       shell: bash
 
     # Cleanup BTP services

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -166,6 +166,12 @@ jobs:
               echo "Performance tests succeeded."
               kubectl get testruns "$PERF_TEST_RUN_NAME" -o json | jq '.status'
               exit 0
+            fi
+
+            if [ "$STATUS" = "Succeeded" ] && [ "$THRESHOLD_STATUS" = "ThresholdBreached" ]; then
+              echo "❌ Performance tests completed but thresholds were breached."
+              kubectl get testruns "$PERF_TEST_RUN_NAME" -o json | jq '.status'
+              exit 1
             fi
 
             if [ "$STATUS" = "Failed" ]; then

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [reopened, synchronize, opened]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [reopened, synchronize, opened]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Deploy to PostgreSQL
         run: cd tests/bookshop && npm run deploy:pg
       - name: Run PostgreSQL tests
-        run: CDS_ENV=pg npx jest --silent
+        run: CDS_ENV=pg npx vitest --silent
 
   test-hana:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [reopened, synchronize, opened]
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   ],
   "scripts": {
     "lint": "npx eslint .",
-    "test": "npx jest --silent",
-    "test:sqlite": "CDS_ENV=sqlite npx jest --silent",
-    "test:pg": "npm run start:pg && CDS_ENV=pg npx jest --silent",
-    "test:hana": "cds bind --exec -- npx jest --silent",
+    "test": "npx vitest --silent",
+    "test:sqlite": "CI=true CDS_ENV=sqlite npx vitest --silent",
+    "test:pg": "npm run start:pg && CI=true CDS_ENV=pg npx vitest --silent",
+    "test:hana": "CI=true cds bind --exec -- npx vitest --silent",
     "deploy:hana": "cd tests/bookshop && cds deploy -2 hana && cd ../../",
     "deploy:hana:rowlevel": "cd tests/bookshop && CDS_ENV=rowlevel cds deploy -2 hana && cd ../../",
     "start:pg": "cd tests/bookshop/ && docker compose -f pg-stack.yml up -d && npm run deploy:pg && cd ../..",
@@ -33,7 +33,9 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": ">=1",
-    "@cap-js/cds-types": "^0"
+    "@cap-js/cds-types": "^0",
+    "@vitest/ui": "^3.2.7",
+    "vitest": "^3.2.7"
   },
   "cds": {
     "requires": {
@@ -45,9 +47,6 @@
         "rowLevelTriggers": false
       }
     }
-  },
-  "jest": {
-    "testTimeout": 200000
   },
   "workspaces": [
     "tests/*"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": ">=1",
-    "@cap-js/cds-types": "^0"
+    "@cap-js/cds-types": "^0",
+    "vitest": "^3.2.7"
   },
   "cds": {
     "requires": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": ">=1",
-    "@cap-js/cds-types": "^0",
-    "@vitest/ui": "^3.2.7",
-    "vitest": "^3.2.7"
+    "@cap-js/cds-types": "^0"
   },
   "cds": {
     "requires": {

--- a/tests/bookshop/db/joins-and-unions.cds
+++ b/tests/bookshop/db/joins-and-unions.cds
@@ -1,8 +1,9 @@
 
+using { cuid } from '@sap/cds/common';
+
 namespace sap.change_tracking;
 
-entity Events {
-    key ID: UUID;
+entity Events : cuid {
     object_ID          : String not null         @mandatory;
     object_Type        : String not null         @mandatory  @assert.range  enum {
         A;
@@ -24,8 +25,7 @@ type Component          : String enum {
   KLM;
 }
 
-entity UseCases {
-    key ID :UUID;
+entity UseCases : cuid {
           type                   : String(100) @changelog;
           booleanField                 : Boolean default false  @changelog;
           name                   : String(100)  @changelog;
@@ -34,21 +34,17 @@ entity UseCases {
           area: String @changelog;
 };
 
-entity DataRequests {
-    key ID :UUID;
+entity DataRequests : cuid {
     useCase_ID: UUID;
     useCase: Association to one UseCases on useCase.ID = useCase_ID;
 };
-entity DataSets {
-    key ID :UUID;
+entity DataSets : cuid {
     dataRequest: Association to one DataRequests;
 };
-entity DataDefinition {
-    key ID :UUID;
+entity DataDefinition : cuid {
     dataRequest: Association to one DataRequests;
 };
-entity DataAreas {
-    key ID :UUID;
+entity DataAreas : cuid {
     name: String @changelog;
 };
 

--- a/tests/build/hana-build.test.js
+++ b/tests/build/hana-build.test.js
@@ -5,6 +5,7 @@ const TempUtil = require('./tempUtil.js');
 const tempUtil = new TempUtil(__filename);
 
 const bookshopDir = path.join(__dirname, '../bookshop');
+cds.test(bookshopDir);
 const isHana = cds.env.requires?.db?.kind === 'hana';
 
 (isHana ? describe : describe.skip)('HANA Build', () => {

--- a/tests/integration/cds-features.test.js
+++ b/tests/integration/cds-features.test.js
@@ -2,8 +2,8 @@ const cds = require('@sap/cds');
 const path = require('path');
 
 const bookshop = path.resolve(__dirname, './../bookshop');
-const { axios, POST, PATCH, DELETE, GET } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice' };
+const { defaults, POST, PATCH, DELETE, GET } = cds.test(bookshop);
+defaults.auth = { username: 'alice' };
 
 describe('CDS Features', () => {
   describe('@Common.Timezone handling', () => {

--- a/tests/integration/composition-draft.test.js
+++ b/tests/integration/composition-draft.test.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
+const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('composition tracking (draft)', () => {

--- a/tests/integration/composition-draft.test.js
+++ b/tests/integration/composition-draft.test.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('composition tracking (draft)', () => {
   describe('Composition of one', () => {

--- a/tests/integration/composition-hierarchy.test.js
+++ b/tests/integration/composition-hierarchy.test.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
+const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('change log generation', () => {

--- a/tests/integration/composition-hierarchy.test.js
+++ b/tests/integration/composition-hierarchy.test.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('change log generation', () => {
   describe('4-level composition hierarchy (GrandRootSample -> RootSample -> Level1Sample -> Level2Sample)', () => {

--- a/tests/integration/composition.test.js
+++ b/tests/integration/composition.test.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
+const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
 axios.defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('composition tracking', () => {

--- a/tests/integration/composition.test.js
+++ b/tests/integration/composition.test.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('composition tracking', () => {
   it('does not link child entity changes to the root entity when composition field is annotated with @changelog false', async () => {

--- a/tests/integration/configuration.test.js
+++ b/tests/integration/configuration.test.js
@@ -3,8 +3,8 @@ const path = require('path');
 const { regenerateTriggers } = require('../test-utils.js');
 
 const bookshop = path.resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, GET, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 const isHana = cds.env.requires?.db?.kind === 'hana';
 

--- a/tests/integration/crud.test.js
+++ b/tests/integration/crud.test.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, GET, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('change log generation', () => {
   describe('Basic CRUD operations', () => {

--- a/tests/integration/expressions.test.js
+++ b/tests/integration/expressions.test.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios } = cds.test(bookshop);
-axios.defaults.auth = { username: 'alice', password: 'admin' };
+const { POST, PATCH, DELETE, GET, defaults } = cds.test(bookshop);
+defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('Expression-based @changelog annotations', () => {
   it('uses expression for objectID when entity has @changelog : [(firstName || lastName)]', async () => {

--- a/tests/integration/incidents-app.test.js
+++ b/tests/integration/incidents-app.test.js
@@ -1,8 +1,8 @@
 const cds = require('@sap/cds');
 const path = require('path');
 const app = path.join(__dirname, '../bookshop');
-const { axios, GET, POST, PATCH, DELETE } = cds.test(app);
-axios.defaults.auth = { username: 'alice' };
+const { defaults, GET, POST, PATCH, DELETE } = cds.test(app);
+defaults.auth = { username: 'alice' };
 
 async function newIncident() {
   const res = await POST(`odata/v4/processor/Incidents`, {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    testTimeout: 20_000
+    testTimeout: 60_000
   }
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 20_000
+  }
+});


### PR DESCRIPTION
# Replace Jest with Vitest as Test Runner

### Test

🧪 Migrated the test framework from Jest to Vitest across the entire project, replacing all Jest-specific configurations and CLI invocations.

### Changes

* `package.json`: Replaced `jest` test scripts with `vitest` equivalents (adding `CI=true` where needed), added `vitest` and `@vitest/ui` as dev dependencies, and removed the `jest` configuration block.
* `vitest.config.js`: Added new Vitest configuration file with a `testTimeout` of 20,000ms (replacing the former Jest `testTimeout` setting).
* `.github/workflows/test.yml`: Updated CI workflow to use `npx vitest` instead of `npx jest` for PostgreSQL test runs; also changed trigger from `pull_request_target` to `pull_request`.
* `.github/actions/integration-tests/action.yml`: Updated the HANA integration test step to use `npx vitest` with Vitest-compatible `--exclude` flag instead of Jest's `--testPathIgnorePatterns`.
* `tests/integration/*.test.js` (multiple files): Replaced `axios.defaults.auth` pattern with the `defaults.auth` pattern returned by `cds.test()`, removing the `axios` destructuring.
* `tests/build/hana-build.test.js`: Added `cds.test(bookshopDir)` call to properly initialize the CDS test environment.
* `tests/bookshop/db/joins-and-unions.cds`: Refactored entity definitions to use the `cuid` aspect instead of explicit `key ID: UUID` fields for consistency.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `4f7f25f0-7ed6-11f1-8a2d-00f047ffcdbb`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
