### PR TITLE
test: generated /changes leaks changelog for fields excluded from a service projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.2.0 - tbd
+
+### Fixed
+- Prevent `/changes` navigation from leaking change history for change-tracked fields that are excluded from a service projection 
+
 ## Version 2.1.0 - 2026-07-28
 
 ### Fixed

--- a/lib/csn-enhancements/index.js
+++ b/lib/csn-enhancements/index.js
@@ -60,6 +60,62 @@ function _replaceTablePlaceholders(on, tableName) {
 }
 
 /**
+ * If a service projection exposes only a subset of the change-tracked fields
+ * of its base entity, extend the changes-association ON condition with an
+ * `attribute IN (<exposed>)` filter so the /changes navigation cannot leak
+ * change history for fields excluded from the projection.
+ *
+ * Uses the inferred projection's own `entity.elements` (which reflects the
+ * actually exposed columns after the CDS compiler has applied `excluding`
+ * / explicit column lists) and maps aliased columns back to their DB name.
+ * Mutates `on` in place.
+ */
+function _restrictChangesToExposedFields(on, entity, baseEntity) {
+  if (!baseEntity?.elements || !entity?.elements) return;
+
+  // All tracked fields on the underlying DB entity
+  const allTracked = [];
+  for (const [name, elem] of Object.entries(baseEntity.elements)) {
+    if (elem['@changelog']) allTracked.push(name);
+  }
+  if (allTracked.length === 0) return;
+
+  // Map projection alias -> DB source column name (for renamed columns)
+  const cqn = entity.projection ?? entity.query?.SELECT;
+  const dbNameByAlias = {};
+  if (Array.isArray(cqn?.columns)) {
+    for (const c of cqn.columns) {
+      if (c && typeof c === 'object' && c.ref && c.as) dbNameByAlias[c.as] = c.ref[0];
+    }
+  }
+
+  // Tracked fields actually exposed through the projection
+  const exposed = new Set();
+  for (const [name, elem] of Object.entries(entity.elements)) {
+    if (!elem['@changelog']) continue;
+    const dbName = dbNameByAlias[name] ?? name;
+    if (baseEntity.elements[dbName]?.['@changelog']) exposed.add(dbName);
+  }
+
+  // No filter needed if the projection exposes all tracked fields
+  if (exposed.size >= allTracked.length) return;
+  // Nothing exposed: leave the ON alone (assoc creation is guarded elsewhere)
+  if (exposed.size === 0) return;
+
+  const attributeFilter = [];
+  let first = true;
+  for (const name of exposed) {
+    if (!first) attributeFilter.push('or');
+    first = false;
+    attributeFilter.push({ ref: ['changes', 'attribute'] }, '=', { val: name });
+  }
+
+  const wrapped = ['(', ...on, ')', 'and', '(', ...attributeFilter, ')'];
+  on.length = 0;
+  on.push(...wrapped);
+}
+
+/**
  * Enhance the CDS model with change tracking associations, facets, and side effects.
  * Returns the updated hierarchyMap and collectedEntities for use by trigger generation.
  */
