### PR TITLE
ci: introduce merge queue and align cf login

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -25,37 +25,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install dependencies and Cloud Foundry CLI (v8.9.0)
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libc6 wget tar
-        wget "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
-        tar -xvzf cf-cli.tar.gz
-        sudo mv cf /usr/local/bin/
-        sudo mv cf8 /usr/local/bin/
-        cf --version
-
-    - name: Authenticate with Cloud Foundry
-      shell: bash
-      env:
-        CF_API: ${{ inputs.CF_API }}
-        CF_USERNAME: ${{ inputs.CF_USERNAME }}
-        CF_PASSWORD: ${{ inputs.CF_PASSWORD }}
-        CF_ORG: ${{ inputs.CF_ORG }}
-        CF_SPACE: ${{ inputs.CF_SPACE }}
-      run: |
-        for i in {1..5}; do
-          cf api "$CF_API" && \
-          cf auth && \
-          cf target -o "$CF_ORG" -s "$CF_SPACE" && break
-          echo "cf login failed, retrying ($i/5)..."
-          sleep 10
-          if [ "$i" -eq 5 ]; then
-            echo "❌ cf login failed after 5 attempts."
-            exit 1
-          fi
-        done
+    - name: Setup CF CLI and authenticate
+      uses: cap-js/cf-setup@v2
+      with:
+        api: ${{ inputs.CF_API }}
+        org: ${{ inputs.CF_ORG }}
+        space: ${{ inputs.CF_SPACE }}
+        username: ${{ inputs.CF_USERNAME }}
+        password: ${{ inputs.CF_PASSWORD }}
 
     - name: Use Node.js ${{ inputs.NODE_VERSION}}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,18 @@
+name: Check Changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v4
+        with:
+          changelog: CHANGELOG.md

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, auto_merge_enabled]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,40 +2,28 @@ name: CI
 
 on:
   workflow_dispatch:
+  merge_group:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
-    types: [reopened, synchronize, opened]
 
 permissions:
   contents: read
 
 jobs:
-  requires-approval:
-    runs-on: ubuntu-latest
-    name: Waiting for PR approval as this workflow runs on pull_request_target
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
-    environment: pr-approval
-    steps:
-      - name: Approval Step
-        run: echo "This job has been approved!"
-
   test-sqlite:
     runs-on: ubuntu-latest
-    needs: requires-approval
-    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     name: SQLite Tests with Node.js ${{ matrix.node-version }} and CDS ${{ matrix.cds-version }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
         cds-version: [9, latest]
+        # On PRs only the "latest" combination runs; the merge queue runs the full matrix.
+        exclude: ${{ github.event_name == 'merge_group' && fromJSON('[]') || fromJSON('[{"node-version":"22.x","cds-version":9},{"node-version":"24.x","cds-version":9},{"node-version":"22.x","cds-version":"latest"}]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          allow-unsafe-pr-checkout: true
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -58,19 +46,16 @@ jobs:
 
   test-postgres:
     runs-on: ubuntu-latest
-    needs: requires-approval
-    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     name: PostgreSQL Tests with Node.js ${{ matrix.node-version }} and CDS ${{ matrix.cds-version }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
         cds-version: [9, latest]
+        # On PRs only the "latest" combination runs; the merge queue runs the full matrix.
+        exclude: ${{ github.event_name == 'merge_group' && fromJSON('[]') || fromJSON('[{"node-version":"22.x","cds-version":9},{"node-version":"24.x","cds-version":9},{"node-version":"22.x","cds-version":"latest"}]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          allow-unsafe-pr-checkout: true
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -97,19 +82,16 @@ jobs:
 
   test-hana:
     runs-on: ubuntu-latest
-    needs: requires-approval
-    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     name: HANA Integration Tests with Node.js ${{ matrix.node-version }} and CDS ${{ matrix.cds-version }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
         cds-version: [9, latest]
+        # On PRs only the "latest" combination runs; the merge queue runs the full matrix.
+        exclude: ${{ github.event_name == 'merge_group' && fromJSON('[]') || fromJSON('[{"node-version":"22.x","cds-version":9},{"node-version":"24.x","cds-version":9},{"node-version":"22.x","cds-version":"latest"}]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          allow-unsafe-pr-checkout: true
       - name: Run HANA integration tests
         uses: ./.github/actions/integration-tests
         with:
@@ -120,3 +102,12 @@ jobs:
           CF_SPACE: ${{ secrets['CF_SPACE'] }}
           NODE_VERSION: ${{ matrix.node-version }}
           CDS_VERSION: ${{ matrix.cds-version }}
+
+  results:
+    if: always()
+    runs-on: ubuntu-latest
+    name: Summary
+    needs: [test-sqlite, test-postgres, test-hana]
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
- Introduce merge queue and run only Node 24 and CDS latest tests for SQLite, Postgres and HANA on PR
- Align `cf login` step with [cap-js/cf-setup](https://github.com/cap-js/cf-setup/blob/main/action.yaml)