### PR TITLE
fix: fix duplicate compile error during tenant upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Prevent `/changes` navigation from leaking change history for change-tracked fields that are excluded from a service projection
 - Consider `@changelog: false` on nested composition-of-many targets during deep writes
+- Fix `Duplicate definition of element "parent_entityKey" (in entity:"sap.changelog.ChangeView"/query:1)` compile error during tenant upgrade in multi-tenant apps with `extensibility: true`
 
 ## Version 2.1.0 - 2026-07-28
 

--- a/lib/csn-enhancements/index.js
+++ b/lib/csn-enhancements/index.js
@@ -115,6 +115,19 @@ function _restrictChangesToExposedFields(on, entity, baseEntity) {
 }
 
 /**
+ * Idempotently add a `parent_<...>_<attr>` column and element to the base
+ * ChangeView. Safe to call repeatedly across enhanceModel invocations
+ */
+function _addParentColumn(changeView, parents, attr) {
+  const alias = parents.join('_') + '_' + attr;
+  const cols = changeView.query.SELECT.columns;
+  if (!cols.some((c) => c?.as === alias)) {
+    cols.push({ ref: ['change', ...parents, attr], as: alias });
+  }
+  changeView.elements[alias] ??= structuredClone(changeView.elements[attr]);
+}
+
+/**
  * Enhance the CDS model with change tracking associations, facets, and side effects.
  * Returns the updated hierarchyMap and collectedEntities for use by trigger generation.
  */
@@ -153,18 +166,8 @@ function enhanceModel(m) {
     const parents = [];
     for (let i = 1; i < depth; i++) {
       parents.push('parent');
-      changeView.query.SELECT.columns.push(
-        {
-          ref: ['change', ...parents, 'entityKey'],
-          as: parents.join('_') + '_' + 'entityKey'
-        },
-        {
-          ref: ['change', ...parents, 'entity'],
-          as: parents.join('_') + '_' + 'entity'
-        }
-      );
-      changeView.elements[parents.join('_') + '_' + 'entityKey'] = structuredClone(changeView.elements.entityKey);
-      changeView.elements[parents.join('_') + '_' + 'entity'] = structuredClone(changeView.elements.entity);
+      _addParentColumn(changeView, parents, 'entityKey');
+      _addParentColumn(changeView, parents, 'entity');
     }
     enhanceChangeViewWithTimeZones(changeView, inferredCSN);
   }

--- a/tests/mtx/enhance-model-idempotency.test.js
+++ b/tests/mtx/enhance-model-idempotency.test.js
@@ -1,0 +1,73 @@
+const cds = require('@sap/cds');
+const path = require('path');
+const { enhanceModel } = require('../../lib/csn-enhancements');
+
+const BOOKSHOP_MTX = path.resolve(__dirname, '../bookshop-mtx');
+void cds.test;
+
+let loadedCsn;
+
+beforeAll(async () => {
+  const pluginIndex = path.resolve(__dirname, '../../index.cds');
+  loadedCsn = await cds.load([path.join(BOOKSHOP_MTX, 'db'), path.join(BOOKSHOP_MTX, 'srv'), pluginIndex], { silent: true });
+});
+
+const freshCsn = () => structuredClone(loadedCsn);
+
+describe('enhanceModel is idempotent across cds.extend().with() (regression: duplicate parent_entityKey)', () => {
+  it('cds.extend().with() drops meta.sap.changelog.enhanced', () => {
+    const base = freshCsn();
+    enhanceModel(base);
+    expect(base.meta?.['sap.changelog.enhanced']).toBe(true);
+    const extended = cds.extend(base).with({ definitions: {}, extensions: [] });
+    expect(extended.meta?.['sap.changelog.enhanced']).toBeUndefined();
+  });
+
+  it('enhanceModel does not duplicate parent_entityKey columns when run twice on an extended CSN', () => {
+    const base = freshCsn();
+    enhanceModel(base);
+
+    const extended = cds.extend(base).with({ definitions: {}, extensions: [] });
+
+    // Simulate the plugin's srv.after(['getCsn','getExtCsn'], enhanceModel) hook
+    enhanceModel(extended);
+
+    const columns = extended.definitions?.['sap.changelog.ChangeView']?.query?.SELECT?.columns ?? [];
+    const dupCount = columns.filter((c) => c?.as === 'parent_entityKey').length;
+    expect(dupCount).toBe(1);
+  });
+
+  it('cds.compile.to.sql succeeds on a twice-enhanced extended CSN', () => {
+    const base = freshCsn();
+    enhanceModel(base);
+    const extended = cds.extend(base).with({ definitions: {}, extensions: [] });
+    enhanceModel(extended);
+
+    let caught;
+    try {
+      cds.compile.to.sql(extended, { dialect: 'sqlite' });
+    } catch (err) {
+      caught = err;
+    }
+    // The customer's exact error signature we must never see again:
+    //   Error: Duplicate definition of element "parent_entityKey"
+    //     (in entity:"sap.changelog.ChangeView"/query:1)
+    expect(caught?.message ?? '').not.toMatch(/Duplicate definition of element .*parent_entityKey/);
+    expect(caught).toBeUndefined();
+  });
+
+  it('does not duplicate the changes column on service entities after double-enhance', () => {
+    const base = freshCsn();
+    enhanceModel(base);
+    const extended = cds.extend(base).with({ definitions: {}, extensions: [] });
+    enhanceModel(extended);
+
+    for (const name of Object.keys(extended.definitions)) {
+      const def = extended.definitions[name];
+      const cqn = def.query?.SELECT ?? def.projection;
+      if (!cqn?.columns) continue;
+      const changesCount = cqn.columns.filter((c) => c?.as === 'changes').length;
+      expect(changesCount, `entity ${name} has ${changesCount} 'changes' columns`).toBeLessThanOrEqual(1);
+    }
+  });
+});


### PR DESCRIPTION
# Fix Duplicate `parent_entityKey` Compile Error During Tenant Upgrade

### Bug Fix

🐛 Resolves a `Duplicate definition of element "parent_entityKey" (in entity:"sap.changelog.ChangeView"/query:1)` compile error that occurred during tenant upgrade in multi-tenant apps with `extensibility: true`.

The root cause was that `enhanceModel` could be called multiple times on the same CSN (e.g., via the `srv.after(['getCsn','getExtCsn'], enhanceModel)` hook after `cds.extend().with()` resets the `meta.sap.changelog.enhanced` flag). Previously, parent columns such as `parent_entityKey` and `parent_entity` were pushed unconditionally, leading to duplicate column definitions that caused a CDS compile error.

### Changes

* `lib/csn-enhancements/index.js`: Extracted a new `_addParentColumn` helper that idempotently adds a `parent_<...>_<attr>` column to the `ChangeView` query — it checks for an existing column with the same alias before inserting, and uses `??=` to avoid overwriting existing elements. The call sites for `entityKey` and `entity` parent columns are replaced with calls to this helper.

* `tests/mtx/enhance-model-idempotency.test.js`: Added a new regression test suite covering the full idempotency scenario:
  - Verifies that `cds.extend().with()` clears the `sap.changelog.enhanced` meta flag (triggering a re-run).
  - Asserts that `parent_entityKey` columns are not duplicated after a double-enhance.
  - Confirms `cds.compile.to.sql` does not throw the customer-reported duplicate definition error.
  - Checks that `changes` columns on service entities are also not duplicated after double-enhance.

* `CHANGELOG.md`: Added an entry documenting the fix for the duplicate element compile error.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Correlation ID: `6a483f50-9b98-11f1-9da3-1a6d8e5e4248`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