@@ -143,6 +199,13 @@ function enhanceModel(m) {
         for (let i = 1; i < cds.env.requires['change-tracking'].maxDisplayHierarchyDepth; i++) {
           on.push('or', { xpr: replaceReferences(structuredClone(onTemplate), i) });
         }
+
+        // If the projection exposes only a subset of the tracked fields
+        // (e.g. `projection ... excluding { secret }`), scope the /changes
+        // navigation to the exposed fields so change history does not leak
+        // across the service authorization boundary.
+        _restrictChangesToExposedFields(on, entity, baseInfo.baseEntity);
+
         const assoc = new cds.builtin.classes.Association({ ...changes, on });
         assoc.target = `${serviceName}.ChangeView`;
         if (!inferredCSN.definitions[`${serviceName}.ChangeView`]) {

--- a/lib/csn-enhancements/index.js
+++ b/lib/csn-enhancements/index.js
@@ -1,5 +1,6 @@
 const cds = require('@sap/cds');
 const DEBUG = cds.debug('change-tracking');
+const LOG = cds.log('change-tracking');
 
 const { isChangeTracked, getBaseEntity, analyzeCompositions, getService } = require('../utils/entity-collector.js');
 const { addSideEffects, addUIFacet } = require('./annotations.js');
@@ -65,10 +66,7 @@ function _replaceTablePlaceholders(on, tableName) {
  * `attribute IN (<exposed>)` filter so the /changes navigation cannot leak
  * change history for fields excluded from the projection.
  *
- * Uses the inferred projection's own `entity.elements` (which reflects the
- * actually exposed columns after the CDS compiler has applied `excluding`
- * / explicit column lists) and maps aliased columns back to their DB name.
- * Mutates `on` in place.
+ * Uses the inferred projection's own `entity.elements` and maps aliased columns back to their DB name.
  */
 function _restrictChangesToExposedFields(on, entity, baseEntity) {
   if (!baseEntity?.elements || !entity?.elements) return;
@@ -94,7 +92,7 @@ function _restrictChangesToExposedFields(on, entity, baseEntity) {
   for (const [name, elem] of Object.entries(entity.elements)) {
     if (!elem['@changelog']) continue;
     const dbName = dbNameByAlias[name] ?? name;
-    if (baseEntity.elements[dbName]?.['@changelog']) exposed.add(dbName);
+    if (allTracked.includes(dbName)) exposed.add(dbName);
   }
 
   // No filter needed if the projection exposes all tracked fields
@@ -102,15 +100,16 @@ function _restrictChangesToExposedFields(on, entity, baseEntity) {
   // Nothing exposed: leave the ON alone (assoc creation is guarded elsewhere)
   if (exposed.size === 0) return;
 
-  const attributeFilter = [];
-  let first = true;
-  for (const name of exposed) {
-    if (!first) attributeFilter.push('or');
-    first = false;
-    attributeFilter.push({ ref: ['changes', 'attribute'] }, '=', { val: name });
-  }
+  const excluded = allTracked.filter((n) => !exposed.has(n));
+  LOG.warn(
+    `${entity.name} exposes only a subset of the change-tracked fields of ${baseEntity.name} (excluding ` +
+      `${excluded.map((n) => `'${n}'`).join(', ')}). The generated changes ON condition has been extended with an` +
+      `'attribute IN (...)' filter which prevent leaking change history from being exposed for excluded fields. However, this may impact performance!`
+  );
 
-  const wrapped = ['(', ...on, ')', 'and', '(', ...attributeFilter, ')'];
+  const attributeFilter = [{ ref: ['changes', 'attribute'] }, 'in', { list: [...exposed].map((name) => ({ val: name })) }];
+
+  const wrapped = ['(', ...on, ')', 'and', ...attributeFilter];
   on.length = 0;
   on.push(...wrapped);
 }
@@ -200,10 +199,7 @@ function enhanceModel(m) {
           on.push('or', { xpr: replaceReferences(structuredClone(onTemplate), i) });
         }
 
-        // If the projection exposes only a subset of the tracked fields
-        // (e.g. `projection ... excluding { secret }`), scope the /changes
-        // navigation to the exposed fields so change history does not leak
-        // across the service authorization boundary.
+        // Scope tracked fields to exposed fields so change history does not leak across the service authorization boundary
         _restrictChangesToExposedFields(on, entity, baseInfo.baseEntity);
 
         const assoc = new cds.builtin.classes.Association({ ...changes, on });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/change-tracking",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "CDS plugin providing out-of-the box support for automatic capturing, storing, and viewing of the change records of modeled entities.",
   "repository": "cap-js/change-tracking",
   "author": "SAP SE (https://www.sap.com)",

--- a/tests/bookshop/db/index.cds
+++ b/tests/bookshop/db/index.cds
@@ -194,3 +194,10 @@ entity EmployeesNestedExpr : Employees {
 entity EmployeesFuncExpr : Employees {
   manager : Association to EmployeesFuncExpr;
 }
+
+// a full projection and a narrow one that excludes `secret`. Used to check whether
+// /changes on the narrow projection leaks changelog rows for the hidden field.
+entity ProjectionScoped : cuid {
+  publicField : String @changelog;
+  secret      : String @changelog;
+}

--- a/tests/bookshop/srv/feature-testing.cds
+++ b/tests/bookshop/srv/feature-testing.cds
@@ -42,6 +42,13 @@ service VariantTesting {
 
   entity EmployeesFuncExpr as projection on my.EmployeesFuncExpr;
 
+  // Full projection exposes both tracked fields, restricted to admin.
+  @restrict: [{ grant: '*', to: 'admin' }]
+  entity ProjectionScopedFull as projection on my.ProjectionScoped;
+  // Narrow projection excludes `secret`, readable by the lower-privilege support role.
+  @restrict: [{ grant: '*', to: 'support' }]
+  entity ProjectionScopedNarrow as projection on my.ProjectionScoped excluding { secret };
+
   // Test for DB-level view shadowing the composition parent mapping
   entity VersionWithAssignments as projection on my.VersionWithAssignments;
   entity VersionAssignment       as projection on my.VersionAssignment;

--- a/tests/integration/expressions.test.js
+++ b/tests/integration/expressions.test.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, defaults } = cds.test(bookshop);
+const { POST, PATCH, DELETE, GET, axios, defaults } = cds.test(bookshop);
 defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('Expression-based @changelog annotations', () => {
@@ -412,5 +412,43 @@ describe('ChangeView access restrictions', () => {
     const response = await GET(`/odata/v4/admin/BookStores(ID=${bookStore.ID},IsActiveEntity=true)/changes`);
     expect(response.status).toBe(200);
     expect(response.data.value.length).toBeGreaterThan(0);
+  });
+
+  // ProjectionScopedFull (admin) exposes `secret`; ProjectionScopedNarrow (support)
+  // excludes it. A support-only user should still read the change history via the
+  // narrow projection, scoped to the fields it exposes: `publicField` visible, `secret` filtered out.
+  it('scopes changelog rows to the fields a service projection exposes', async () => {
+    const bob = { auth: { username: 'bob', password: '' } }; // support role only
+
+    const ID = cds.utils.uuid();
+    await POST(`/odata/v4/variant-testing/ProjectionScopedFull`, { ID, publicField: 'pub-v1', secret: 'SECRET-v1' });
+    await PATCH(`/odata/v4/variant-testing/ProjectionScopedFull(ID=${ID})`, { publicField: 'pub-v2', secret: 'SECRET-v2' });
+
+    // bob cannot read `secret` on the entity itself
+    await expect(axios.get(`/odata/v4/variant-testing/ProjectionScopedFull(ID=${ID})`, bob)).rejects.toMatchObject({
+      response: { status: 403 }
+    });
+
+    // bob can read the narrow projection, but `secret` is not part of it
+    const { data: narrow } = await axios.get(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})`, bob);
+    expect(narrow.publicField).toBe('pub-v2');
+    expect(narrow.secret).toBeUndefined();
+
+    // bob's change history via the narrow projection: exactly the two `publicField`
+    // rows (create from POST, update from PATCH), and no `secret` rows.
+    const { data } = await axios.get(
+      `/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})/changes?$select=attribute,valueChangedTo,modification`,
+      bob
+    );
+    // sort in JS: createdAt is the transaction timestamp, so same-request writes are not
+    // totally ordered by the DB. `modification` gives a stable order (create < update).
+    const rows = data.value
+      .map((r) => ({ attribute: r.attribute, valueChangedTo: r.valueChangedTo, modification: r.modification }))
+      .sort((a, b) => a.modification.localeCompare(b.modification));
+    // exactly the `publicField` history (create from POST, update from PATCH); no `secret`
+    expect(rows).toEqual([
+      { attribute: 'publicField', valueChangedTo: 'pub-v1', modification: 'create' },
+      { attribute: 'publicField', valueChangedTo: 'pub-v2', modification: 'update' }
+    ]);
   });
 });

--- a/tests/integration/expressions.test.js
+++ b/tests/integration/expressions.test.js
@@ -436,15 +436,10 @@ describe('ChangeView access restrictions', () => {
 
     // bob's change history via the narrow projection: exactly the two `publicField`
     // rows (create from POST, update from PATCH), and no `secret` rows.
-    const { data } = await axios.get(
-      `/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})/changes?$select=attribute,valueChangedTo,modification`,
-      bob
-    );
+    const { data } = await axios.get(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})/changes?$select=attribute,valueChangedTo,modification`, bob);
     // sort in JS: createdAt is the transaction timestamp, so same-request writes are not
     // totally ordered by the DB. `modification` gives a stable order (create < update).
-    const rows = data.value
-      .map((r) => ({ attribute: r.attribute, valueChangedTo: r.valueChangedTo, modification: r.modification }))
-      .sort((a, b) => a.modification.localeCompare(b.modification));
+    const rows = data.value.map((r) => ({ attribute: r.attribute, valueChangedTo: r.valueChangedTo, modification: r.modification })).sort((a, b) => a.modification.localeCompare(b.modification));
     // exactly the `publicField` history (create from POST, update from PATCH); no `secret`
     expect(rows).toEqual([
       { attribute: 'publicField', valueChangedTo: 'pub-v1', modification: 'create' },

--- a/tests/integration/expressions.test.js
+++ b/tests/integration/expressions.test.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds');
 const bookshop = require('path').resolve(__dirname, './../bookshop');
-const { POST, PATCH, DELETE, GET, axios, defaults } = cds.test(bookshop);
+const { POST, PATCH, DELETE, GET, defaults } = cds.test(bookshop);
 defaults.auth = { username: 'alice', password: 'admin' };
 
 describe('Expression-based @changelog annotations', () => {
@@ -414,9 +414,8 @@ describe('ChangeView access restrictions', () => {
     expect(response.data.value.length).toBeGreaterThan(0);
   });
 
-  // ProjectionScopedFull (admin) exposes `secret`; ProjectionScopedNarrow (support)
-  // excludes it. A support-only user should still read the change history via the
-  // narrow projection, scoped to the fields it exposes: `publicField` visible, `secret` filtered out.
+  // ProjectionScopedFull (admin) exposes `secret`; ProjectionScopedNarrow (support) excludes it.
+  // A support-only user should still read the change history via the narrow projection, scoped to the fields it exposes: `publicField` visible, `secret` filtered out.
   it('scopes changelog rows to the fields a service projection exposes', async () => {
     const bob = { auth: { username: 'bob', password: '' } }; // support role only
 
@@ -425,20 +424,19 @@ describe('ChangeView access restrictions', () => {
     await PATCH(`/odata/v4/variant-testing/ProjectionScopedFull(ID=${ID})`, { publicField: 'pub-v2', secret: 'SECRET-v2' });
 
     // bob cannot read `secret` on the entity itself
-    await expect(axios.get(`/odata/v4/variant-testing/ProjectionScopedFull(ID=${ID})`, bob)).rejects.toMatchObject({
+    await expect(GET(`/odata/v4/variant-testing/ProjectionScopedFull(ID=${ID})`, bob)).rejects.toMatchObject({
       response: { status: 403 }
     });
 
     // bob can read the narrow projection, but `secret` is not part of it
-    const { data: narrow } = await axios.get(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})`, bob);
+    const { data: narrow } = await GET(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})`, bob);
     expect(narrow.publicField).toBe('pub-v2');
     expect(narrow.secret).toBeUndefined();
 
     // bob's change history via the narrow projection: exactly the two `publicField`
     // rows (create from POST, update from PATCH), and no `secret` rows.
-    const { data } = await axios.get(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})/changes?$select=attribute,valueChangedTo,modification`, bob);
-    // sort in JS: createdAt is the transaction timestamp, so same-request writes are not
-    // totally ordered by the DB. `modification` gives a stable order (create < update).
+    const { data } = await GET(`/odata/v4/variant-testing/ProjectionScopedNarrow(ID=${ID})/changes?$select=attribute,valueChangedTo,modification`, bob);
+    // sort by `modification` gives a stable order (create < update).
     const rows = data.value.map((r) => ({ attribute: r.attribute, valueChangedTo: r.valueChangedTo, modification: r.modification })).sort((a, b) => a.modification.localeCompare(b.modification));
     // exactly the `publicField` history (create from POST, update from PATCH); no `secret`
     expect(rows).toEqual([


### PR DESCRIPTION
Two services project the same change-tracked entity with different field visibility. The narrow projection's generated `/changes` still returns the history of the excluded field, crossing the authz boundary.

No fix, the scoping contract is your call.
