### PR TITLE
docs: update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 2.2.0 - tbd
+## Version 2.2.0 - 2026-08-19
 
 ### Fixed
 - Prevent `/changes` navigation from leaking change history for change-tracked fields that are excluded from a service projection
 - Consider `@changelog: false` on nested composition-of-many targets during deep writes
 - Fix `Duplicate definition of element "parent_entityKey" (in entity:"sap.changelog.ChangeView"/query:1)` compile error during tenant upgrade in multi-tenant apps with `extensibility: true`
 - Fix HANA `SqlError: invalid number` / `invalid DATE, TIME or TIMESTAMP value` when reading the Fiori change hierarchy caused by casting `valueChanged*Label` instead `valueChanged*` in `ChangeView`
+- Fix trigger generation for H2 for local CAP Java development
 
 ## Version 2.1.0 - 2026-07-28
 


### PR DESCRIPTION
# docs: Update Changelog for Version 2.2.0 Release

### Documentation

📝 Updated the changelog to finalize the release of version 2.2.0 by setting the release date and adding a missing fix entry.

### Changes

* `CHANGELOG.md`:
  - Changed the version 2.2.0 release date from `tbd` to `2026-08-19`.
  - Added a new fix entry: *Fix trigger generation for H2 for local CAP Java development*.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.33`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `e72e8cd0-9bcb-11f1-9634-dd9b24ffac86`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
