### PR TITLE
build: remove vitest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": ">=1",
-    "@cap-js/cds-types": "^0",
-    "vitest": "^4.1.10"
+    "@cap-js/cds-types": "^0"
   },
   "cds": {
     "requires": {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,5 @@
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
+export default {
   test: {
     testTimeout: 60_000
   }
-});
+};


### PR DESCRIPTION
# Remove `vitest` Direct Dependency

### Chore

🔧 Removed the explicit `vitest` package from `devDependencies` and simplified the Vitest configuration file to no longer import from `vitest/config`.

### Changes

* `package.json`: Removed `vitest` from `devDependencies`, keeping only `@cap-js/cds-types` alongside `@cap-js/cds-test`.
* `vitest.config.js`: Replaced the `defineConfig` wrapper (imported from `vitest/config`) with a plain exported object, simplifying the configuration.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.14`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `332fa1a0-8fdd-11f1-83bb-e416d6484fe8`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
