### PR TITLE
fix: skip `.texts` entities during trigger generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.0.3 - 2026-07-21
+
+### Fixed
+- Skip trigger generation for localized text tables (`*.texts`)
+
 ## Version 2.0.2 - 2026-07-13
 
 ### Fixed

--- a/lib/utils/entity-collector.js
+++ b/lib/utils/entity-collector.js
@@ -293,6 +293,8 @@ function _collectStandaloneEntities(model, result, processed) {
     if (!isTableEntity || processed.has(def.name)) continue;
 
     if (isChangeTracked(def)) {
+      // Skip CDS-generated localized text tables
+      if (def.name.endsWith('.texts')) continue;
       result.push({ dbEntityName: def.name, mergedAnnotations: null });
       processed.add(def.name);
       DEBUG?.(`Including DB entity ${def.name} directly (no service entities collected)`);
@@ -324,6 +326,8 @@ function _discoverCompositionTargets(model, result, processed) {
 
         const targetEntity = model[element.target];
         if (!targetEntity) continue;
+        // Skip CDS-generated localized text tables
+        if (element.target.endsWith('.texts')) continue;
         if (!changelogAnnotation && !_hasTrackedElements(targetEntity)) continue;
 
         const entry = { dbEntityName: element.target, mergedAnnotations: null };
@@ -347,7 +351,8 @@ function getEntitiesForTriggerGeneration(model, collected) {
   _collectStandaloneEntities(model, result, processed);
   _discoverCompositionTargets(model, result, processed);
 
-  return result;
+  // Skip CDS-generated localized text tables (*.texts)
+  return result.filter(({ dbEntityName }) => !dbEntityName.endsWith('.texts'));
 }
 
 // Recursively find the base entity of a projection (needed for loaded lifecycle hook)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",
@@ -19,7 +19,7 @@
     "test": "npx vitest --silent",
     "test:sqlite": "CI=true CDS_ENV=sqlite npx vitest --silent",
     "test:pg": "npm run start:pg && CI=true CDS_ENV=pg npx vitest --silent",
-    "test:hana": "CI=true cds bind --exec -- npx vitest --silent",
+    "test:hana": "CI=true cds bind --exec -- npx vitest --silent=true",
     "deploy:hana": "cd tests/bookshop && cds deploy -2 hana && cd ../../",
     "deploy:hana:rowlevel": "cd tests/bookshop && CDS_ENV=rowlevel cds deploy -2 hana && cd ../../",
     "start:pg": "cd tests/bookshop/ && docker compose -f pg-stack.yml up -d && npm run deploy:pg && cd ../..",

--- a/tests/bookshop/srv/admin-service.cds
+++ b/tests/bookshop/srv/admin-service.cds
@@ -100,3 +100,8 @@ annotate AdminService.Order with @(UI.Facets: [{
   Label  : 'Custom Changes',
   Target : 'changes/@UI.PresentationVariant',
 }]);
+
+// Test if trigger generation for .texts tables are skipped
+annotate AdminService.Books.texts with {
+  title @changelog;
+};

--- a/tests/build/hana-build.test.js
+++ b/tests/build/hana-build.test.js
@@ -86,5 +86,12 @@ const isHana = cds.env.requires?.db?.kind === 'hana';
       const triggers = result.definitions.filter((def) => def.kind === 'HDBTRIGGER' || (def.sql && def.sql.includes('TRIGGER')));
       expect(triggers.length).toBeGreaterThan(0);
     });
+
+    test('Build does not generate triggers for .texts entities', () => {
+      const result = compiler(freshCsn(), {});
+      const triggers = result.definitions.filter((def) => def.sql && def.sql.includes('TRIGGER'));
+      const textsTriggers = triggers.filter((def) => def.name.includes('.texts'));
+      expect(textsTriggers).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
# Fix: Skip `.texts` Entities During Trigger Generation

### Bug Fix

🐛 Resolved an issue where CDS-generated localized text tables (`*.texts`) were incorrectly included in trigger generation, causing unintended behavior during `cds deploy --to hana`.

### Changes

* `lib/utils/entity-collector.js`: Added guards to skip `.texts` entities in three places:
  - In `_collectStandaloneEntities`, standalone DB entities ending with `.texts` are now skipped.
  - In `_discoverCompositionTargets`, composition targets ending with `.texts` are now skipped.
  - In `getEntitiesForTriggerGeneration`, a final filter removes any remaining `.texts` entries from the result.
* `tests/bookshop/srv/admin-service.cds`: Added a `@changelog` annotation on `AdminService.Books.texts` to serve as a test case for the new skip behavior.
* `tests/build/hana-build.test.js`: Added a test asserting that no HDBTRIGGER definitions are generated for `.texts` entities.
* `CHANGELOG.md`: Documented the fix under the new `Version 2.0.3` entry.
* `package.json`: Bumped version from `2.0.2` to `2.0.3`; also fixed the `test:hana` script to use `--silent=true`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.2`

- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `10a6e6e0-84fa-11f1-8219-bad7d25d7a2c`
</details>
